### PR TITLE
feat: unified participant list (+payments N+1 fix, srovnání ročníků 500 fix, UI polish)

### DIFF
--- a/Controller/WebAdmin/WebAdminParticipantPaymentsImportController.php
+++ b/Controller/WebAdmin/WebAdminParticipantPaymentsImportController.php
@@ -49,10 +49,12 @@ final class WebAdminParticipantPaymentsImportController extends AbstractControll
 
     private function renderMessage(string $title, string $message): Response
     {
-        return $this->render('@OswisOrgOswisCore/web/pages/message.html.twig', [
+        // Admin message skeleton (keeps the admin menu) — not the public message page.
+        return $this->render('@OswisOrgOswisCore/web_admin/message.html.twig', [
             'title'     => $title,
             'pageTitle' => $title,
             'message'   => $message,
+            'backUrl'   => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participant_payments_list'),
         ]);
     }
 

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -113,10 +113,12 @@ final class WebAdminParticipantsController extends AbstractController
     {
         $this->participantService->sendAutoMails(null, $type, $limit);
 
-        return $this->render('@OswisOrgOswisCore/web/pages/message.html.twig', [
+        // Admin message skeleton (keeps the admin menu) — not the public message page.
+        return $this->render('@OswisOrgOswisCore/web_admin/message.html.twig', [
             'title'     => 'Akce provedena.',
             'pageTitle' => 'Akce provedena.',
             'message'   => 'E-maily rozeslány.',
+            'backUrl'   => $this->generateUrl('oswis_org_oswis_core_web_admin_homepage'),
         ]);
     }
 
@@ -214,5 +216,48 @@ final class WebAdminParticipantsController extends AbstractController
             'oswis_org_oswis_calendar_web_admin_participant_arrival',
             ['participantId' => $participantId, 'arrival' => '0'],
         ));
+    }
+
+    /**
+     * Soft-delete a participant (reversible via the restore action). Used by the quick
+     * action on the unified participant list. Redirects back to the referring list view
+     * when safe (same-host admin URL only), otherwise to the participant detail.
+     */
+    #[IsGranted('ROLE_ADMIN')]
+    public function delete(Request $request, int $participantId): Response
+    {
+        if (!$this->isCsrfTokenValid('participant_delete_'.$participantId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $participant = $this->participantService->getParticipant(
+            [
+                ParticipantRepository::CRITERIA_ID              => $participantId,
+                ParticipantRepository::CRITERIA_INCLUDE_DELETED => true,
+            ],
+            true,
+        ) ?? throw $this->createNotFoundException('Účastník nenalezen.');
+
+        $this->participantService->delete($participant);
+        $this->addFlash('success', sprintf('Účastník #%d smazán (lze obnovit).', $participantId));
+
+        return new RedirectResponse($this->safeListRedirect($request, $participantId));
+    }
+
+    /**
+     * Resolve a safe post-action redirect target: the `return` form field if it is a
+     * same-host admin (/web_admin/...) path, otherwise the participant detail page.
+     * Never trusts an absolute/off-site URL (open-redirect guard).
+     */
+    private function safeListRedirect(Request $request, int $participantId): string
+    {
+        $return = (string) $request->request->get('return', '');
+        if (str_starts_with($return, '/web_admin/') && !str_contains($return, "\n") && !str_contains($return, "\r")) {
+            return $return;
+        }
+
+        return $this->generateUrl(
+            'oswis_org_oswis_calendar_web_admin_participant_arrival',
+            ['participantId' => $participantId, 'arrival' => '0'],
+        );
     }
 }

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -82,14 +82,18 @@ class WebAdminParticipantsListController extends AbstractController
     }
 
     /**
-     * Unified participant list. Scope comes from the path ($eventSlug / $participantCategorySlug),
-     * everything else from the query string: ?filter=, ?flags[]=, ?expr=, ?page=, ?all=1.
+     * Unified participant list. The whole view is driven by the query string:
+     * scope (?eventSlug=, ?participantCategorySlug=) + ?filter=, ?flags[]=, ?expr=, ?page=, ?all=1.
+     *
+     * Scope lives in the query (not the path) so any combination is expressible — notably a
+     * category-only scope, which a positional `/{eventSlug?}/{categorySlug?}` path cannot
+     * represent (you can't fill the 2nd optional segment while leaving the 1st empty). Legacy
+     * path-form bookmarks 301-redirect here via {@see legacyScopeRedirect()}.
      */
-    public function list(
-        Request $request,
-        ?string $eventSlug = null,
-        ?string $participantCategorySlug = null,
-    ): Response {
+    public function list(Request $request): Response
+    {
+        $eventSlug = $request->query->get('eventSlug') ?: null;
+        $participantCategorySlug = $request->query->get('participantCategorySlug') ?: null;
         $participantCategory = $this->participantCategoryService->getParticipantTypeBySlug($participantCategorySlug);
         $event = $this->eventService->getRepository()->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug]);
         $scoped = (null !== $event) || (null !== $participantCategory);
@@ -169,6 +173,7 @@ class WebAdminParticipantsListController extends AbstractController
             'availableFunctions'  => $this->filterEvaluator->getFunctionNames(),
             'eventSlug'           => $eventSlug,
             'participantCategorySlug' => $participantCategorySlug,
+            'participantCategories'   => $this->participantCategoryService->getRepository()->findBy([], ['name' => 'ASC']),
         ]);
     }
 
@@ -188,6 +193,25 @@ class WebAdminParticipantsListController extends AbstractController
             'participantCategorySlug' => $participantCategorySlug,
             'filter'                  => self::FILTER_ALL === $filter ? null : $filter,
         ], static fn (?string $value): bool => null !== $value);
+
+        return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list', $query, Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Backward-compatible alias for the old path-form list URL
+     * (/web_admin/seznam-prihlasek/{eventSlug}/{participantCategorySlug?}). 301-redirects to the
+     * canonical query-form list, preserving any extra query params (filter/flags/expr/page).
+     */
+    public function legacyScopeRedirect(
+        Request $request,
+        string $eventSlug,
+        ?string $participantCategorySlug = null,
+    ): RedirectResponse {
+        $query = $request->query->all();
+        $query['eventSlug'] = $eventSlug;
+        if (null !== $participantCategorySlug && '' !== $participantCategorySlug) {
+            $query['participantCategorySlug'] = $participantCategorySlug;
+        }
 
         return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list', $query, Response::HTTP_MOVED_PERMANENTLY);
     }
@@ -346,7 +370,7 @@ class WebAdminParticipantsListController extends AbstractController
     }
 
     /**
-     * @return list<array{url: string, label: string, group: string, active: bool}>
+     * @return list<array{key: string, url: string, label: string, group: string, active: bool}>
      */
     private function buildFilterTabs(?string $eventSlug, ?string $participantCategorySlug, string $active): array
     {
@@ -357,6 +381,7 @@ class WebAdminParticipantsListController extends AbstractController
                 $query['filter'] = $filter['key'];
             }
             $tabs[] = [
+                'key'    => $filter['key'],
                 'url'    => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list', $query),
                 'label'  => $filter['label'],
                 'group'  => $filter['group'],
@@ -431,12 +456,11 @@ class WebAdminParticipantsListController extends AbstractController
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError
      */
-    public function showParticipantsCsv(
-        Request $request,
-        ?string $eventSlug = null,
-        ?string $participantCategorySlug = null,
-        bool $includeDeleted = false,
-    ): Response {
+    public function showParticipantsCsv(Request $request): Response
+    {
+        $eventSlug = $request->query->get('eventSlug') ?: null;
+        $participantCategorySlug = $request->query->get('participantCategorySlug') ?: null;
+        $includeDeleted = $request->query->getBoolean('includeDeleted');
         $data = $this->getParticipantsData($eventSlug, $participantCategorySlug, $includeDeleted);
         $participants = $data['participants'] ?? null;
         if (!$participants instanceof Collection) {

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -678,8 +678,9 @@ class WebAdminParticipantsListController extends AbstractController
         ]);
 
         return $this->render("@OswisOrgOswisCalendar/web_admin/years-compare.html.twig", [
-            'title' => "Srovnání ročníků :: ADMIN",
-            'events' => $events,
+            'title'        => "Srovnání ročníků :: ADMIN",
+            'events'       => $events,
+            'defaultEvent' => $this->eventService->getDefaultEvent(),
         ]);
     }
 
@@ -699,7 +700,7 @@ class WebAdminParticipantsListController extends AbstractController
         return $this->render('@OswisOrgOswisCalendar/web_admin/event.html.twig', [
             'title'          => 'Přehled události :: ADMIN',
             'event'          => $event,
-            'isDefaultEvent' => $event === $defaultEvent,
+            'defaultEvent'   => $defaultEvent,
             ...$this->eventAggregationsService->getEventAggregations($event),
         ]);
     }

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -6,39 +6,64 @@
 
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
-use Closure;
-use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlag;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagCategory;
+use OswisOrg\OswisCalendarBundle\Export\ParticipantExportDefinition;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use OswisOrg\OswisCalendarBundle\Repository\Registration\RegistrationFlagRepository;
 use OswisOrg\OswisCalendarBundle\Service\Aggregations\EventAggregationsService;
 use OswisOrg\OswisCalendarBundle\Service\Event\EventSeriesService;
 use OswisOrg\OswisCalendarBundle\Service\Event\EventService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantCategoryService;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFilterEvaluator;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantService;
 use OswisOrg\OswisCalendarBundle\Service\Registration\RegistrationOfferService;
-use OswisOrg\OswisCalendarBundle\Export\ParticipantExportDefinition;
 use OswisOrg\OswisCoreBundle\Enum\ExportFormat;
 use OswisOrg\OswisCoreBundle\Exceptions\NotFoundException;
 use OswisOrg\OswisCoreBundle\Export\ExportManager;
 use OswisOrg\OswisCoreBundle\Export\ExportRequest;
 use OswisOrg\OswisCoreBundle\Export\ExportResponseFactory;
+use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Single, registry-driven admin participant list. One {@see list()} action replaces the
+ * former five near-identical show* methods (all/unpaid/unpaid-deposit/overpaid/food).
+ *
+ * Two axes of control, both fully encoded in the URL (shareable/bookmarkable):
+ *  - SCOPE — which participants: event (+sub-events) and/or participant category in the
+ *    path; unscoped means all participants across events/years.
+ *  - FILTER — which of them: a registry key (?filter=), faceted flag checkboxes (?flags[]=,
+ *    OR within a category, AND across categories) and a free-form advanced boolean
+ *    expression (?expr=). All three compile into one ExpressionLanguage expression
+ *    evaluated per participant by {@see ParticipantFilterEvaluator}.
+ *
+ * Volume: scoped views load the full set (full-export need, no pagination); unscoped views
+ * default to pagination and offer an explicit "show all" with a warning.
+ */
 class WebAdminParticipantsListController extends AbstractController
 {
-    public const string FILTER_ALL            = 'all';
-    public const string FILTER_UNPAID         = 'unpaid';
-    public const string FILTER_UNPAID_DEPOSIT = 'unpaid-deposit';
-    public const string FILTER_OVERPAID       = 'overpaid';
-    public const string FILTER_FOOD           = 'food';
+    public const string FILTER_ALL               = 'all';
+    public const string FILTER_UNPAID            = 'unpaid';
+    public const string FILTER_UNPAID_DEPOSIT    = 'unpaid-deposit';
+    public const string FILTER_OVERPAID          = 'overpaid';
+    public const string FILTER_FOOD              = 'food';
+    public const string FILTER_WITH_REGISTRATION = 'with-registration';
+    public const string FILTER_NOT_ACTIVATED     = 'not-activated';
+    public const string FILTER_WITH_NOTE         = 'with-note';
+    public const string FILTER_DELETED           = 'deleted';
+
+    /** Page size for the unscoped (all-participants) paginated view. */
+    private const int PER_PAGE = 100;
 
     public function __construct(
         public EventService $eventService,
@@ -51,108 +76,325 @@ class WebAdminParticipantsListController extends AbstractController
         public ExportManager $exportManager,
         public ExportResponseFactory $exportResponseFactory,
         public ParticipantExportDefinition $participantExportDefinition,
+        public ParticipantFilterEvaluator $filterEvaluator,
+        public RegistrationFlagRepository $registrationFlagRepository,
     ) {
     }
 
-    public function showParticipants(?string $eventSlug = null, ?string $participantCategorySlug = null): Response
-    {
-        return $this->renderFiltered(
-            $eventSlug, $participantCategorySlug,
-            self::FILTER_ALL, 'Přehled přihlášek :: ADMIN',
-            static fn (Participant $p) => true,
-        );
-    }
-
-    public function showUnpaidParticipants(?string $eventSlug = null, ?string $participantCategorySlug = null): Response
-    {
-        return $this->renderFiltered(
-            $eventSlug, $participantCategorySlug,
-            self::FILTER_UNPAID, 'Přehled nezaplacených účastníků :: ADMIN',
-            static fn (Participant $p) => $p->getRemainingPrice() > 0,
-        );
-    }
-
-    public function showUnpaidDepositParticipants(?string $eventSlug = null, ?string $participantCategorySlug = null): Response
-    {
-        return $this->renderFiltered(
-            $eventSlug, $participantCategorySlug,
-            self::FILTER_UNPAID_DEPOSIT, 'Přehled přihlášek s nezaplacenou zálohou :: ADMIN',
-            static fn (Participant $p) => $p->getRemainingDeposit() > 0,
-        );
-    }
-
-    public function showOverpaidParticipants(?string $eventSlug = null, ?string $participantCategorySlug = null): Response
-    {
-        return $this->renderFiltered(
-            $eventSlug, $participantCategorySlug,
-            self::FILTER_OVERPAID, 'Přehled přeplacených účastníků :: ADMIN',
-            static fn (Participant $p) => $p->getRemainingPrice() < 0,
-        );
-    }
-
-    public function showFoodParticipants(?string $eventSlug = null, ?string $participantCategorySlug = null): Response
-    {
-        return $this->renderFiltered(
-            $eventSlug, $participantCategorySlug,
-            self::FILTER_FOOD, 'Přehled účastníků se stravovacím omezením :: ADMIN',
-            static fn (Participant $p) => $p->getParticipantFlags(null, RegistrationFlagCategory::TYPE_FOOD, true)->count() > 0,
-        );
-    }
-
     /**
-     * Render the participant list scoped to event + category and filtered by the given
-     * predicate, with the five-tab nav (Vše / Nezaplacení / Nezaplacená záloha /
-     * Přeplacení / Stravovací omezení) so admins can switch between views without
-     * re-typing URLs.
-     *
-     * @param Closure(Participant): bool $filterPredicate
+     * Unified participant list. Scope comes from the path ($eventSlug / $participantCategorySlug),
+     * everything else from the query string: ?filter=, ?flags[]=, ?expr=, ?page=, ?all=1.
      */
-    private function renderFiltered(
-        ?string $eventSlug,
-        ?string $participantCategorySlug,
-        string $activeFilter,
-        string $title,
-        Closure $filterPredicate,
+    public function list(
+        Request $request,
+        ?string $eventSlug = null,
+        ?string $participantCategorySlug = null,
     ): Response {
         $participantCategory = $this->participantCategoryService->getParticipantTypeBySlug($participantCategorySlug);
         $event = $this->eventService->getRepository()->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug]);
+        $scoped = (null !== $event) || (null !== $participantCategory);
 
-        $participants = $this->participantService->getParticipants([
+        $filterKey = $request->query->getString('filter', self::FILTER_ALL);
+        if (!$this->isKnownFilter($filterKey)) {
+            $filterKey = self::FILTER_ALL;
+        }
+        $selectedFlags = array_values(array_filter($request->query->all('flags'), 'is_string'));
+        $advancedExpr = trim($request->query->getString('expr'));
+        $advancedExpr = '' === $advancedExpr ? null : $advancedExpr;
+        $showAll = $request->query->getBoolean('all');
+        $page = max(1, $request->query->getInt('page', 1));
+
+        $hasActiveFilter = self::FILTER_ALL !== $filterKey || [] !== $selectedFlags || null !== $advancedExpr;
+
+        [$flagFacets, $slugToCategory] = $this->buildFlagOffering($selectedFlags);
+        $expression = $this->compileFilterExpression($filterKey, $selectedFlags, $advancedExpr, $slugToCategory);
+
+        $criteria = [
+            // We always load deleted rows and let the compiled expression decide
+            // (active filters add `not isDeleted()`, the "deleted" filter adds `isDeleted()`).
             ParticipantRepository::CRITERIA_INCLUDE_DELETED       => true,
             ParticipantRepository::CRITERIA_EVENT                 => $event,
             ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY  => $participantCategory,
             ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 2,
-        ])->filter($filterPredicate);
+        ];
 
-        $participantsArray = $participants->toArray();
-        usort($participantsArray, static fn (Participant $a, Participant $b) => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()));
+        $loadAll = $scoped || $showAll;
+        $pagination = null;
+        if ($loadAll) {
+            $loaded = $this->participantService->getParticipants($criteria);
+        } else {
+            $offset = ($page - 1) * self::PER_PAGE;
+            $loaded = $this->participantService->getParticipants($criteria, true, self::PER_PAGE, $offset);
+            $pagination = [
+                'page'    => $page,
+                'perPage' => self::PER_PAGE,
+                'hasPrev' => $page > 1,
+                'hasNext' => $loaded->count() >= self::PER_PAGE,
+            ];
+        }
+
+        // Prime the LAZY collections the filter + row template walk, in a constant number
+        // of queries (avoids the per-participant N+1).
+        $ids = array_values(array_filter($loaded->map(static fn (Participant $p): ?int => $p->getId())->toArray()));
+        $this->participantService->getRepository()->primeAggregationCollections($ids);
+
+        $matched = $loaded->filter(fn (Participant $p): bool => $this->filterEvaluator->matches($p, $expression));
+        $participantsArray = $matched->toArray();
+        usort(
+            $participantsArray,
+            static fn (Participant $a, Participant $b): int => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
+        );
+
+        // Summary stats are computed from the full scoped set (pre-filter) — meaningless
+        // and expensive for an unscoped paginated page, so skipped there.
+        $stats = $loadAll ? $this->computeStats($loaded) : null;
 
         return $this->render("@OswisOrgOswisCalendar/web_admin/participants.html.twig", [
-            'participantCategory' => $participantCategory,
+            'title'               => 'Přehled přihlášek :: ADMIN',
             'event'               => $event,
+            'participantCategory' => $participantCategory,
             'participants'        => new ArrayCollection($participantsArray),
-            'title'               => $title,
-            'filterTabs'          => $this->buildFilterTabs($eventSlug, $participantCategorySlug, $activeFilter),
+            'scoped'              => $scoped,
+            'filterTabs'          => $this->buildFilterTabs($eventSlug, $participantCategorySlug, $filterKey),
+            'flagFacets'          => $flagFacets,
+            'activeFilter'        => $filterKey,
+            'selectedFlags'       => $selectedFlags,
+            'advancedExpr'        => $advancedExpr,
+            'expression'          => $expression,
+            'stats'               => $stats,
+            'pagination'          => $pagination,
+            'showAll'             => $showAll,
+            'hasActiveFilter'     => $hasActiveFilter,
+            'filterScopeWarning'  => !$loadAll && $hasActiveFilter,
+            'availableFunctions'  => $this->filterEvaluator->getFunctionNames(),
+            'eventSlug'           => $eventSlug,
+            'participantCategorySlug' => $participantCategorySlug,
         ]);
     }
 
     /**
-     * @return list<array{url: string, label: string, active: bool}>
+     * Backward-compatible alias for the five legacy list URLs (/prihlasky/nezaplacene, …).
+     * 301-redirects to the canonical list with the matching ?filter= so old bookmarks keep
+     * working while there is a single page going forward. The target filter comes from the
+     * route default.
+     */
+    public function legacyFilterRedirect(
+        string $filter,
+        ?string $eventSlug = null,
+        ?string $participantCategorySlug = null,
+    ): RedirectResponse {
+        $query = array_filter([
+            'eventSlug'               => $eventSlug,
+            'participantCategorySlug' => $participantCategorySlug,
+            'filter'                  => self::FILTER_ALL === $filter ? null : $filter,
+        ], static fn (?string $value): bool => null !== $value);
+
+        return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list', $query, Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Registry of named filters. Each maps to an ExpressionLanguage fragment (or null for
+     * the special "all"/"deleted" keys whose only effect is the deleted-row handling).
+     *
+     * @return list<array{key: string, label: string, group: string, expr: string|null}>
+     */
+    private function getFilterRegistry(): array
+    {
+        return [
+            ['key' => self::FILTER_ALL,               'label' => 'Vše',                 'group' => '',         'expr' => null],
+            ['key' => self::FILTER_UNPAID,            'label' => 'Nezaplacení',         'group' => 'Platby',   'expr' => 'remainingPrice() > 0'],
+            ['key' => self::FILTER_UNPAID_DEPOSIT,    'label' => 'Nezaplacená záloha',  'group' => 'Platby',   'expr' => 'remainingDeposit() > 0'],
+            ['key' => self::FILTER_OVERPAID,          'label' => 'Přeplacení',          'group' => 'Platby',   'expr' => 'remainingPrice() < 0'],
+            ['key' => self::FILTER_FOOD,              'label' => 'Stravovací omezení',  'group' => 'Příznaky', 'expr' => sprintf("hasFlagOfType('%s')", RegistrationFlagCategory::TYPE_FOOD)],
+            ['key' => self::FILTER_WITH_REGISTRATION, 'label' => 'S přihláškou',        'group' => 'Stav',     'expr' => 'hasRegistration()'],
+            ['key' => self::FILTER_NOT_ACTIVATED,     'label' => 'Neaktivovaný účet',   'group' => 'Stav',     'expr' => 'not isActivated()'],
+            ['key' => self::FILTER_WITH_NOTE,         'label' => 'S poznámkou',         'group' => 'Stav',     'expr' => 'hasNote()'],
+            ['key' => self::FILTER_DELETED,           'label' => 'Smazané',             'group' => 'Stav',     'expr' => null],
+        ];
+    }
+
+    private function isKnownFilter(string $key): bool
+    {
+        foreach ($this->getFilterRegistry() as $filter) {
+            if ($filter['key'] === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function registryExpr(string $key): ?string
+    {
+        foreach ($this->getFilterRegistry() as $filter) {
+            if ($filter['key'] === $key) {
+                return $filter['expr'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Combine registry filter + flag facets + advanced expression + deleted handling into a
+     * single boolean expression evaluated per participant.
+     *
+     * @param list<string>          $selectedFlags  flag slugs from ?flags[]
+     * @param array<string, string> $slugToCategory known flag slug => category slug (untrusted slugs excluded)
+     */
+    private function compileFilterExpression(
+        string $filterKey,
+        array $selectedFlags,
+        ?string $advancedExpr,
+        array $slugToCategory,
+    ): string {
+        $parts = [];
+        // Deleted handling: the dedicated "deleted" filter shows only soft-deleted rows,
+        // every other filter excludes them (fixes the legacy "deleted shown among active").
+        $parts[] = self::FILTER_DELETED === $filterKey ? 'isDeleted()' : 'not isDeleted()';
+
+        $registryExpr = $this->registryExpr($filterKey);
+        if (null !== $registryExpr) {
+            $parts[] = $registryExpr;
+        }
+
+        $facetExpr = $this->compileFlagFacets($selectedFlags, $slugToCategory);
+        if (null !== $facetExpr) {
+            $parts[] = $facetExpr;
+        }
+
+        if (null !== $advancedExpr) {
+            $parts[] = '('.$advancedExpr.')';
+        }
+
+        return implode(' and ', $parts);
+    }
+
+    /**
+     * Faceted flag predicate: OR within a category, AND across categories. Only slugs known
+     * to exist (present in $slugToCategory) are used — untrusted slugs are dropped, which
+     * also prevents expression injection via ?flags[].
+     *
+     * @param list<string>          $selectedFlags
+     * @param array<string, string> $slugToCategory
+     */
+    private function compileFlagFacets(array $selectedFlags, array $slugToCategory): ?string
+    {
+        /** @var array<string, list<string>> $byCategory */
+        $byCategory = [];
+        foreach ($selectedFlags as $slug) {
+            if (!isset($slugToCategory[$slug])) {
+                continue; // unknown/forged slug — ignore
+            }
+            $byCategory[$slugToCategory[$slug]][] = $slug;
+        }
+        if ([] === $byCategory) {
+            return null;
+        }
+        $groupExpressions = [];
+        foreach ($byCategory as $slugs) {
+            $orParts = array_map(static fn (string $slug): string => sprintf("hasFlag('%s')", $slug), $slugs);
+            $groupExpressions[] = '('.implode(' or ', $orParts).')';
+        }
+
+        return implode(' and ', $groupExpressions);
+    }
+
+    /**
+     * Build the flag facet offering for the UI and the slug→category map for compilation.
+     * Flags are grouped by their category; flags with no category fall under "Ostatní".
+     *
+     * @param list<string> $selectedFlags
+     *
+     * @return array{0: list<array{categorySlug: string, categoryName: string, flags: list<array{slug: string, label: string, selected: bool}>}>, 1: array<string, string>}
+     */
+    private function buildFlagOffering(array $selectedFlags): array
+    {
+        $selectedLookup = array_fill_keys($selectedFlags, true);
+        /** @var array<string, array{categoryName: string, flags: list<array{slug: string, label: string, selected: bool}>}> $grouped */
+        $grouped = [];
+        $slugToCategory = [];
+
+        /** @var RegistrationFlag $flag */
+        foreach ($this->registrationFlagRepository->findBy([], ['id' => 'ASC']) as $flag) {
+            $slug = $flag->getSlug();
+            if ('' === $slug) {
+                continue;
+            }
+            $category = $flag->getCategory();
+            $categorySlug = $category?->getSlug() ?? '';
+            $categoryName = $category?->getName() ?? 'Ostatní';
+            $slugToCategory[$slug] = $categorySlug;
+            $grouped[$categorySlug]['categoryName'] ??= $categoryName;
+            $grouped[$categorySlug]['flags'][] = [
+                'slug'     => $slug,
+                'label'    => $flag->getShortName() ?? $flag->getName() ?? $slug,
+                'selected' => isset($selectedLookup[$slug]),
+            ];
+        }
+
+        $facets = [];
+        foreach ($grouped as $categorySlug => $data) {
+            $facets[] = [
+                'categorySlug' => $categorySlug,
+                'categoryName' => $data['categoryName'],
+                'flags'        => $data['flags'],
+            ];
+        }
+
+        return [$facets, $slugToCategory];
+    }
+
+    /**
+     * @return list<array{url: string, label: string, group: string, active: bool}>
      */
     private function buildFilterTabs(?string $eventSlug, ?string $participantCategorySlug, string $active): array
     {
-        $routeArgs = [
-            'eventSlug'               => $eventSlug,
-            'participantCategorySlug' => $participantCategorySlug,
-        ];
+        $tabs = [];
+        foreach ($this->getFilterRegistry() as $filter) {
+            $query = ['eventSlug' => $eventSlug, 'participantCategorySlug' => $participantCategorySlug];
+            if (self::FILTER_ALL !== $filter['key']) {
+                $query['filter'] = $filter['key'];
+            }
+            $tabs[] = [
+                'url'    => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list', $query),
+                'label'  => $filter['label'],
+                'group'  => $filter['group'],
+                'active' => $filter['key'] === $active,
+            ];
+        }
 
-        return [
-            ['url' => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list',            $routeArgs), 'label' => 'Vše',                'active' => self::FILTER_ALL            === $active],
-            ['url' => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_unpaid',          $routeArgs), 'label' => 'Nezaplacení',        'active' => self::FILTER_UNPAID         === $active],
-            ['url' => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_unpaid_deposit',  $routeArgs), 'label' => 'Nezaplacená záloha', 'active' => self::FILTER_UNPAID_DEPOSIT === $active],
-            ['url' => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_overpaid',        $routeArgs), 'label' => 'Přeplacení',         'active' => self::FILTER_OVERPAID       === $active],
-            ['url' => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_food',            $routeArgs), 'label' => 'Stravovací omezení', 'active' => self::FILTER_FOOD           === $active],
-        ];
+        return $tabs;
+    }
+
+    /**
+     * Summary statistics over a (pre-filter) participant collection.
+     *
+     * @param Collection<int, Participant> $participants
+     *
+     * @return array{total: int, deleted: int, paid: int, unpaid: int, sumPaid: int, sumPrice: int, sumRemaining: int}
+     */
+    private function computeStats(Collection $participants): array
+    {
+        $stats = ['total' => 0, 'deleted' => 0, 'paid' => 0, 'unpaid' => 0, 'sumPaid' => 0, 'sumPrice' => 0, 'sumRemaining' => 0];
+        foreach ($participants as $participant) {
+            if ($participant->isDeleted()) {
+                ++$stats['deleted'];
+                continue;
+            }
+            ++$stats['total'];
+            $stats['sumPaid'] += $participant->getPaidPrice();
+            $stats['sumPrice'] += $participant->getPrice();
+            $remaining = $participant->getRemainingPrice();
+            if ($remaining > 0) {
+                ++$stats['unpaid'];
+                $stats['sumRemaining'] += $remaining;
+            } else {
+                ++$stats['paid'];
+            }
+        }
+
+        return $stats;
     }
 
     public function getParticipantsData(

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlag;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagCategory;
 use OswisOrg\OswisCalendarBundle\Export\ParticipantExportDefinition;
@@ -62,6 +63,11 @@ class WebAdminParticipantsListController extends AbstractController
     public const string FILTER_WITH_NOTE         = 'with-note';
     public const string FILTER_DELETED           = 'deleted';
 
+    public const string SORT_NAME    = 'name';
+    public const string SORT_PAYMENT = 'payment';
+    public const string SORT_CREATED = 'created';
+    public const string SORT_ID      = 'id';
+
     /** Page size for the unscoped (all-participants) paginated view. */
     private const int PER_PAGE = 100;
 
@@ -92,11 +98,13 @@ class WebAdminParticipantsListController extends AbstractController
      */
     public function list(Request $request): Response
     {
-        $eventSlug = $request->query->get('eventSlug') ?: null;
+        // Scope: one or more events (?eventSlug= single + ?events[] multi) and/or a category.
+        [$events, $eventSlugs] = $this->resolveEventsFromRequest($request);
         $participantCategorySlug = $request->query->get('participantCategorySlug') ?: null;
         $participantCategory = $this->participantCategoryService->getParticipantTypeBySlug($participantCategorySlug);
-        $event = $this->eventService->getRepository()->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug]);
-        $scoped = (null !== $event) || (null !== $participantCategory);
+        $depthRaw = $request->query->get('depth');
+        $depthOverride = (null !== $depthRaw && '' !== $depthRaw) ? max(0, (int) $depthRaw) : null;
+        $scoped = ([] !== $events) || (null !== $participantCategory);
 
         $filterKey = $request->query->getString('filter', self::FILTER_ALL);
         if (!$this->isKnownFilter($filterKey)) {
@@ -105,6 +113,8 @@ class WebAdminParticipantsListController extends AbstractController
         $selectedFlags = array_values(array_filter($request->query->all('flags'), 'is_string'));
         $advancedExpr = trim($request->query->getString('expr'));
         $advancedExpr = '' === $advancedExpr ? null : $advancedExpr;
+        $sort = $this->normalizeSort($request->query->getString('sort', self::SORT_NAME));
+        $dir = 'desc' === $request->query->getString('dir') ? 'desc' : 'asc';
         $showAll = $request->query->getBoolean('all');
         $page = max(1, $request->query->getInt('page', 1));
 
@@ -113,22 +123,15 @@ class WebAdminParticipantsListController extends AbstractController
         [$flagFacets, $slugToCategory] = $this->buildFlagOffering($selectedFlags);
         $expression = $this->compileFilterExpression($filterKey, $selectedFlags, $advancedExpr, $slugToCategory);
 
-        $criteria = [
-            // We always load deleted rows and let the compiled expression decide
-            // (active filters add `not isDeleted()`, the "deleted" filter adds `isDeleted()`).
-            ParticipantRepository::CRITERIA_INCLUDE_DELETED       => true,
-            ParticipantRepository::CRITERIA_EVENT                 => $event,
-            ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY  => $participantCategory,
-            ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 2,
-        ];
-
         $loadAll = $scoped || $showAll;
         $pagination = null;
-        if ($loadAll) {
-            $loaded = $this->participantService->getParticipants($criteria);
+        if ($scoped) {
+            $loaded = $this->loadScopedParticipants($events, $participantCategory, $depthOverride);
+        } elseif ($showAll) {
+            $loaded = $this->participantService->getParticipants($this->unscopedCriteria());
         } else {
             $offset = ($page - 1) * self::PER_PAGE;
-            $loaded = $this->participantService->getParticipants($criteria, true, self::PER_PAGE, $offset);
+            $loaded = $this->participantService->getParticipants($this->unscopedCriteria(), true, self::PER_PAGE, $offset);
             $pagination = [
                 'page'    => $page,
                 'perPage' => self::PER_PAGE,
@@ -143,23 +146,24 @@ class WebAdminParticipantsListController extends AbstractController
         $this->participantService->getRepository()->primeAggregationCollections($ids);
 
         $matched = $loaded->filter(fn (Participant $p): bool => $this->filterEvaluator->matches($p, $expression));
-        $participantsArray = $matched->toArray();
-        usort(
-            $participantsArray,
-            static fn (Participant $a, Participant $b): int => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
-        );
+        $participantsArray = $this->sortParticipants(array_values($matched->toArray()), $sort, $dir);
 
         // Summary stats are computed from the full scoped set (pre-filter) — meaningless
         // and expensive for an unscoped paginated page, so skipped there.
         $stats = $loadAll ? $this->computeStats($loaded) : null;
 
+        // The scope/sort params that every in-page control must carry forward (as hidden
+        // fields in the GET filter form and as query merges in links) so nothing is lost.
+        $scopeParams = $this->buildScopeParams($eventSlugs, $participantCategorySlug, $depthOverride, $sort, $dir);
+
         return $this->render("@OswisOrgOswisCalendar/web_admin/participants.html.twig", [
             'title'               => 'Přehled přihlášek :: ADMIN',
-            'event'               => $event,
+            'event'               => 1 === count($events) ? $events[0] : null,
+            'events'              => $events,
             'participantCategory' => $participantCategory,
             'participants'        => new ArrayCollection($participantsArray),
             'scoped'              => $scoped,
-            'filterTabs'          => $this->buildFilterTabs($eventSlug, $participantCategorySlug, $filterKey),
+            'filterTabs'          => $this->buildFilterTabs($filterKey),
             'flagFacets'          => $flagFacets,
             'activeFilter'        => $filterKey,
             'selectedFlags'       => $selectedFlags,
@@ -171,10 +175,169 @@ class WebAdminParticipantsListController extends AbstractController
             'hasActiveFilter'     => $hasActiveFilter,
             'filterScopeWarning'  => !$loadAll && $hasActiveFilter,
             'availableFunctions'  => $this->filterEvaluator->getFunctionNames(),
-            'eventSlug'           => $eventSlug,
+            'scopeParams'         => $scopeParams,
+            'sort'                => $sort,
+            'dir'                 => $dir,
+            'depthOverride'       => $depthOverride,
             'participantCategorySlug' => $participantCategorySlug,
             'participantCategories'   => $this->participantCategoryService->getRepository()->findBy([], ['name' => 'ASC']),
         ]);
+    }
+
+    /**
+     * Resolve the scope events from the request: ?eventSlug= (single) merged with ?events[]
+     * (multi), de-duplicated, each resolved to an Event (unknown slugs dropped).
+     *
+     * @return array{0: list<\OswisOrg\OswisCalendarBundle\Entity\Event\Event>, 1: list<string>}
+     */
+    private function resolveEventsFromRequest(Request $request): array
+    {
+        $slugs = array_filter($request->query->all('events'), 'is_string');
+        $single = $request->query->get('eventSlug');
+        if (is_string($single) && '' !== $single) {
+            $slugs[] = $single;
+        }
+        $slugs = array_values(array_unique(array_filter($slugs, static fn (string $s): bool => '' !== $s)));
+
+        $events = [];
+        $resolvedSlugs = [];
+        foreach ($slugs as $slug) {
+            $event = $this->eventService->getRepository()->getEvent([EventRepository::CRITERIA_SLUG => $slug]);
+            if (null !== $event) {
+                $events[] = $event;
+                $resolvedSlugs[] = $slug;
+            }
+        }
+
+        return [$events, $resolvedSlugs];
+    }
+
+    /**
+     * Load the scoped participant set: union of each event's participants (recursing into
+     * sub-events to the per-event default depth, or an explicit override) de-duplicated by id,
+     * optionally narrowed to a participant category. Empty $events = category-only scope.
+     *
+     * @param list<\OswisOrg\OswisCalendarBundle\Entity\Event\Event> $events
+     *
+     * @return ArrayCollection<int, Participant>
+     */
+    private function loadScopedParticipants(array $events, ?ParticipantCategory $category, ?int $depthOverride, bool $includeDeleted = true): ArrayCollection
+    {
+        if ([] === $events) {
+            $collection = $this->participantService->getParticipants([
+                ParticipantRepository::CRITERIA_INCLUDE_DELETED      => $includeDeleted,
+                ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY => $category,
+                ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 0,
+            ]);
+
+            return new ArrayCollection($collection->toArray());
+        }
+        /** @var array<int, Participant> $byId */
+        $byId = [];
+        foreach ($events as $event) {
+            $depth = $depthOverride ?? $this->defaultDepth($event);
+            $collection = $this->participantService->getParticipants([
+                ParticipantRepository::CRITERIA_INCLUDE_DELETED       => $includeDeleted,
+                ParticipantRepository::CRITERIA_EVENT                 => $event,
+                ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY  => $category,
+                ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => $depth,
+            ]);
+            foreach ($collection as $participant) {
+                $id = $participant->getId();
+                if (null !== $id) {
+                    $byId[$id] = $participant;
+                }
+            }
+        }
+
+        return new ArrayCollection(array_values($byId));
+    }
+
+    /**
+     * Sensible default sub-event recursion depth for an event.
+     *
+     * A year (ročník) aggregates its turnusy, which are the registration units, so it recurses
+     * one level (depth 1) to gather their participants. Any other event (a turnus or a plain
+     * event) shows only its own direct registrations (depth 0) — by design we do NOT drill into
+     * a turnus's sub-events (e.g. skupiny) by default; use the sub-event links or an explicit
+     * ?depth= override for that.
+     */
+    private function defaultDepth(\OswisOrg\OswisCalendarBundle\Entity\Event\Event $event): int
+    {
+        return $event->isYear() ? 1 : 0;
+    }
+
+    /**
+     * @param list<Participant> $participants
+     *
+     * @return list<Participant>
+     */
+    private function sortParticipants(array $participants, string $sort, string $dir): array
+    {
+        $factor = 'desc' === $dir ? -1 : 1;
+        usort($participants, static function (Participant $a, Participant $b) use ($sort, $factor): int {
+            $comparison = match ($sort) {
+                self::SORT_PAYMENT => $a->getRemainingPrice() <=> $b->getRemainingPrice(),
+                self::SORT_CREATED => ($a->getCreatedAt()?->getTimestamp() ?? 0) <=> ($b->getCreatedAt()?->getTimestamp() ?? 0),
+                self::SORT_ID      => ($a->getId() ?? 0) <=> ($b->getId() ?? 0),
+                default            => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
+            };
+
+            return $factor * $comparison;
+        });
+
+        return $participants;
+    }
+
+    private function normalizeSort(string $sort): string
+    {
+        return in_array($sort, [self::SORT_NAME, self::SORT_PAYMENT, self::SORT_CREATED, self::SORT_ID], true)
+            ? $sort : self::SORT_NAME;
+    }
+
+    /**
+     * Criteria for the unscoped (all events) view.
+     *
+     * @return array<string, mixed>
+     */
+    private function unscopedCriteria(): array
+    {
+        return [
+            ParticipantRepository::CRITERIA_INCLUDE_DELETED       => true,
+            ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 0,
+        ];
+    }
+
+    /**
+     * The scope+sort query params to carry across every in-page control. Single event →
+     * eventSlug; multiple → events[]. Defaults (sort=name, dir=asc, auto depth) are omitted.
+     *
+     * @param list<string> $eventSlugs
+     *
+     * @return array<string, string|int|list<string>>
+     */
+    private function buildScopeParams(array $eventSlugs, ?string $participantCategorySlug, ?int $depthOverride, string $sort, string $dir): array
+    {
+        $params = [];
+        if (1 === count($eventSlugs)) {
+            $params['eventSlug'] = $eventSlugs[0];
+        } elseif (count($eventSlugs) > 1) {
+            $params['events'] = $eventSlugs;
+        }
+        if (null !== $participantCategorySlug) {
+            $params['participantCategorySlug'] = $participantCategorySlug;
+        }
+        if (null !== $depthOverride) {
+            $params['depth'] = $depthOverride;
+        }
+        if (self::SORT_NAME !== $sort) {
+            $params['sort'] = $sort;
+        }
+        if ('asc' !== $dir) {
+            $params['dir'] = $dir;
+        }
+
+        return $params;
     }
 
     /**
@@ -370,19 +533,17 @@ class WebAdminParticipantsListController extends AbstractController
     }
 
     /**
-     * @return list<array{key: string, url: string, label: string, group: string, active: bool}>
+     * Filter pills for the GET form (the selected scope/sort ride along as hidden fields, so
+     * these only need the radio value/label/group/active flag — no per-tab URL).
+     *
+     * @return list<array{key: string, label: string, group: string, active: bool}>
      */
-    private function buildFilterTabs(?string $eventSlug, ?string $participantCategorySlug, string $active): array
+    private function buildFilterTabs(string $active): array
     {
         $tabs = [];
         foreach ($this->getFilterRegistry() as $filter) {
-            $query = ['eventSlug' => $eventSlug, 'participantCategorySlug' => $participantCategorySlug];
-            if (self::FILTER_ALL !== $filter['key']) {
-                $query['filter'] = $filter['key'];
-            }
             $tabs[] = [
                 'key'    => $filter['key'],
-                'url'    => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list', $query),
                 'label'  => $filter['label'],
                 'group'  => $filter['group'],
                 'active' => $filter['key'] === $active,
@@ -458,14 +619,29 @@ class WebAdminParticipantsListController extends AbstractController
      */
     public function showParticipantsCsv(Request $request): Response
     {
-        $eventSlug = $request->query->get('eventSlug') ?: null;
+        // Export the same scoped set the list shows (multi-event + depth aware). Unscoped
+        // (no event, no category) exports everything.
+        [$events, ] = $this->resolveEventsFromRequest($request);
         $participantCategorySlug = $request->query->get('participantCategorySlug') ?: null;
+        $participantCategory = $this->participantCategoryService->getParticipantTypeBySlug($participantCategorySlug);
+        $depthRaw = $request->query->get('depth');
+        $depthOverride = (null !== $depthRaw && '' !== $depthRaw) ? max(0, (int) $depthRaw) : null;
         $includeDeleted = $request->query->getBoolean('includeDeleted');
-        $data = $this->getParticipantsData($eventSlug, $participantCategorySlug, $includeDeleted);
-        $participants = $data['participants'] ?? null;
-        if (!$participants instanceof Collection) {
-            $participants = new ArrayCollection();
+
+        if ([] !== $events || null !== $participantCategory) {
+            $participants = $this->loadScopedParticipants($events, $participantCategory, $depthOverride, $includeDeleted);
+        } else {
+            $participants = $this->participantService->getParticipants([
+                ParticipantRepository::CRITERIA_INCLUDE_DELETED       => $includeDeleted,
+                ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 0,
+            ]);
         }
+        $participantsArray = $participants->toArray();
+        usort(
+            $participantsArray,
+            static fn (Participant $a, Participant $b): int => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
+        );
+        $participants = new ArrayCollection($participantsArray);
         $columnKeys = array_values(array_filter($request->query->all('columns'), 'is_string'));
         $exportRequest = new ExportRequest(
             ExportFormat::fromRequest($request->query->getString('format')),

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -104,6 +104,18 @@ class WebAdminParticipantsListController extends AbstractController
         $participantCategory = $this->participantCategoryService->getParticipantTypeBySlug($participantCategorySlug);
         $depthRaw = $request->query->get('depth');
         $depthOverride = (null !== $depthRaw && '' !== $depthRaw) ? max(0, (int) $depthRaw) : null;
+        $allEvents = $request->query->getBoolean('allEvents');
+
+        // Default scope = the current default event. Showing every participant across all
+        // events at once is opt-in (?allEvents=1), not the landing view.
+        $isDefaultScope = false;
+        if ([] === $events && null === $participantCategory && !$allEvents) {
+            $defaultEvent = $this->eventService->getDefaultEvent();
+            if (null !== $defaultEvent) {
+                $events = [$defaultEvent];
+                $isDefaultScope = true;
+            }
+        }
         $scoped = ([] !== $events) || (null !== $participantCategory);
 
         $filterKey = $request->query->getString('filter', self::FILTER_ALL);
@@ -154,7 +166,7 @@ class WebAdminParticipantsListController extends AbstractController
 
         // The scope/sort params that every in-page control must carry forward (as hidden
         // fields in the GET filter form and as query merges in links) so nothing is lost.
-        $scopeParams = $this->buildScopeParams($eventSlugs, $participantCategorySlug, $depthOverride, $sort, $dir);
+        $scopeParams = $this->buildScopeParams($eventSlugs, $participantCategorySlug, $depthOverride, $sort, $dir, $allEvents);
 
         return $this->render("@OswisOrgOswisCalendar/web_admin/participants.html.twig", [
             'title'               => 'Přehled přihlášek :: ADMIN',
@@ -176,6 +188,8 @@ class WebAdminParticipantsListController extends AbstractController
             'filterScopeWarning'  => !$loadAll && $hasActiveFilter,
             'availableFunctions'  => $this->filterEvaluator->getFunctionNames(),
             'scopeParams'         => $scopeParams,
+            'isDefaultScope'      => $isDefaultScope,
+            'allEvents'           => $allEvents,
             'sort'                => $sort,
             'dir'                 => $dir,
             'depthOverride'       => $depthOverride,
@@ -316,13 +330,16 @@ class WebAdminParticipantsListController extends AbstractController
      *
      * @return array<string, string|int|list<string>>
      */
-    private function buildScopeParams(array $eventSlugs, ?string $participantCategorySlug, ?int $depthOverride, string $sort, string $dir): array
+    private function buildScopeParams(array $eventSlugs, ?string $participantCategorySlug, ?int $depthOverride, string $sort, string $dir, bool $allEvents = false): array
     {
         $params = [];
         if (1 === count($eventSlugs)) {
             $params['eventSlug'] = $eventSlugs[0];
         } elseif (count($eventSlugs) > 1) {
             $params['events'] = $eventSlugs;
+        }
+        if ($allEvents) {
+            $params['allEvents'] = 1;
         }
         if (null !== $participantCategorySlug) {
             $params['participantCategorySlug'] = $participantCategorySlug;

--- a/Repository/Participant/ParticipantPaymentRepository.php
+++ b/Repository/Participant/ParticipantPaymentRepository.php
@@ -28,9 +28,19 @@ class ParticipantPaymentRepository extends ServiceEntityRepository
      */
     public function findFiltered(string $filter, int $limit = 500): array
     {
+        // Participant has fetch=EAGER on offer/event/participantCategory and AbstractContact
+        // has fetch=EAGER on appUser — without join-fetching them here, hydrating each row's
+        // participant fires 4 extra queries per distinct participant (the payments overview
+        // measured ~1646 queries for 500 rows). These are all to-one joins, so they collapse
+        // into the single result query with no row multiplication. EAGER stays intentional;
+        // we just load it up-front instead of lazily (per the page-scoped optimisation rule).
         $qb = $this->createQueryBuilder('p')
             ->leftJoin('p.participant', 'participant')->addSelect('participant')
             ->leftJoin('participant.contact', 'contact')->addSelect('contact')
+            ->leftJoin('contact.appUser', 'appUser')->addSelect('appUser')
+            ->leftJoin('participant.offer', 'offer')->addSelect('offer')
+            ->leftJoin('participant.event', 'pEvent')->addSelect('pEvent')
+            ->leftJoin('participant.participantCategory', 'pCategory')->addSelect('pCategory')
             ->leftJoin('p.import', 'import')->addSelect('import')
             ->orderBy('p.dateTime', 'DESC')
             ->setMaxResults($limit);

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -67,12 +67,20 @@ oswis_org_oswis_calendar_web_event:
   controller: oswis_org_oswis_calendar.event.event_controller::showEvent
   path: "/akce/{eventSlug?}"
 
-# Canonical unified participant list. Scope (event/category) in the path; filter, flag
-# facets, advanced expression, pagination all in the query string (?filter=, ?flags[]=,
-# ?expr=, ?page=, ?all=1) so the whole view is shareable/bookmarkable.
+# Canonical unified participant list. EVERYTHING is in the query string — scope
+# (?eventSlug=, ?participantCategorySlug=) + ?filter=, ?flags[]=, ?expr=, ?page=, ?all=1 —
+# so the whole view is shareable/bookmarkable AND any scope combination is expressible
+# (a positional /{eventSlug?}/{categorySlug?} path can't represent category-only scope).
 oswis_org_oswis_calendar_web_admin_participants_list:
   controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::list
-  path: "/web_admin/seznam-prihlasek/{eventSlug?}/{participantCategorySlug?}"
+  path: "/web_admin/seznam-prihlasek"
+  methods: [GET]
+
+# BC: old path-form list URL → 301 to the canonical query-form list. eventSlug required
+# so this never clashes with the bare canonical path above.
+oswis_org_oswis_calendar_web_admin_participants_list_legacy_path:
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::legacyScopeRedirect
+  path: "/web_admin/seznam-prihlasek/{eventSlug}/{participantCategorySlug?}"
   methods: [GET]
 
 # Legacy filter URLs — 301-redirect to the canonical list with the matching ?filter=
@@ -99,7 +107,8 @@ oswis_org_oswis_calendar_web_admin_participants_food:
 
 oswis_org_oswis_calendar_web_admin_participants_list_csv:
   controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showParticipantsCsv
-  path: "/web_admin/seznam-prihlasek-csv/{eventSlug?}/{participantCategorySlug?}"
+  path: "/web_admin/seznam-prihlasek-csv"
+  methods: [GET]
 
 oswis_org_oswis_calendar_web_admin_event:
   controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showEvent

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -67,25 +67,35 @@ oswis_org_oswis_calendar_web_event:
   controller: oswis_org_oswis_calendar.event.event_controller::showEvent
   path: "/akce/{eventSlug?}"
 
+# Canonical unified participant list. Scope (event/category) in the path; filter, flag
+# facets, advanced expression, pagination all in the query string (?filter=, ?flags[]=,
+# ?expr=, ?page=, ?all=1) so the whole view is shareable/bookmarkable.
 oswis_org_oswis_calendar_web_admin_participants_list:
-  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showParticipants
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::list
   path: "/web_admin/seznam-prihlasek/{eventSlug?}/{participantCategorySlug?}"
+  methods: [GET]
 
+# Legacy filter URLs — 301-redirect to the canonical list with the matching ?filter=
+# (kept so old bookmarks/links don't break).
 oswis_org_oswis_calendar_web_admin_participants_unpaid:
-  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showUnpaidParticipants
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::legacyFilterRedirect
   path: "/web_admin/prihlasky/nezaplacene/{eventSlug?}/{participantCategorySlug?}"
+  defaults: { filter: unpaid }
 
 oswis_org_oswis_calendar_web_admin_participants_unpaid_deposit:
-  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showUnpaidDepositParticipants
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::legacyFilterRedirect
   path: "/web_admin/prihlasky/nezaplacene-zalohy/{eventSlug?}/{participantCategorySlug?}"
+  defaults: { filter: unpaid-deposit }
 
 oswis_org_oswis_calendar_web_admin_participants_overpaid:
-  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showOverpaidParticipants
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::legacyFilterRedirect
   path: "/web_admin/prihlasky/preplacene/{eventSlug?}/{participantCategorySlug?}"
+  defaults: { filter: overpaid }
 
 oswis_org_oswis_calendar_web_admin_participants_food:
-  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showFoodParticipants
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::legacyFilterRedirect
   path: "/web_admin/prihlasky/stravovaci-omezeni/{eventSlug?}/{participantCategorySlug?}"
+  defaults: { filter: food }
 
 oswis_org_oswis_calendar_web_admin_participants_list_csv:
   controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showParticipantsCsv

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -196,6 +196,13 @@ oswis_org_oswis_calendar_web_admin_participant_restore:
     participantId: '\d+'
   methods: [POST]
 
+oswis_org_oswis_calendar_web_admin_participant_delete:
+  controller: oswis_org_oswis_calendar.web_admin.participants_controller::delete
+  path: "/web_admin/ucastnici/{participantId}/smazat"
+  requirements:
+    participantId: '\d+'
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_participant_resend_activation:
   controller: oswis_org_oswis_calendar.web_admin.participants_controller::resendActivation
   path: "/web_admin/ucastnici/{participantId}/znovu-poslat-aktivaci"

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -250,6 +250,9 @@ services:
     alias: oswis_org_oswis_calendar.registration.registration_flag_service
     public: true
 
+  OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFilterEvaluator:
+    autowire: true
+
   oswis_org_oswis_calendar.registration.registration_flag_category_service:
     class: OswisOrg\OswisCalendarBundle\Service\Registration\RegistrationFlagCategoryService
     autowire: true

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -1,75 +1,136 @@
-<div class="container">
-    {% if filterTabs is defined %}
-        <ul class="nav nav-tabs mb-3">
-            {% for tab in filterTabs %}
-                <li class="nav-item">
-                    <a class="nav-link{{ tab.active ? ' active' : '' }}" href="{{ tab.url }}">{{ tab.label }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-    {% endif %}
-    <div class="row">
+{# Unified participant list. Scope (event/category) in the path, filter/flags/expr/page in
+   the query — the whole view is driven by the controller's registry. All controls are GET
+   so every state is shareable/bookmarkable. #}
+{% set listPath = path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug, participantCategorySlug: participantCategorySlug}) %}
+<div class="container-fluid">
+
+    {# ---- SCOPE BAR ------------------------------------------------------- #}
+    <div class="row mb-3">
         <div class="col">
-            <h2>Přehled přihlášek</h2>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col">
-            <h3>Omezení</h3>
-            <table class="list">
-                <thead>
-                <tr>
-                    <th>Typ omezení</th>
-                    <th>Hodnota</th>
-                </tr>
-                </thead>
-                {% if participantCategory|default %}
-                    <tbody>
-                    <tr>
-                        <td>Kategorie účastníka:</td>
-                        <td>
-                            <strong>{{ participantCategory.name|default(participantCategory.slug|default('bez názvu')) }}</strong>
-                        </td>
-                    </tr>
-                    </tbody>
-                {% endif %}
+            <h2 class="d-inline-block me-3">Přehled přihlášek</h2>
+            {% if scoped %}
+                <a class="btn btn-sm btn-outline-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× Zrušit omezení (všichni)</a>
+            {% else %}
+                <span class="badge bg-warning text-dark">Bez omezení — všichni účastníci napříč akcemi</span>
+            {% endif %}
+            <div class="mt-2 d-flex flex-wrap gap-3 align-items-center">
                 {% if event|default %}
-                    <tbody>
-                    <tr>
-                        <td>Událost:</td>
-                        <td>
-                            <strong>{{ event.name|default(event.slug|default('bez názvu')) }}</strong>
-                            <ul>
-                                {% for subEvent in event.subEvents %}
-                                    <li>
-                                        <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list',
-                                            {'eventSlug': subEvent.slug, 'participantCategorySlug': participantCategory.slug|default}) }}">
-                                            {{ subEvent.name }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                                {% if event.superEvent %}
-                                    <li>
-                                        součást akce:
-                                        <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list',
-                                            {'eventSlug': event.superEvent.slug, 'participantCategorySlug': participantCategory.slug|default}) }}">
-                                            {{ event.superEvent.name }}
-                                        </a>
-                                    </li>
-                                {% endif %}
-                            </ul>
-                        </td>
-                    </tr>
-                    </tbody>
+                    <div class="small">
+                        <strong>Akce:</strong> {{ event.name|default(event.slug|default('—')) }}
+                        {% if event.superEvent %}
+                            · <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: event.superEvent.slug, participantCategorySlug: participantCategorySlug}) }}">↑ {{ event.superEvent.name }}</a>
+                        {% endif %}
+                        {% for subEvent in event.subEvents %}
+                            · <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: subEvent.slug, participantCategorySlug: participantCategorySlug}) }}">↳ {{ subEvent.name }}</a>
+                        {% endfor %}
+                    </div>
                 {% endif %}
-            </table>
+                {% if participantCategories|default %}
+                    <div class="small">
+                        <strong>Typ účastníka:</strong>
+                        <select class="form-select form-select-sm d-inline-block" style="width:auto;"
+                                onchange="if(this.value){location.href=this.value;}">
+                            <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug}) }}"
+                                {{ participantCategory|default ? '' : 'selected' }}>(všechny typy)</option>
+                            {% for category in participantCategories %}
+                                <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug, participantCategorySlug: category.slug}) }}"
+                                    {{ participantCategory|default and participantCategory.slug == category.slug ? 'selected' : '' }}>
+                                    {{ category.name|default(category.slug) }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                {% endif %}
+            </div>
         </div>
     </div>
 
+    {# ---- SUMMARY STATS (scoped only) ------------------------------------- #}
+    {% if stats|default %}
+        <div class="row mb-3">
+            <div class="col d-flex flex-wrap gap-2">
+                <span class="badge bg-primary">Přihlášek: {{ stats.total }}</span>
+                <span class="badge bg-success">Zaplaceno: {{ stats.paid }}</span>
+                <span class="badge bg-danger">Nezaplaceno: {{ stats.unpaid }}</span>
+                <span class="badge bg-info text-dark">Vybráno: {{ stats.sumPaid }} Kč</span>
+                <span class="badge bg-warning text-dark">Zbývá: {{ stats.sumRemaining }} Kč</span>
+                <span class="badge bg-secondary">Celková cena: {{ stats.sumPrice }} Kč</span>
+                <span class="badge bg-dark">Smazaných: {{ stats.deleted }}</span>
+            </div>
+        </div>
+    {% endif %}
+
+    {# ---- FILTER FORM (one GET form → all state in URL) ------------------- #}
+    <form method="get" action="{{ listPath }}" class="card card-body mb-3">
+        <div class="mb-2 d-flex flex-wrap align-items-center gap-1">
+            {% for tab in filterTabs %}
+                {% if not loop.first and tab.group != filterTabs[loop.index0 - 1].group %}
+                    <span class="vr mx-1"></span>
+                {% endif %}
+                <label class="btn btn-sm {{ tab.active ? 'btn-primary' : 'btn-outline-primary' }} mb-1"
+                       title="{{ tab.group }}">
+                    <input type="radio" name="filter" value="{{ tab.key }}" class="d-none"
+                           onchange="this.form.submit()" {{ tab.active ? 'checked' : '' }}> {{ tab.label }}
+                </label>
+            {% endfor %}
+        </div>
+
+        {% if flagFacets|default %}
+            <details class="mb-2" {{ selectedFlags|default([])|length > 0 ? 'open' : '' }}>
+                <summary class="small text-secondary" style="cursor:pointer;">Filtr dle příznaků (NEBO uvnitř kategorie, A napříč) — vybráno: {{ selectedFlags|default([])|length }}</summary>
+                <div class="row mt-2">
+                    {% for facet in flagFacets %}
+                        <div class="col-md-3 col-sm-6 mb-2">
+                            <strong class="small d-block">{{ facet.categoryName }}</strong>
+                            {% for flag in facet.flags %}
+                                <label class="d-block small" style="font-weight:normal;">
+                                    <input type="checkbox" name="flags[]" value="{{ flag.slug }}" {{ flag.selected ? 'checked' : '' }}>
+                                    {{ flag.label }}
+                                </label>
+                            {% endfor %}
+                        </div>
+                    {% endfor %}
+                </div>
+            </details>
+        {% endif %}
+
+        <details class="mb-2" {{ advancedExpr|default ? 'open' : '' }}>
+            <summary class="small text-secondary" style="cursor:pointer;">Pokročilý filtr (výraz)</summary>
+            <div class="mt-2">
+                <input type="text" name="expr" class="form-control form-control-sm" value="{{ advancedExpr|default }}"
+                       placeholder="např. hasFlag('panske-m') or hasFlag('damske-m')">
+                <small class="text-secondary">Funkce: {{ availableFunctions|default([])|join('(), ') }}()</small>
+            </div>
+        </details>
+
+        <div>
+            <button type="submit" class="btn btn-sm btn-primary">Použít filtr</button>
+            {% if hasActiveFilter|default %}
+                <a class="btn btn-sm btn-outline-secondary" href="{{ listPath }}">Zrušit filtry</a>
+            {% endif %}
+            {% if expression|default %}
+                <small class="text-secondary ms-2">výraz: <code>{{ expression }}</code></small>
+            {% endif %}
+        </div>
+    </form>
+
+    {# ---- WARNINGS -------------------------------------------------------- #}
+    {% if filterScopeWarning|default %}
+        <div class="alert alert-warning py-2 small">
+            Filtruješ bez omezení akce — filtr se aplikuje jen na <strong>aktuálně načtenou stránku</strong>.
+            Pro filtr přes všechny přihlášky zvol akci/typ, nebo
+            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({all: 1, page: null})) }}">zobraz vše</a>
+            (může být hodně dat), případně použij CSV export.
+        </div>
+    {% elseif showAll|default and not scoped %}
+        <div class="alert alert-warning py-2 small">Zobrazeno <strong>vše</strong> bez omezení — může jít o velké množství dat.</div>
+    {% endif %}
+
+    {# ---- LIST + EXPORT -------------------------------------------------- #}
     <div class="row">
         <div class="col">
             <h3>
-                Přehled nezrušených přihlášek
+                Přihlášky <small class="text-secondary">({{ participants|length }})</small>
                 <small class="small text-secondary">
                     <details class="d-inline-block" style="position: relative;">
                         <summary class="btn btn-sm btn-outline-secondary" style="cursor: pointer;">Export ▾</summary>
@@ -102,54 +163,36 @@
                         </form>
                     </details>
                     {% if is_granted('ROLE_ADMIN') %}
-                        ·
-                        [<a class="text-secondary"
-                            href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}">hromadný přesun</a>]
+                        · [<a class="text-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}">hromadný přesun</a>]
                     {% endif %}
                 </small>
             </h3>
-            <table class="list">
-                {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
-                {% for participant in participants|filter(participant => not participant.deleted) %}
-                    {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}
-                {% else %}
-                    <tbody>
-                    <tr>
-                        <td colspan="4" class="text-center bold">Žádné nezrušené přihlášky.</td>
-                    </tr>
-                    </tbody>
-                {% endfor %}
-            </table>
-            <p>
-                <small>
-                    {{ participants|filter(participant => not participant.deleted)|map(p => p.contact.email)|join(', ') }}
-                </small>
-            </p>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col">
-            <h3>Přehled zrušených přihlášek</h3>
             <table class="list">
                 {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
-                {% for participant in participants|filter(participant => participant.deleted) %}
+                {% for participant in participants %}
                     {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}
                 {% else %}
                     <tbody>
-                    <tr>
-                        <td colspan="4" class="text-center bold">Žádné zrušené přihlášky.</td>
-                    </tr>
+                    <tr><td colspan="4" class="text-center bold">Žádné přihlášky odpovídající filtru.</td></tr>
                     </tbody>
                 {% endfor %}
             </table>
-            <p>
-                <span class="block small">
-                    <small>
-                        {{ participants|filter(participant => participant.deleted and participant.contact|default)|map(p => p.contact.email|default(''))|filter(e => e != '')|join(', ') }}
-                    </small>
-                </span>
-            </p>
+
+            {% if pagination|default %}
+                <nav class="mt-3 d-flex gap-2 align-items-center">
+                    {% if pagination.hasPrev %}
+                        <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({page: pagination.page - 1})) }}">← Předchozí</a>
+                    {% endif %}
+                    <span class="small">strana {{ pagination.page }}</span>
+                    {% if pagination.hasNext %}
+                        <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({page: pagination.page + 1})) }}">Další →</a>
+                    {% endif %}
+                    <a class="btn btn-sm btn-outline-secondary ms-2" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({all: 1, page: null})) }}">Zobrazit vše</a>
+                </nav>
+            {% endif %}
+
+            <p class="mt-2"><small>{{ participants|map(p => p.contact.email|default(''))|filter(e => e != '')|join(', ') }}</small></p>
         </div>
     </div>
 

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -4,7 +4,7 @@
    expression, sub-event depth) live in a collapsed "Pokročilé" panel so ordinary users aren't
    overwhelmed and the page stays compact. #}
 {% set qbase = app.request.query.all %}
-<div class="container-fluid">
+<div class="container">
 
     {# ---- HEADER + SCOPE (compact, one row) ------------------------------ #}
     <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
@@ -14,15 +14,19 @@
             {% for ev in events %}
                 <span class="badge bg-secondary">{{ ev.name|default(ev.slug) }}</span>
             {% endfor %}
+            {% if isDefaultScope|default %}<span class="badge bg-light text-secondary border">výchozí akce</span>{% endif %}
         {% endif %}
         {% if participantCategory|default %}
             <span class="badge bg-info text-dark">{{ participantCategory.name|default(participantCategory.slug) }}</span>
         {% endif %}
 
-        {% if scoped %}
-            <a class="btn btn-sm btn-outline-secondary py-0" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× zrušit omezení</a>
-        {% else %}
-            <span class="badge bg-warning text-dark">bez omezení — všichni napříč akcemi</span>
+        {% if allEvents|default %}
+            <span class="badge bg-warning text-dark">všichni napříč akcemi</span>
+            <a class="btn btn-sm btn-outline-secondary py-0" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× zpět na výchozí akci</a>
+        {% elseif isDefaultScope|default %}
+            <a class="btn btn-sm btn-outline-secondary py-0" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {allEvents: 1}) }}">› všechny akce</a>
+        {% elseif scoped %}
+            <a class="btn btn-sm btn-outline-secondary py-0" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× zpět na výchozí akci</a>
         {% endif %}
 
         {# Category switcher — preserves the rest of the query. #}
@@ -119,20 +123,22 @@
                         <select name="depth" class="form-select form-select-sm">
                             <option value="" {{ depthOverride is null ? 'selected' : '' }}>auto</option>
                             {% for d in 0..3 %}
-                                <option value="{{ d }}" {{ depthOverride == d ? 'selected' : '' }}>{{ d }}</option>
+                                <option value="{{ d }}" {{ (depthOverride is not null and depthOverride == d) ? 'selected' : '' }}>{{ d }}</option>
                             {% endfor %}
                         </select>
                     </div>
                 </div>
+                <div class="mt-2">
+                    <button type="submit" class="btn btn-sm btn-primary">Použít filtry</button>
+                    {% if hasActiveFilter|default or depthOverride is not null %}
+                        <a class="btn btn-sm btn-outline-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', scopeParams) }}">Zrušit filtry</a>
+                    {% endif %}
+                </div>
             </div>
         </details>
 
-        <div class="mt-2">
-            <button type="submit" class="btn btn-sm btn-primary">Použít</button>
-            {% if hasActiveFilter|default or depthOverride is not null %}
-                <a class="btn btn-sm btn-outline-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', scopeParams) }}">Zrušit filtry</a>
-            {% endif %}
-        </div>
+        {# Pills auto-submit; a Submit fallback for when JS is off. #}
+        <noscript><button type="submit" class="btn btn-sm btn-primary mt-2">Použít</button></noscript>
     </form>
 
     {# ---- WARNINGS ------------------------------------------------------- #}
@@ -202,7 +208,7 @@
     </div>
 
     {# ---- TABLE ---------------------------------------------------------- #}
-    <table class="list">
+    <table class="list" style="table-layout: fixed; word-break: break-word;">
         {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
         {% for participant in participants %}
             {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -1,199 +1,230 @@
-{# Unified participant list. Scope (event/category) in the path, filter/flags/expr/page in
-   the query — the whole view is driven by the controller's registry. All controls are GET
-   so every state is shareable/bookmarkable. #}
-{% set listPath = path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug, participantCategorySlug: participantCategorySlug}) %}
+{# Unified participant list. Everything is in the query string (scope + filter + flags + expr
+   + sort + page), so the view is shareable/bookmarkable. UI is progressive: the common path
+   (pick scope, pick a filter pill) is always visible; power features (flag facets, boolean
+   expression, sub-event depth) live in a collapsed "Pokročilé" panel so ordinary users aren't
+   overwhelmed and the page stays compact. #}
+{% set qbase = app.request.query.all %}
 <div class="container-fluid">
 
-    {# ---- SCOPE BAR ------------------------------------------------------- #}
-    <div class="row mb-3">
-        <div class="col">
-            <h2 class="d-inline-block me-3">Přehled přihlášek</h2>
-            {% if scoped %}
-                <a class="btn btn-sm btn-outline-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× Zrušit omezení (všichni)</a>
-            {% else %}
-                <span class="badge bg-warning text-dark">Bez omezení — všichni účastníci napříč akcemi</span>
-            {% endif %}
-            <div class="mt-2 d-flex flex-wrap gap-3 align-items-center">
-                {% if event|default %}
-                    <div class="small">
-                        <strong>Akce:</strong> {{ event.name|default(event.slug|default('—')) }}
-                        {% if event.superEvent %}
-                            · <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: event.superEvent.slug, participantCategorySlug: participantCategorySlug}) }}">↑ {{ event.superEvent.name }}</a>
-                        {% endif %}
-                        {% for subEvent in event.subEvents %}
-                            · <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: subEvent.slug, participantCategorySlug: participantCategorySlug}) }}">↳ {{ subEvent.name }}</a>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-                {% if participantCategories|default %}
-                    <div class="small">
-                        <strong>Typ účastníka:</strong>
-                        <select class="form-select form-select-sm d-inline-block" style="width:auto;"
-                                onchange="if(this.value){location.href=this.value;}">
-                            <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug}) }}"
-                                {{ participantCategory|default ? '' : 'selected' }}>(všechny typy)</option>
-                            {% for category in participantCategories %}
-                                <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', {eventSlug: eventSlug, participantCategorySlug: category.slug}) }}"
-                                    {{ participantCategory|default and participantCategory.slug == category.slug ? 'selected' : '' }}>
-                                    {{ category.name|default(category.slug) }}
-                                </option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                {% endif %}
-            </div>
-        </div>
+    {# ---- HEADER + SCOPE (compact, one row) ------------------------------ #}
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+        <h2 class="h4 mb-0 me-2">Přehled přihlášek</h2>
+
+        {% if events|default %}
+            {% for ev in events %}
+                <span class="badge bg-secondary">{{ ev.name|default(ev.slug) }}</span>
+            {% endfor %}
+        {% endif %}
+        {% if participantCategory|default %}
+            <span class="badge bg-info text-dark">{{ participantCategory.name|default(participantCategory.slug) }}</span>
+        {% endif %}
+
+        {% if scoped %}
+            <a class="btn btn-sm btn-outline-secondary py-0" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}">× zrušit omezení</a>
+        {% else %}
+            <span class="badge bg-warning text-dark">bez omezení — všichni napříč akcemi</span>
+        {% endif %}
+
+        {# Category switcher — preserves the rest of the query. #}
+        {% if participantCategories|default %}
+            <select class="form-select form-select-sm w-auto py-0" title="Typ účastníka"
+                    onchange="if(this.value){location.href=this.value;}">
+                <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({participantCategorySlug: null, page: null})) }}"
+                    {{ participantCategory|default ? '' : 'selected' }}>— typ účastníka —</option>
+                {% for category in participantCategories %}
+                    <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({participantCategorySlug: category.slug, page: null})) }}"
+                        {{ participantCategory|default and participantCategory.slug == category.slug ? 'selected' : '' }}>{{ category.name|default(category.slug) }}</option>
+                {% endfor %}
+            </select>
+        {% endif %}
     </div>
 
-    {# ---- SUMMARY STATS (scoped only) ------------------------------------- #}
-    {% if stats|default %}
-        <div class="row mb-3">
-            <div class="col d-flex flex-wrap gap-2">
-                <span class="badge bg-primary">Přihlášek: {{ stats.total }}</span>
-                <span class="badge bg-success">Zaplaceno: {{ stats.paid }}</span>
-                <span class="badge bg-danger">Nezaplaceno: {{ stats.unpaid }}</span>
-                <span class="badge bg-info text-dark">Vybráno: {{ stats.sumPaid }} Kč</span>
-                <span class="badge bg-warning text-dark">Zbývá: {{ stats.sumRemaining }} Kč</span>
-                <span class="badge bg-secondary">Celková cena: {{ stats.sumPrice }} Kč</span>
-                <span class="badge bg-dark">Smazaných: {{ stats.deleted }}</span>
-            </div>
+    {# Sub-event / super-event quick links (only for a single-event scope). #}
+    {% if event|default and (event.subEvents|length > 0 or event.superEvent) %}
+        <div class="small text-secondary mb-2">
+            {% if event.superEvent %}
+                <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({eventSlug: event.superEvent.slug, events: null, page: null})) }}">↑ {{ event.superEvent.name }}</a>
+            {% endif %}
+            {% for subEvent in event.subEvents %}
+                <a class="ms-2" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({eventSlug: subEvent.slug, events: null, page: null})) }}">↳ {{ subEvent.name }}</a>
+            {% endfor %}
         </div>
     {% endif %}
 
-    {# ---- FILTER FORM (one GET form → all state in URL) ------------------- #}
-    <form method="get" action="{{ listPath }}" class="card card-body mb-3">
-        <div class="mb-2 d-flex flex-wrap align-items-center gap-1">
-            {% for tab in filterTabs %}
-                {% if not loop.first and tab.group != filterTabs[loop.index0 - 1].group %}
-                    <span class="vr mx-1"></span>
+    {# ---- STATS (scoped, compact one-liner) ------------------------------ #}
+    {% if stats|default %}
+        <div class="d-flex flex-wrap gap-2 mb-2 small">
+            <span class="badge bg-primary">přihlášek {{ stats.total }}</span>
+            <span class="badge bg-success">zaplaceno {{ stats.paid }}</span>
+            <span class="badge bg-danger">nezaplaceno {{ stats.unpaid }}</span>
+            <span class="badge bg-info text-dark">vybráno {{ stats.sumPaid }} Kč</span>
+            <span class="badge bg-warning text-dark">zbývá {{ stats.sumRemaining }} Kč</span>
+            {% if stats.deleted > 0 %}<span class="badge bg-dark">smazaných {{ stats.deleted }}</span>{% endif %}
+        </div>
+    {% endif %}
+
+    {# ---- FILTER FORM (GET; hidden fields carry scope+sort so nothing is lost) #}
+    <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="mb-2">
+        {% for key, value in scopeParams %}
+            {% if key != 'depth' %}
+                {% if value is iterable %}
+                    {% for item in value %}<input type="hidden" name="{{ key }}[]" value="{{ item }}">{% endfor %}
+                {% else %}
+                    <input type="hidden" name="{{ key }}" value="{{ value }}">
                 {% endif %}
-                <label class="btn btn-sm {{ tab.active ? 'btn-primary' : 'btn-outline-primary' }} mb-1"
-                       title="{{ tab.group }}">
-                    <input type="radio" name="filter" value="{{ tab.key }}" class="d-none"
-                           onchange="this.form.submit()" {{ tab.active ? 'checked' : '' }}> {{ tab.label }}
-                </label>
+            {% endif %}
+        {% endfor %}
+
+        {# Primary filter pills (always visible, the common case). #}
+        <div class="btn-group btn-group-sm flex-wrap" role="group">
+            {% for tab in filterTabs %}
+                <input type="radio" class="btn-check" name="filter" id="flt-{{ tab.key }}" value="{{ tab.key }}"
+                       autocomplete="off" onchange="this.form.submit()" {{ tab.active ? 'checked' : '' }}>
+                <label class="btn btn-outline-primary" for="flt-{{ tab.key }}"
+                       title="{{ tab.group }}">{{ tab.label }}</label>
             {% endfor %}
         </div>
 
-        {% if flagFacets|default %}
-            <details class="mb-2" {{ selectedFlags|default([])|length > 0 ? 'open' : '' }}>
-                <summary class="small text-secondary" style="cursor:pointer;">Filtr dle příznaků (NEBO uvnitř kategorie, A napříč) — vybráno: {{ selectedFlags|default([])|length }}</summary>
-                <div class="row mt-2">
-                    {% for facet in flagFacets %}
-                        <div class="col-md-3 col-sm-6 mb-2">
-                            <strong class="small d-block">{{ facet.categoryName }}</strong>
-                            {% for flag in facet.flags %}
-                                <label class="d-block small" style="font-weight:normal;">
-                                    <input type="checkbox" name="flags[]" value="{{ flag.slug }}" {{ flag.selected ? 'checked' : '' }}>
-                                    {{ flag.label }}
-                                </label>
+        {# Power features, collapsed by default to keep the page simple/compact. #}
+        <details class="mt-2" {{ (selectedFlags|default([])|length > 0 or advancedExpr|default or depthOverride is not null) ? 'open' : '' }}>
+            <summary class="small text-secondary" style="cursor:pointer;">Pokročilé filtry (příznaky, výraz, hloubka podakcí)</summary>
+            <div class="card card-body py-2 mt-1">
+                {% if flagFacets|default %}
+                    <div class="mb-2">
+                        <div class="small fw-bold">Příznaky <span class="text-secondary fw-normal">(NEBO uvnitř kategorie, A napříč)</span></div>
+                        <div class="row">
+                            {% for facet in flagFacets %}
+                                <div class="col-md-3 col-sm-6">
+                                    <div class="small text-secondary">{{ facet.categoryName }}</div>
+                                    {% for flag in facet.flags %}
+                                        <label class="d-block small" style="font-weight:normal;">
+                                            <input type="checkbox" name="flags[]" value="{{ flag.slug }}" {{ flag.selected ? 'checked' : '' }}> {{ flag.label }}
+                                        </label>
+                                    {% endfor %}
+                                </div>
                             {% endfor %}
                         </div>
-                    {% endfor %}
-                </div>
-            </details>
-        {% endif %}
+                    </div>
+                {% endif %}
 
-        <details class="mb-2" {{ advancedExpr|default ? 'open' : '' }}>
-            <summary class="small text-secondary" style="cursor:pointer;">Pokročilý filtr (výraz)</summary>
-            <div class="mt-2">
-                <input type="text" name="expr" class="form-control form-control-sm" value="{{ advancedExpr|default }}"
-                       placeholder="např. hasFlag('panske-m') or hasFlag('damske-m')">
-                <small class="text-secondary">Funkce: {{ availableFunctions|default([])|join('(), ') }}()</small>
+                <div class="row g-2 align-items-end">
+                    <div class="col-md-8">
+                        <label class="small text-secondary d-block">Výraz (pokročilé)</label>
+                        <input type="text" name="expr" class="form-control form-control-sm" value="{{ advancedExpr|default }}"
+                               placeholder="hasFlag('panske-m') or hasFlag('damske-m')">
+                        <small class="text-secondary">{{ availableFunctions|default([])|join('(), ') }}()</small>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="small text-secondary d-block">Hloubka podakcí</label>
+                        <select name="depth" class="form-select form-select-sm">
+                            <option value="" {{ depthOverride is null ? 'selected' : '' }}>auto</option>
+                            {% for d in 0..3 %}
+                                <option value="{{ d }}" {{ depthOverride == d ? 'selected' : '' }}>{{ d }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
             </div>
         </details>
 
-        <div>
-            <button type="submit" class="btn btn-sm btn-primary">Použít filtr</button>
-            {% if hasActiveFilter|default %}
-                <a class="btn btn-sm btn-outline-secondary" href="{{ listPath }}">Zrušit filtry</a>
-            {% endif %}
-            {% if expression|default %}
-                <small class="text-secondary ms-2">výraz: <code>{{ expression }}</code></small>
+        <div class="mt-2">
+            <button type="submit" class="btn btn-sm btn-primary">Použít</button>
+            {% if hasActiveFilter|default or depthOverride is not null %}
+                <a class="btn btn-sm btn-outline-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', scopeParams) }}">Zrušit filtry</a>
             {% endif %}
         </div>
     </form>
 
-    {# ---- WARNINGS -------------------------------------------------------- #}
+    {# ---- WARNINGS ------------------------------------------------------- #}
     {% if filterScopeWarning|default %}
-        <div class="alert alert-warning py-2 small">
-            Filtruješ bez omezení akce — filtr se aplikuje jen na <strong>aktuálně načtenou stránku</strong>.
-            Pro filtr přes všechny přihlášky zvol akci/typ, nebo
-            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({all: 1, page: null})) }}">zobraz vše</a>
-            (může být hodně dat), případně použij CSV export.
+        <div class="alert alert-warning py-1 px-2 small mb-2">
+            Bez omezení akce se filtr aplikuje jen na <strong>načtenou stránku</strong>. Pro filtr přes vše zvol akci/typ nebo
+            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({all: 1, page: null})) }}">zobraz vše</a>, příp. CSV.
         </div>
     {% elseif showAll|default and not scoped %}
-        <div class="alert alert-warning py-2 small">Zobrazeno <strong>vše</strong> bez omezení — může jít o velké množství dat.</div>
+        <div class="alert alert-warning py-1 px-2 small mb-2">Zobrazeno <strong>vše</strong> bez omezení — může být hodně dat.</div>
     {% endif %}
 
-    {# ---- LIST + EXPORT -------------------------------------------------- #}
-    <div class="row">
-        <div class="col">
-            <h3>
-                Přihlášky <small class="text-secondary">({{ participants|length }})</small>
-                <small class="small text-secondary">
-                    <details class="d-inline-block" style="position: relative;">
-                        <summary class="btn btn-sm btn-outline-secondary" style="cursor: pointer;">Export ▾</summary>
-                        <form method="get"
-                              action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_csv', {'eventSlug': event.slug|default, 'participantCategorySlug': participantCategory.slug|default}) }}"
-                              class="card card-body shadow"
-                              style="position: absolute; z-index: 1000; min-width: 16rem; text-align: left;">
-                            <div style="max-height: 14rem; overflow: auto; margin-bottom: .5rem;">
-                                {% set exportColumns = {
-                                    'id': 'ID', 'familyName': 'Příjmení', 'givenName': 'Křestní jméno', 'fullName': 'Celé jméno',
-                                    'variableSymbol': 'Variabilní symbol', 'event': 'Akce', 'category': 'Kategorie',
-                                    'email': 'E-mail', 'phone': 'Telefon', 'tShirt': 'Velikost trička', 'createdAt': 'Datum přihlášky',
-                                    'activated': 'Aktivováno', 'price': 'Celková cena', 'paidPrice': 'Zaplaceno [Kč]',
-                                    'remainingPrice': 'Zbývá [Kč]', 'paidPercentage': 'Zaplaceno [%]', 'deletedAt': 'Smazáno'
-                                } %}
-                                {% for key, label in exportColumns %}
-                                    <label class="d-block small" style="font-weight: normal;">
-                                        <input type="checkbox" name="columns[]" value="{{ key }}" checked> {{ label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
-                            <label class="small d-block mb-2">Formát:
-                                <select name="format" class="form-select form-select-sm">
-                                    <option value="csv">CSV (Excel)</option>
-                                    <option value="csv-rfc">CSV (RFC 4180)</option>
-                                    <option value="pdf">PDF</option>
-                                </select>
-                            </label>
-                            <button type="submit" class="btn btn-sm btn-primary">Exportovat</button>
-                        </form>
-                    </details>
-                    {% if is_granted('ROLE_ADMIN') %}
-                        · [<a class="text-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}">hromadný přesun</a>]
-                    {% endif %}
-                </small>
-            </h3>
+    {# ---- LIST TOOLBAR (count + sort + export) --------------------------- #}
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+        <strong>{{ participants|length }}</strong> <span class="small text-secondary">přihlášek</span>
+        <select class="form-select form-select-sm w-auto py-0 ms-2" title="Řazení"
+                onchange="if(this.value){location.href=this.value;}">
+            {% set sortOpts = {'name': 'jméno', 'payment': 'zbývá zaplatit', 'created': 'datum přihlášky', 'id': 'ID'} %}
+            {% for key, label in sortOpts %}
+                <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({sort: key, dir: null, page: null})) }}"
+                    {{ sort == key ? 'selected' : '' }}>řadit: {{ label }}</option>
+            {% endfor %}
+        </select>
+        <a class="btn btn-sm btn-outline-secondary py-0" title="Obrátit pořadí"
+           href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({dir: (dir == 'asc' ? 'desc' : 'asc'), page: null})) }}">{{ dir == 'asc' ? '↑' : '↓' }}</a>
 
-            <table class="list">
-                {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
-                {% for participant in participants %}
-                    {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}
-                {% else %}
-                    <tbody>
-                    <tr><td colspan="4" class="text-center bold">Žádné přihlášky odpovídající filtru.</td></tr>
-                    </tbody>
+        <details class="d-inline-block ms-auto" style="position: relative;">
+            <summary class="btn btn-sm btn-outline-secondary py-0" style="cursor: pointer;">Export ▾</summary>
+            <form method="get"
+                  action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_csv') }}"
+                  class="card card-body shadow" style="position: absolute; z-index: 1000; min-width: 16rem; text-align: left;">
+                {# Scope as hidden fields — a GET form discards its action's query string. #}
+                {% for key, value in scopeParams %}
+                    {% if key not in ['sort', 'dir'] %}
+                        {% if value is iterable %}
+                            {% for item in value %}<input type="hidden" name="{{ key }}[]" value="{{ item }}">{% endfor %}
+                        {% else %}
+                            <input type="hidden" name="{{ key }}" value="{{ value }}">
+                        {% endif %}
+                    {% endif %}
                 {% endfor %}
-            </table>
-
-            {% if pagination|default %}
-                <nav class="mt-3 d-flex gap-2 align-items-center">
-                    {% if pagination.hasPrev %}
-                        <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({page: pagination.page - 1})) }}">← Předchozí</a>
-                    {% endif %}
-                    <span class="small">strana {{ pagination.page }}</span>
-                    {% if pagination.hasNext %}
-                        <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({page: pagination.page + 1})) }}">Další →</a>
-                    {% endif %}
-                    <a class="btn btn-sm btn-outline-secondary ms-2" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', app.request.query.all|merge({all: 1, page: null})) }}">Zobrazit vše</a>
-                </nav>
-            {% endif %}
-
-            <p class="mt-2"><small>{{ participants|map(p => p.contact.email|default(''))|filter(e => e != '')|join(', ') }}</small></p>
-        </div>
+                <div style="max-height: 14rem; overflow: auto; margin-bottom: .5rem;">
+                    {% set exportColumns = {
+                        'id': 'ID', 'familyName': 'Příjmení', 'givenName': 'Křestní jméno', 'fullName': 'Celé jméno',
+                        'variableSymbol': 'Variabilní symbol', 'event': 'Akce', 'category': 'Kategorie',
+                        'email': 'E-mail', 'phone': 'Telefon', 'tShirt': 'Velikost trička', 'createdAt': 'Datum přihlášky',
+                        'activated': 'Aktivováno', 'price': 'Celková cena', 'paidPrice': 'Zaplaceno [Kč]',
+                        'remainingPrice': 'Zbývá [Kč]', 'paidPercentage': 'Zaplaceno [%]', 'deletedAt': 'Smazáno'
+                    } %}
+                    {% for key, label in exportColumns %}
+                        <label class="d-block small" style="font-weight: normal;"><input type="checkbox" name="columns[]" value="{{ key }}" checked> {{ label }}</label>
+                    {% endfor %}
+                </div>
+                <label class="small d-block mb-2">Formát:
+                    <select name="format" class="form-select form-select-sm">
+                        <option value="csv">CSV (Excel)</option>
+                        <option value="csv-rfc">CSV (RFC 4180)</option>
+                        <option value="pdf">PDF</option>
+                    </select>
+                </label>
+                <button type="submit" class="btn btn-sm btn-primary">Exportovat</button>
+            </form>
+        </details>
+        {% if is_granted('ROLE_ADMIN') %}
+            <a class="small text-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}">hromadný přesun</a>
+        {% endif %}
     </div>
+
+    {# ---- TABLE ---------------------------------------------------------- #}
+    <table class="list">
+        {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
+        {% for participant in participants %}
+            {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}
+        {% else %}
+            <tbody><tr><td colspan="4" class="text-center bold">Žádné přihlášky odpovídající filtru.</td></tr></tbody>
+        {% endfor %}
+    </table>
+
+    {# ---- PAGINATION (unscoped paginated view) --------------------------- #}
+    {% if pagination|default %}
+        <nav class="mt-2 d-flex gap-2 align-items-center">
+            {% if pagination.hasPrev %}
+                <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({page: pagination.page - 1})) }}">← Předchozí</a>
+            {% endif %}
+            <span class="small">strana {{ pagination.page }}</span>
+            {% if pagination.hasNext %}
+                <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({page: pagination.page + 1})) }}">Další →</a>
+            {% endif %}
+            <a class="btn btn-sm btn-outline-secondary ms-2" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({all: 1, page: null})) }}">Zobrazit vše</a>
+        </nav>
+    {% endif %}
+
+    <p class="mt-2"><small class="text-secondary">{{ participants|map(p => p.contact.email|default(''))|filter(e => e != '')|join(', ') }}</small></p>
 
 </div>

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -11,6 +11,7 @@
         <h2 class="h4 mb-0 me-2">Přehled přihlášek</h2>
 
         {% if events|default %}
+            <span class="small text-secondary">Akce:</span>
             {% for ev in events %}
                 <span class="badge bg-secondary">{{ ev.name|default(ev.slug) }}</span>
             {% endfor %}
@@ -31,6 +32,7 @@
 
         {# Category switcher — preserves the rest of the query. #}
         {% if participantCategories|default %}
+            <span class="small text-secondary ms-1">Typ:</span>
             <select class="form-select form-select-sm w-auto py-0" title="Typ účastníka"
                     onchange="if(this.value){location.href=this.value;}">
                 <option value="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({participantCategorySlug: null, page: null})) }}"
@@ -68,7 +70,26 @@
     {% endif %}
 
     {# ---- FILTER FORM (GET; hidden fields carry scope+sort so nothing is lost) #}
-    <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="mb-2">
+    {# Empty advanced fields are dropped before submit (disabled inputs aren't sent) so shared
+       URLs stay clean — no trailing &expr=&depth=. Works for both the Submit button (onsubmit)
+       and the auto-submitting pills (which call form.submit(), bypassing onsubmit). #}
+    <script>
+        function oswisStripEmptyFilter(form) {
+            for (var i = 0; i < form.elements.length; i++) {
+                var el = form.elements[i];
+                if ((el.name === 'expr' || el.name === 'depth') && el.value === '') {
+                    el.disabled = true;
+                }
+            }
+        }
+        function oswisSubmitFilter(input) {
+            var form = input.form;
+            oswisStripEmptyFilter(form);
+            form.submit();
+        }
+    </script>
+    <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="mb-2"
+          onsubmit="oswisStripEmptyFilter(this);">
         {% for key, value in scopeParams %}
             {% if key != 'depth' %}
                 {% if value is iterable %}
@@ -83,7 +104,7 @@
         <div class="btn-group btn-group-sm flex-wrap" role="group">
             {% for tab in filterTabs %}
                 <input type="radio" class="btn-check" name="filter" id="flt-{{ tab.key }}" value="{{ tab.key }}"
-                       autocomplete="off" onchange="this.form.submit()" {{ tab.active ? 'checked' : '' }}>
+                       autocomplete="off" onchange="oswisSubmitFilter(this)" {{ tab.active ? 'checked' : '' }}>
                 <label class="btn btn-outline-primary" for="flt-{{ tab.key }}"
                        title="{{ tab.group }}">{{ tab.label }}</label>
             {% endfor %}
@@ -96,12 +117,14 @@
                 {% if flagFacets|default %}
                     <div class="mb-2">
                         <div class="small fw-bold">Příznaky <span class="text-secondary fw-normal">(NEBO uvnitř kategorie, A napříč)</span></div>
-                        <div class="row">
+                        {# CSS multicolumn: categories pack tightly top-to-bottom then wrap to the next
+                           column, filling space instead of leaving row-height gaps like a grid. #}
+                        <div style="column-width: 12rem; column-gap: 1rem;">
                             {% for facet in flagFacets %}
-                                <div class="col-md-3 col-sm-6">
+                                <div style="break-inside: avoid; -webkit-column-break-inside: avoid; display: inline-block; width: 100%; margin-bottom: .4rem;">
                                     <div class="small text-secondary">{{ facet.categoryName }}</div>
                                     {% for flag in facet.flags %}
-                                        <label class="d-block small" style="font-weight:normal;">
+                                        <label class="d-block small" style="font-weight:normal; line-height: 1.3;">
                                             <input type="checkbox" name="flags[]" value="{{ flag.slug }}" {{ flag.selected ? 'checked' : '' }}> {{ flag.label }}
                                         </label>
                                     {% endfor %}

--- a/Resources/views/other/participant-list/parts/participant-list-head.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-head.html.twig
@@ -1,20 +1,19 @@
 <thead>
 <tr>
-    <th style="max-width: 25%;">
+    <th style="width: 20%;">
         ID
         <span class="block small">Vytvořeno</span>
     </th>
-    <th>
+    <th style="width: 38%;">
         Účastník, Událost
         <span class="block small">Poznámky</span>
     </th>
-    <th style="max-width:25%;">
+    <th style="width: 22%;">
         Příznaky
     </th>
-    <th style="max-width:25%;">
+    <th style="width: 20%;">
         Zaplaceno
         <span class="block small">Cena</span>
     </th>
 </tr>
 </thead>
-

--- a/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
@@ -44,6 +44,24 @@
         <div class="block small">
             ✉ <a href="mailto:{{ contact.email|default }}" target="_blank">{{ contact.email|default }}</a>
         </div>
+        {# Quick actions: detail / compose mail / soft-delete (restore lives above, shown when deleted). #}
+        <div class="block small mt-1" style="white-space: nowrap;">
+            <a class="btn btn-sm btn-outline-primary" style="padding:1px 8px; font-size:.75rem;"
+               href="{{ path('oswis_org_oswis_calendar_web_admin_participant_detail', { participantId: participant.id }) }}">Detail</a>
+            {% if is_granted('ROLE_ADMIN') %}
+                <a class="btn btn-sm btn-outline-secondary" style="padding:1px 8px; font-size:.75rem;"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_participant_compose_mail', { participantId: participant.id }) }}">✉ Mail</a>
+                {% if not participant.deletedAt|default %}
+                    <form method="post" style="display:inline-block;"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_participant_delete', { participantId: participant.id }) }}"
+                          onsubmit="return confirm('Opravdu smazat účastníka #{{ participant.id }}? (lze obnovit)');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('participant_delete_' ~ participant.id) }}">
+                        <input type="hidden" name="return" value="{{ app.request.requestUri }}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger" style="padding:1px 8px; font-size:.75rem;">🗑 Smazat</button>
+                    </form>
+                {% endif %}
+            {% endif %}
+        </div>
     </td>
     <td style="border: 1px solid grey; padding: .3em .6em;">
         <ul>

--- a/Resources/views/other/payments-list/parts/payments-list-inner.html.twig
+++ b/Resources/views/other/payments-list/parts/payments-list-inner.html.twig
@@ -23,7 +23,10 @@
     <td style="background-color: {{ assignedBackgroundColor }};">
         <strong style="color: {{ assignedColor }};">
             {% if payment.participant.id|default %}
-                {{ payment.participant.id|default(0) }} | {{ payment.participant.name|default('<nepojmenovaný>') }}
+                {# cachedContact = denormalised contact FK (EAGER-fetched in the list query);
+                   participant.name would call getContact() → load the participantContacts
+                   collection per row (was 391 N+1 queries on this overview). #}
+                {{ payment.participant.id|default(0) }} | {{ payment.participant.cachedContact.name|default('<nepojmenovaný>') }}
             {% else %}
                 ⚠️ NEPŘIŘAZENO ⚠️
             {% endif %}

--- a/Resources/views/web_admin/event-details-table.html.twig
+++ b/Resources/views/web_admin/event-details-table.html.twig
@@ -131,7 +131,7 @@
             <div class="block small">Událost nejvyššího řádu?</div>
         </td>
         <td>
-            {{ isDefaultEvent ? 'ANO' : 'NE' }}
+            {{ (defaultEvent is defined and defaultEvent and defaultEvent.id == event.id) ? 'ANO' : 'NE' }}
             <div class="block small">{{ event.root|default ? 'ANO' : 'NE' }}</div>
         </td>
     </tr>

--- a/Service/Participant/ParticipantFilterEvaluator.php
+++ b/Service/Participant/ParticipantFilterEvaluator.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Service\Participant;
+
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlag;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantNote;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Evaluates a sandboxed boolean filter expression against a single {@see Participant}.
+ *
+ * The unified participant list lets admins combine arbitrary AND/OR/NOT predicates
+ * (e.g. `hasFlag('panske-m') or hasFlag('damske-m')`,
+ * `hasFlag('hotel-a') and not isPaid()`). Symfony ExpressionLanguage gives us a safe
+ * sandbox: only the whitelisted functions registered here plus the supplied variables
+ * are reachable — no arbitrary PHP. The whole feature is ROLE_ADMIN-only on top of that.
+ *
+ * Faceted flag checkboxes in the UI compile down to one of these expressions, so there
+ * is a single evaluation path for both the simple and the advanced filter modes.
+ *
+ * Evaluation is per-participant in PHP over an already-loaded (scoped + primed)
+ * collection — flag predicates cannot reasonably be pushed to SQL.
+ */
+final class ParticipantFilterEvaluator
+{
+    /**
+     * Hard cap on expression length. The page is admin-only so abuse risk is low,
+     * but an unbounded expression is a needless DoS surface.
+     */
+    public const int MAX_EXPRESSION_LENGTH = 2000;
+
+    private ExpressionLanguage $expressionLanguage;
+
+    public function __construct()
+    {
+        $this->expressionLanguage = new ExpressionLanguage();
+        foreach ($this->buildFunctions() as $function) {
+            $this->expressionLanguage->addFunction($function);
+        }
+    }
+
+    /**
+     * Whether the participant matches the given filter expression.
+     *
+     * An empty/null expression matches everything. A syntactically invalid expression
+     * raises {@see BadRequestHttpException} (HTTP 400) rather than bubbling up as a 500.
+     *
+     * @throws BadRequestHttpException on syntax errors or over-long expressions
+     */
+    public function matches(Participant $participant, ?string $expression): bool
+    {
+        $expression = null === $expression ? '' : trim($expression);
+        if ('' === $expression) {
+            return true;
+        }
+        if (mb_strlen($expression) > self::MAX_EXPRESSION_LENGTH) {
+            throw new BadRequestHttpException(
+                sprintf('Filtrační výraz je příliš dlouhý (max %d znaků).', self::MAX_EXPRESSION_LENGTH),
+            );
+        }
+        try {
+            return (bool) $this->expressionLanguage->evaluate($expression, ['p' => $participant]);
+        } catch (SyntaxError $syntaxError) {
+            throw new BadRequestHttpException(
+                sprintf('Neplatný filtrační výraz: %s', $syntaxError->getMessage()),
+                $syntaxError,
+            );
+        }
+    }
+
+    /**
+     * Validate an expression without evaluating it (used by the UI before applying).
+     *
+     * @return string|null null when valid, otherwise a human-readable error message
+     */
+    public function validate(?string $expression): ?string
+    {
+        $expression = null === $expression ? '' : trim($expression);
+        if ('' === $expression) {
+            return null;
+        }
+        if (mb_strlen($expression) > self::MAX_EXPRESSION_LENGTH) {
+            return sprintf('Filtrační výraz je příliš dlouhý (max %d znaků).', self::MAX_EXPRESSION_LENGTH);
+        }
+        try {
+            $this->expressionLanguage->parse($expression, ['p']);
+
+            return null;
+        } catch (SyntaxError $syntaxError) {
+            return $syntaxError->getMessage();
+        }
+    }
+
+    /**
+     * Names of the whitelisted functions, for the advanced-filter autocomplete in the UI.
+     *
+     * @return list<string>
+     */
+    public function getFunctionNames(): array
+    {
+        return [
+            'hasFlag', 'hasFlagInCategory', 'flagCount',
+            'isPaid', 'isOverpaid', 'remainingPrice', 'remainingDeposit',
+            'isDeleted', 'isActivated', 'hasNote', 'hasRegistration',
+            'gender', 'eventSlug',
+        ];
+    }
+
+    /**
+     * @return list<ExpressionFunction>
+     */
+    private function buildFunctions(): array
+    {
+        return [
+            $this->fn('hasFlag', static fn (Participant $p, string $slug): bool => self::activeFlagSlugs($p)[$slug] ?? false),
+            $this->fn('hasFlagInCategory', static fn (Participant $p, string $catSlug): bool => self::flagCountInCategory($p, $catSlug) > 0),
+            $this->fn('flagCount', static fn (Participant $p, string $catSlug): int => self::flagCountInCategory($p, $catSlug)),
+            $this->fn('isPaid', static fn (Participant $p): bool => $p->getRemainingPrice() <= 0),
+            $this->fn('isOverpaid', static fn (Participant $p): bool => $p->getRemainingPrice() < 0),
+            $this->fn('remainingPrice', static fn (Participant $p): int => $p->getRemainingPrice()),
+            $this->fn('remainingDeposit', static fn (Participant $p): int => $p->getRemainingDeposit()),
+            $this->fn('isDeleted', static fn (Participant $p): bool => $p->isDeleted()),
+            $this->fn('isActivated', static fn (Participant $p): bool => $p->hasActivatedContactUser()),
+            $this->fn('hasNote', static fn (Participant $p): bool => self::hasNote($p)),
+            $this->fn('hasRegistration', static fn (Participant $p): bool => null !== $p->getParticipantRegistration()),
+            $this->fn('gender', static fn (Participant $p): string => $p->getContact()?->getGender() ?? ''),
+            $this->fn('eventSlug', static fn (Participant $p): string => $p->getEvent()?->getSlug() ?? ''),
+        ];
+    }
+
+    /**
+     * Register a function whose evaluator receives the bound Participant ($values['p'])
+     * as its first argument followed by the expression-supplied arguments.
+     *
+     * @param callable $callable receives (Participant, ...$args) and returns bool|int|string
+     */
+    private function fn(string $name, callable $callable): ExpressionFunction
+    {
+        return new ExpressionFunction(
+            $name,
+            // Compiler: never used (evaluate-only) but ExpressionFunction requires it.
+            static fn (string ...$args): string => sprintf('%s(%s)', $name, implode(', ', $args)),
+            /**
+             * @param array{p: Participant} $values
+             */
+            static fn (array $values, mixed ...$args): mixed => $callable($values['p'], ...$args),
+        );
+    }
+
+    /**
+     * Map of active flag slug => true for fast `hasFlag()` lookups.
+     *
+     * @return array<string, true>
+     */
+    private static function activeFlagSlugs(Participant $participant): array
+    {
+        $slugs = [];
+        /** @var ParticipantFlag $participantFlag */
+        foreach ($participant->getParticipantFlags(null, null, true) as $participantFlag) {
+            $slug = $participantFlag->getFlag()?->getSlug();
+            if (null !== $slug && '' !== $slug) {
+                $slugs[$slug] = true;
+            }
+        }
+
+        return $slugs;
+    }
+
+    private static function flagCountInCategory(Participant $participant, string $categorySlug): int
+    {
+        $count = 0;
+        /** @var ParticipantFlag $participantFlag */
+        foreach ($participant->getParticipantFlags(null, null, true) as $participantFlag) {
+            if ($participantFlag->getFlag()?->getCategory()?->getSlug() === $categorySlug) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+
+    private static function hasNote(Participant $participant): bool
+    {
+        /** @var ParticipantNote $note */
+        foreach ($participant->getNotes() as $note) {
+            if (!$note->isDeleted() && null !== ($text = $note->getTextValue()) && '' !== trim($text)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Service/Participant/ParticipantFilterEvaluator.php
+++ b/Service/Participant/ParticipantFilterEvaluator.php
@@ -105,7 +105,7 @@ final class ParticipantFilterEvaluator
     public function getFunctionNames(): array
     {
         return [
-            'hasFlag', 'hasFlagInCategory', 'flagCount',
+            'hasFlag', 'hasFlagInCategory', 'hasFlagOfType', 'flagCount',
             'isPaid', 'isOverpaid', 'remainingPrice', 'remainingDeposit',
             'isDeleted', 'isActivated', 'hasNote', 'hasRegistration',
             'gender', 'eventSlug',
@@ -120,6 +120,7 @@ final class ParticipantFilterEvaluator
         return [
             $this->fn('hasFlag', static fn (Participant $p, string $slug): bool => self::activeFlagSlugs($p)[$slug] ?? false),
             $this->fn('hasFlagInCategory', static fn (Participant $p, string $catSlug): bool => self::flagCountInCategory($p, $catSlug) > 0),
+            $this->fn('hasFlagOfType', static fn (Participant $p, string $type): bool => self::hasFlagOfType($p, $type)),
             $this->fn('flagCount', static fn (Participant $p, string $catSlug): int => self::flagCountInCategory($p, $catSlug)),
             $this->fn('isPaid', static fn (Participant $p): bool => $p->getRemainingPrice() <= 0),
             $this->fn('isOverpaid', static fn (Participant $p): bool => $p->getRemainingPrice() < 0),
@@ -183,6 +184,18 @@ final class ParticipantFilterEvaluator
         }
 
         return $count;
+    }
+
+    private static function hasFlagOfType(Participant $participant, string $type): bool
+    {
+        /** @var ParticipantFlag $participantFlag */
+        foreach ($participant->getParticipantFlags(null, null, true) as $participantFlag) {
+            if ($participantFlag->getFlag()?->getType() === $type) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static function hasNote(Participant $participant): bool

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -354,6 +354,23 @@ class ParticipantService
     }
 
     /**
+     * Soft-delete a participant (set deletedAt to now). Reversible via {@see restore()}.
+     *
+     * Child collections (flag groups, registrations) are left untouched — they keep their
+     * own deletedAt state, mirroring the asymmetric restore() behaviour.
+     */
+    public function delete(Participant $participant): void
+    {
+        if ($participant->isDeleted()) {
+            return;
+        }
+        $participant->delete();
+        $this->em->persist($participant);
+        $this->em->flush();
+        $this->logger->info("Participant ({$participant->getId()}) soft-deleted.");
+    }
+
+    /**
      * @param Participant|null $participant
      * @param ParticipantToken $participantToken
      * @param bool $sendConfirmation

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "oswis-org/oswis-address-book-bundle": "^0.1.0 || ^0.1.1",
     "oswis-org/oswis-core-bundle": "^0.1.0 || ^0.2",
     "rikudou/czqrpayment": "^v5.0",
+    "symfony/expression-language": "^8.1",
     "symfony/html-sanitizer": "^8.1",
     "webklex/php-imap": "~6.2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "c7f1c6a31a0eacc188c118f823f8b6b0",
+  "content-hash": "7ca9ce6204152d78f2ab7b5db026492b",
   "packages": [
     {
       "name": "adci/full-name-parser",


### PR DESCRIPTION
Unifies 5+ near-identical participant-list pages into one registry-driven controller + one query-driven page, plus two fixes and perf found while verifying.

**Unified list** (`/web_admin/seznam-prihlasek`)
- Scope (event / sub-event / category / all-events opt-in), default = current default event
- `ParticipantFilterEvaluator` (ExpressionLanguage sandbox): hasFlag/hasFlagInCategory/hasFlagOfType/flagCount/isPaid/isOverpaid/remainingPrice/remainingDeposit/isDeleted/isActivated/hasNote/hasRegistration/gender/eventSlug
- Filter pills + flag facets (OR-within / AND-across) + arbitrary `?expr=` + sort + smart sub-event depth (`isYear()?1:0`, `?depth=` override); all state in the query string (shareable)
- Soft-delete / restore row actions; old routes → 301 redirects; CSV export
- Compact, progressive-disclosure UI; scope-bar labels; clean URLs (empty expr/depth stripped before submit)

**Fixes**
- `srovnani-rocniku` 500: shared `event-details-table` partial referenced an undefined `isDefaultEvent` in a loop → now derives default-ness per event from a passed `defaultEvent`.
- **perf(payments)**: overview ran ~400 queries → **9** (profiler). Row template used `participant.name` (walks the lazy participantContacts collection per row) → switched to the EAGER-loaded `participant.cachedContact`; plus join-fetched the EAGER to-one assocs in `findFiltered()`. EAGER kept intentional.

Verification: PHPStan level max **0 errors**; twig+yaml lint OK; functional suite 3 tests / 38 assertions / 0 failures; browser click-through (admin + public web + registration + edit forms); payments profiler 400→9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)