### PR TITLE
release: v0.2.24 — bulk mail subsystem (Ink.1+2a+2b) + check-in fix

### DIFF
--- a/Command/SendMailCommand.php
+++ b/Command/SendMailCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Command;
+
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Drains the e-mail outbox — intended to be run periodically by cron (ISPConfig). Sends real mail,
+ * so it is SAFE BY DEFAULT:
+ *   - drains only the explicit ad-hoc bulk outbox ({@see ParticipantMailBulk}), which an admin
+ *     deliberately composed + queued;
+ *   - the auto-mail engine (infomail / feedback groups) runs ONLY with --automails, AND only for
+ *     groups whose automaticMailing flag + date window are set — a deliberate double gate so old
+ *     campaigns can't blast (see the 2026-06-08 disable of 19 stale groups);
+ *   - --dry-run reports what WOULD be sent without sending anything.
+ *
+ * Single-instance via a native flock (no symfony/lock dependency); overlapping cron ticks no-op.
+ */
+#[AsCommand(
+    name: 'oswis:mail:send',
+    description: 'Drain the bulk e-mail outbox (cron). Safe-by-default: bulks only; --automails to also run auto-mail groups.',
+)]
+final class SendMailCommand extends Command
+{
+    private const string LOCK_FILE = 'oswis-mail-send.lock';
+
+    public function __construct(
+        private readonly ParticipantBulkMailService $bulkMailService,
+        private readonly ParticipantMailBulkRepository $bulkRepository,
+        private readonly ParticipantService $participantService,
+    ) {
+        parent::__construct();
+    }
+
+    private function intOption(InputInterface $input, string $name, int $default): int
+    {
+        $value = $input->getOption($name);
+
+        return is_numeric($value) ? (int) $value : $default;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('batch', null, InputOption::VALUE_REQUIRED, 'Recipients per drain batch.', '15')
+            ->addOption('max-recipients', null, InputOption::VALUE_REQUIRED, 'Cap total bulk recipients processed this run (0 = drain all pending).', '0')
+            ->addOption('automails', null, InputOption::VALUE_NONE, 'ALSO run the auto-mail engine (off by default — sends real automatic mails).')
+            ->addOption('automail-limit', null, InputOption::VALUE_REQUIRED, 'Max participants per auto-mail group when --automails.', '100')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would be sent without sending.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $batch = max(1, $this->intOption($input, 'batch', 15));
+        $maxRecipients = max(0, $this->intOption($input, 'max-recipients', 0));
+        $withAutomails = (bool) $input->getOption('automails');
+        $automailLimit = max(1, $this->intOption($input, 'automail-limit', 100));
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        // Single-instance guard (native flock, no daemon/dependency).
+        $lockPath = sys_get_temp_dir().'/'.self::LOCK_FILE;
+        $lockHandle = fopen($lockPath, 'c');
+        if (false === $lockHandle || !flock($lockHandle, LOCK_EX | LOCK_NB)) {
+            $io->note('Another oswis:mail:send run holds the lock — skipping this tick.');
+            if (false !== $lockHandle) {
+                fclose($lockHandle);
+            }
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            $pending = $this->bulkRepository->findPending(100);
+
+            if ($dryRun) {
+                $io->section('DRY-RUN (nic se neodešle)');
+                $totalRemaining = 0;
+                foreach ($pending as $bulk) {
+                    $remaining = $bulk->getRemainingCount();
+                    $totalRemaining += $remaining;
+                    $io->writeln(sprintf(
+                        '  bulk #%d "%s" — %d/%d zpracováno, zbývá %d, status %s',
+                        $bulk->getId() ?? 0,
+                        $bulk->getSubject(),
+                        $bulk->getProcessedCount(),
+                        $bulk->getTotalCount(),
+                        $remaining,
+                        $bulk->getStatus(),
+                    ));
+                }
+                $io->writeln(sprintf('Pending bulků: %d, příjemců zbývá celkem: %d', count($pending), $totalRemaining));
+                $io->writeln($withAutomails ? 'Automaily: ZAPNUTO (běh by zpracoval aktivní automail skupiny).' : 'Automaily: vypnuto (--automails pro zapnutí).');
+
+                return Command::SUCCESS;
+            }
+
+            $bulksTouched = 0;
+            $totalSent = 0;
+            $totalFailed = 0;
+            $processedThisRun = 0;
+
+            foreach ($pending as $bulk) {
+                if (0 !== $maxRecipients && $processedThisRun >= $maxRecipients) {
+                    break;
+                }
+                $bulksTouched++;
+                while (!$bulk->isDone()) {
+                    if (0 !== $maxRecipients && $processedThisRun >= $maxRecipients) {
+                        break;
+                    }
+                    $progress = $this->bulkMailService->drainBatch($bulk, $batch);
+                    $totalSent += $progress['sent'];
+                    $totalFailed += $progress['failed'];
+                    $processedThisRun += $progress['sent'] + $progress['failed'];
+                    if (0 === $progress['sent'] + $progress['failed']) {
+                        break; // nothing advanced (empty slice) — avoid spin
+                    }
+                }
+            }
+
+            if ($bulksTouched > 0) {
+                $io->success(sprintf('Bulk outbox: %d dávek, odesláno %d, selhalo %d.', $bulksTouched, $totalSent, $totalFailed));
+            } else {
+                $io->writeln('Bulk outbox: nic ke zpracování.');
+            }
+
+            if ($withAutomails) {
+                $summary = $this->participantService->sendAutoMails(null, null, $automailLimit);
+                $io->success(sprintf(
+                    'Automaily: odesláno %d, selhalo %d.%s',
+                    $summary['sent'],
+                    $summary['failed'],
+                    [] === $summary['errors'] ? '' : ' Chyby: '.implode(' | ', array_slice($summary['errors'], 0, 10)),
+                ));
+            }
+
+            return Command::SUCCESS;
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
+    }
+}

--- a/Controller/Api/ParticipantExportController.php
+++ b/Controller/Api/ParticipantExportController.php
@@ -14,6 +14,7 @@ use OswisOrg\OswisCoreBundle\Enum\ExportFormat;
 use OswisOrg\OswisCoreBundle\Export\ExportManager;
 use OswisOrg\OswisCoreBundle\Export\ExportRequest;
 use OswisOrg\OswisCoreBundle\Export\ExportResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -67,12 +68,28 @@ final class ParticipantExportController
             ? $this->participantCategoryService->getParticipantTypeBySlug($categorySlug)
             : null;
 
+        // Load at most MAX_EXPORT_ROWS+1 (true SQL LIMIT → memory never blows up on a huge scope).
+        // The +1 is the overflow sentinel: if it comes back, the real set is over the cap.
+        $loadLimit = ParticipantExportDefinition::MAX_EXPORT_ROWS + 1;
         $participants = $this->participantService->getParticipants([
             ParticipantRepository::CRITERIA_INCLUDE_DELETED => $request->query->getBoolean('includeDeleted'),
             ParticipantRepository::CRITERIA_EVENT => $event,
             ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY => $category,
             ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 2,
-        ]);
+        ], true, $loadLimit);
+
+        // Over the cap → refuse with a clear 413 (never silently truncate). Tell the client to
+        // narrow the scope (an event/category) and retry.
+        if ($participants->count() > ParticipantExportDefinition::MAX_EXPORT_ROWS) {
+            return new JsonResponse([
+                'error'   => 'export_too_large',
+                'message' => sprintf(
+                    'Export je omezen na %d záznamů a tento výběr je překračuje. Zužte rozsah (vyberte akci nebo kategorii) a export opakujte.',
+                    ParticipantExportDefinition::MAX_EXPORT_ROWS,
+                ),
+                'limit'   => ParticipantExportDefinition::MAX_EXPORT_ROWS,
+            ], Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
+        }
 
         $columnKeys = array_values(array_filter($request->query->all('columns'), 'is_string'));
         $exportRequest = new ExportRequest(

--- a/Controller/WebAdmin/WebAdminBulkMailController.php
+++ b/Controller/WebAdmin/WebAdminBulkMailController.php
@@ -8,6 +8,7 @@ use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
@@ -35,6 +36,7 @@ final class WebAdminBulkMailController extends AbstractController
         private readonly ParticipantBulkMailService $bulkMailService,
         private readonly ParticipantRepository $participantRepository,
         private readonly ParticipantMailBulkRepository $bulkRepository,
+        private readonly MailPreviewService $mailPreview,
     ) {
     }
 
@@ -83,12 +85,14 @@ final class WebAdminBulkMailController extends AbstractController
         }
         [$subject, $body] = $this->readMessage($request);
 
-        $html = $this->renderView(
+        $result = $this->mailPreview->renderTemplate(
             ParticipantBulkMailService::AD_HOC_TEMPLATE,
-            $this->bulkMailService->previewContext($participant, $subject, $body, $this->adminName()),
+            $participant,
+            ['bodyHtml' => $body, 'adminName' => $this->adminName(), 'type' => 'ad-hoc-bulk-preview'],
+            $subject,
         );
 
-        return new Response($html);
+        return new Response($result['html']);
     }
 
     /** Step 2: queue the bulk (snapshot of recipients). Sends nothing; the drain does. */

--- a/Controller/WebAdmin/WebAdminBulkMailController.php
+++ b/Controller/WebAdmin/WebAdminBulkMailController.php
@@ -10,9 +10,8 @@ use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepos
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService;
+use OswisOrg\OswisCoreBundle\Exceptions\OswisException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -85,10 +84,23 @@ final class WebAdminBulkMailController extends AbstractController
         }
         [$subject, $body] = $this->readMessage($request);
 
+        // Body is trusted Twig (entity-API variables + conditional blocks) → render + sanitize first,
+        // then drop the result into the ad-hoc wrapper. A body Twig error shows inline, not a blank.
+        try {
+            $renderedBody = $this->mailPreview->renderBodyFragment($body, $participant);
+        } catch (\Throwable $exception) {
+            $renderedBody = sprintf(
+                '<div style="color:#842029;background:#f8d7da;border:1px solid #f5c2c7;padding:.75rem;'
+                .'border-radius:.375rem;font-family:monospace;white-space:pre-wrap;">'
+                .'<strong>Chyba v těle (Twig):</strong><br>%s</div>',
+                htmlspecialchars($exception->getMessage(), ENT_QUOTES),
+            );
+        }
+
         $result = $this->mailPreview->renderTemplate(
             ParticipantBulkMailService::AD_HOC_TEMPLATE,
             $participant,
-            ['bodyHtml' => $body, 'adminName' => $this->adminName(), 'type' => 'ad-hoc-bulk-preview'],
+            ['bodyHtml' => $renderedBody, 'adminName' => $this->adminName(), 'type' => 'ad-hoc-bulk-preview'],
             $subject,
         );
 
@@ -114,7 +126,15 @@ final class WebAdminBulkMailController extends AbstractController
             return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
         }
 
-        $bulk = $this->bulkMailService->queue($subject, $body, $ids, $this->adminName());
+        // Queue-validation: the service renders the body against the first recipient and rejects a
+        // bulk whose Twig won't compile — so a typo never reaches real recipients via the drain.
+        try {
+            $bulk = $this->bulkMailService->queue($subject, $body, $ids, $this->adminName());
+        } catch (OswisException $exception) {
+            $this->addFlash('danger', 'E-mail nelze zařadit – chyba v těle (Twig): '.$exception->getMessage());
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
+        }
         $this->addFlash('success', sprintf('Hromadný e-mail zařazen: %d příjemců. Spustí se odesílání.', count($ids)));
 
         return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_bulk_mail_status', ['highlight' => $bulk->getId()]);
@@ -171,21 +191,16 @@ final class WebAdminBulkMailController extends AbstractController
     }
 
     /**
-     * @return array{0: string, 1: string} sanitized [subject, bodyHtml]
+     * @return array{0: string, 1: string} [subject, raw body] — the body is stored verbatim as trusted
+     *                                      Twig; it is rendered and HTML-sanitized at send/preview time
+     *                                      (see {@see MailPreviewService::renderBodyFragment}), not here.
      */
     private function readMessage(Request $request): array
     {
-        $subject = trim((string) $request->request->get('subject', ''));
-        $rawBody = (string) $request->request->get('body', '');
-        $sanitizer = new HtmlSanitizer(
-            (new HtmlSanitizerConfig())
-                ->allowSafeElements()
-                ->allowLinkSchemes(['http', 'https', 'mailto', 'tel'])
-                ->allowRelativeLinks(false)
-                ->allowRelativeMedias(false),
-        );
-
-        return [$subject, $sanitizer->sanitize($rawBody)];
+        return [
+            trim((string) $request->request->get('subject', '')),
+            (string) $request->request->get('body', ''),
+        ];
     }
 
     private function adminName(): ?string

--- a/Controller/WebAdmin/WebAdminBulkMailController.php
+++ b/Controller/WebAdmin/WebAdminBulkMailController.php
@@ -88,21 +88,25 @@ final class WebAdminBulkMailController extends AbstractController
             'ids'            => $ids,
             'idsCsv'         => implode(',', $ids),
             'recipientCount' => count($ids),
+            'recipients'     => $this->participantRepository->findByIds($ids),
             'campaigns'      => $templates['campaigns'],
             'snippets'       => $templates['snippets'],
             'variableCatalog' => MailPreviewService::variableCatalog(),
         ]);
     }
 
-    /** Live preview: render the ad-hoc template (through MJML) for the first recipient. No send. */
+    /** Live preview through MJML for a chosen recipient (default: the first). No send. */
     public function preview(Request $request): Response
     {
         if (!$this->isCsrfTokenValid('bulk_mail_preview', (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
         $ids = $this->readIds($request);
-        $first = $ids[0] ?? null;
-        $participant = null !== $first ? $this->participantRepository->find($first) : null;
+        // Preview for a specific recipient if asked (and it really is in the snapshot), else the first.
+        $chosenRaw = (string) $request->request->get('previewParticipantId', '');
+        $chosen = ctype_digit($chosenRaw) ? (int) $chosenRaw : 0;
+        $previewId = ($chosen > 0 && in_array($chosen, $ids, true)) ? $chosen : ($ids[0] ?? null);
+        $participant = null !== $previewId ? $this->participantRepository->find($previewId) : null;
         if (!$participant instanceof Participant) {
             return new Response('<p style="font-family:sans-serif;color:#666">Náhled nelze vytvořit – příjemce nenalezen.</p>');
         }

--- a/Controller/WebAdmin/WebAdminBulkMailController.php
+++ b/Controller/WebAdmin/WebAdminBulkMailController.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
+
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Ad-hoc bulk e-mail to selected participants (Fáze G, Inkrement 2a). Recipients come from the
+ * participant list selection (checkboxes / select-all over a scoped + flag-faceted view — so
+ * "send to faculty / accommodation X" = filter the list by that flag, select all, compose here).
+ * Real mail → cap + preview + confirmation + durable outbox drained in batches (JS auto-drain now,
+ * cron later). {@see ParticipantBulkMailService}.
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class WebAdminBulkMailController extends AbstractController
+{
+    /** Hard ceiling on recipients per bulk (real mail; mirrors the export cap rationale). */
+    private const int MAX_RECIPIENTS = 1000;
+
+    public function __construct(
+        private readonly ParticipantBulkMailService $bulkMailService,
+        private readonly ParticipantRepository $participantRepository,
+        private readonly ParticipantMailBulkRepository $bulkRepository,
+    ) {
+    }
+
+    /** Step 1: open the compose form for the selected recipients (POSTed from the list bulk bar). */
+    public function compose(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bulk_mail', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $ids = $this->readIds($request);
+        if ([] === $ids) {
+            $this->addFlash('warning', 'Nebyli vybráni žádní příjemci.');
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
+        }
+        if (count($ids) > self::MAX_RECIPIENTS) {
+            $this->addFlash('danger', sprintf(
+                'Hromadný e-mail je omezen na %d příjemců, vybráno %d. Zužte výběr.',
+                self::MAX_RECIPIENTS,
+                count($ids),
+            ));
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/bulk_mail/compose.html.twig', [
+            'title'        => 'Hromadný e-mail :: ADMIN',
+            'pageTitle'    => 'Hromadný e-mail',
+            'ids'          => $ids,
+            'idsCsv'       => implode(',', $ids),
+            'recipientCount' => count($ids),
+        ]);
+    }
+
+    /** Live preview: render the ad-hoc template (through MJML) for the first recipient. No send. */
+    public function preview(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bulk_mail_preview', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $ids = $this->readIds($request);
+        $first = $ids[0] ?? null;
+        $participant = null !== $first ? $this->participantRepository->find($first) : null;
+        if (!$participant instanceof Participant) {
+            return new Response('<p style="font-family:sans-serif;color:#666">Náhled nelze vytvořit – příjemce nenalezen.</p>');
+        }
+        [$subject, $body] = $this->readMessage($request);
+
+        $html = $this->renderView(
+            ParticipantBulkMailService::AD_HOC_TEMPLATE,
+            $this->bulkMailService->previewContext($participant, $subject, $body, $this->adminName()),
+        );
+
+        return new Response($html);
+    }
+
+    /** Step 2: queue the bulk (snapshot of recipients). Sends nothing; the drain does. */
+    public function queue(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bulk_mail', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $ids = $this->readIds($request);
+        [$subject, $body] = $this->readMessage($request);
+        if ([] === $ids || '' === trim($subject) || '' === trim($body)) {
+            $this->addFlash('warning', 'Vyplňte předmět i text a vyberte příjemce.');
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
+        }
+        if (count($ids) > self::MAX_RECIPIENTS) {
+            $this->addFlash('danger', sprintf('Příliš mnoho příjemců (max %d).', self::MAX_RECIPIENTS));
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
+        }
+
+        $bulk = $this->bulkMailService->queue($subject, $body, $ids, $this->adminName());
+        $this->addFlash('success', sprintf('Hromadný e-mail zařazen: %d příjemců. Spustí se odesílání.', count($ids)));
+
+        return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_bulk_mail_status', ['highlight' => $bulk->getId()]);
+    }
+
+    /** Status page: list bulks + progress; JS on the page auto-drains pending ones in batches. */
+    public function status(Request $request): Response
+    {
+        return $this->render('@OswisOrgOswisCalendar/web_admin/bulk_mail/status.html.twig', [
+            'title'     => 'Hromadné e-maily :: ADMIN',
+            'pageTitle' => 'Hromadné e-maily',
+            'bulks'     => $this->bulkRepository->findRecent(30),
+            'highlight' => $request->query->getInt('highlight'),
+        ]);
+    }
+
+    /** Drain one batch of a bulk (POST, CSRF) → JSON progress. Used by the status-page auto-drain. */
+    public function drain(Request $request): JsonResponse
+    {
+        if (!$this->isCsrfTokenValid('bulk_mail_drain', (string) $request->request->get('_token'))) {
+            return new JsonResponse(['error' => 'csrf'], Response::HTTP_FORBIDDEN);
+        }
+        $bulkId = $request->request->getInt('bulkId');
+        $bulk = $bulkId > 0 ? $this->bulkRepository->find($bulkId) : null;
+        if (!$bulk instanceof ParticipantMailBulk) {
+            return new JsonResponse(['error' => 'not-found'], Response::HTTP_NOT_FOUND);
+        }
+        $progress = $this->bulkMailService->drainBatch($bulk, 15);
+
+        return new JsonResponse(['bulkId' => $bulkId] + $progress);
+    }
+
+    /**
+     * Parse recipient participant IDs from the request (ids[] or comma-joined idsCsv), positive
+     * unique ints only.
+     *
+     * @return list<int>
+     */
+    private function readIds(Request $request): array
+    {
+        $raw = $request->request->all('ids');
+        if ([] === $raw) {
+            $csv = (string) $request->request->get('idsCsv', '');
+            $raw = '' === $csv ? [] : explode(',', $csv);
+        }
+        $ids = [];
+        foreach ($raw as $value) {
+            if (is_numeric($value) && (int) $value > 0) {
+                $ids[(int) $value] = true; // dedup (int keys)
+            }
+        }
+
+        return array_keys($ids);
+    }
+
+    /**
+     * @return array{0: string, 1: string} sanitized [subject, bodyHtml]
+     */
+    private function readMessage(Request $request): array
+    {
+        $subject = trim((string) $request->request->get('subject', ''));
+        $rawBody = (string) $request->request->get('body', '');
+        $sanitizer = new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowLinkSchemes(['http', 'https', 'mailto', 'tel'])
+                ->allowRelativeLinks(false)
+                ->allowRelativeMedias(false),
+        );
+
+        return [$subject, $sanitizer->sanitize($rawBody)];
+    }
+
+    private function adminName(): ?string
+    {
+        $user = $this->getUser();
+
+        return $user instanceof UserInterface ? $user->getUserIdentifier() : null;
+    }
+}

--- a/Controller/WebAdmin/WebAdminBulkMailController.php
+++ b/Controller/WebAdmin/WebAdminBulkMailController.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
+use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService;
+use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use OswisOrg\OswisCoreBundle\Exceptions\OswisException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -36,7 +38,24 @@ final class WebAdminBulkMailController extends AbstractController
         private readonly ParticipantRepository $participantRepository,
         private readonly ParticipantMailBulkRepository $bulkRepository,
         private readonly MailPreviewService $mailPreview,
+        private readonly EntityManagerInterface $em,
     ) {
+    }
+
+    /**
+     * Stored campaign/snippet templates offered in the composer — campaigns for the "send a whole
+     * stored mail" mode, snippets for click-to-insert {% include %} into the free body.
+     *
+     * @return array<string, list<TwigTemplate>>
+     */
+    private function offerableTemplates(): array
+    {
+        $repo = $this->em->getRepository(TwigTemplate::class);
+
+        return [
+            'campaigns' => $repo->findBy(['kind' => TwigTemplate::KIND_CAMPAIGN], ['name' => 'ASC']),
+            'snippets'  => $repo->findBy(['kind' => TwigTemplate::KIND_SNIPPET], ['name' => 'ASC']),
+        ];
     }
 
     /** Step 1: open the compose form for the selected recipients (POSTed from the list bulk bar). */
@@ -61,12 +80,17 @@ final class WebAdminBulkMailController extends AbstractController
             return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
         }
 
+        $templates = $this->offerableTemplates();
+
         return $this->render('@OswisOrgOswisCalendar/web_admin/bulk_mail/compose.html.twig', [
-            'title'        => 'Hromadný e-mail :: ADMIN',
-            'pageTitle'    => 'Hromadný e-mail',
-            'ids'          => $ids,
-            'idsCsv'       => implode(',', $ids),
+            'title'          => 'Hromadný e-mail :: ADMIN',
+            'pageTitle'      => 'Hromadný e-mail',
+            'ids'            => $ids,
+            'idsCsv'         => implode(',', $ids),
             'recipientCount' => count($ids),
+            'campaigns'      => $templates['campaigns'],
+            'snippets'       => $templates['snippets'],
+            'variableCatalog' => MailPreviewService::variableCatalog(),
         ]);
     }
 
@@ -83,9 +107,17 @@ final class WebAdminBulkMailController extends AbstractController
             return new Response('<p style="font-family:sans-serif;color:#666">Náhled nelze vytvořit – příjemce nenalezen.</p>');
         }
         [$subject, $body] = $this->readMessage($request);
+        $templateSlug = trim((string) $request->request->get('templateSlug', ''));
 
-        // Body is trusted Twig (entity-API variables + conditional blocks) → render + sanitize first,
-        // then drop the result into the ad-hoc wrapper. A body Twig error shows inline, not a blank.
+        // "Stored template" mode → render the whole campaign/snippet (DatabaseLoader resolves a slug).
+        if ('' !== $templateSlug) {
+            $result = $this->mailPreview->renderTemplate($templateSlug, $participant, [], $subject);
+
+            return new Response($result['html']);
+        }
+
+        // Free-body mode: body is trusted Twig (entity-API variables + conditional blocks) → render +
+        // sanitize first, then drop into the ad-hoc wrapper. A body Twig error shows inline, not blank.
         try {
             $renderedBody = $this->mailPreview->renderBodyFragment($body, $participant);
         } catch (\Throwable $exception) {
@@ -115,8 +147,10 @@ final class WebAdminBulkMailController extends AbstractController
         }
         $ids = $this->readIds($request);
         [$subject, $body] = $this->readMessage($request);
-        if ([] === $ids || '' === trim($subject) || '' === trim($body)) {
-            $this->addFlash('warning', 'Vyplňte předmět i text a vyberte příjemce.');
+        $templateSlug = trim((string) $request->request->get('templateSlug', ''));
+        // A bulk needs a subject + recipients + either a free body OR a stored template.
+        if ([] === $ids || '' === trim($subject) || ('' === trim($body) && '' === $templateSlug)) {
+            $this->addFlash('warning', 'Vyplňte předmět, vyberte příjemce a zadejte text nebo uloženou šablonu.');
 
             return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
         }
@@ -126,10 +160,10 @@ final class WebAdminBulkMailController extends AbstractController
             return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list');
         }
 
-        // Queue-validation: the service renders the body against the first recipient and rejects a
+        // Queue-validation: the service renders the message against the first recipient and rejects a
         // bulk whose Twig won't compile — so a typo never reaches real recipients via the drain.
         try {
-            $bulk = $this->bulkMailService->queue($subject, $body, $ids, $this->adminName());
+            $bulk = $this->bulkMailService->queue($subject, $body, $ids, $this->adminName(), '' !== $templateSlug ? $templateSlug : null);
         } catch (OswisException $exception) {
             $this->addFlash('danger', 'E-mail nelze zařadit – chyba v těle (Twig): '.$exception->getMessage());
 

--- a/Controller/WebAdmin/WebAdminBulkParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminBulkParticipantsController.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Export\ParticipantExportDefinition;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantService;
+use OswisOrg\OswisCoreBundle\Enum\ExportFormat;
+use OswisOrg\OswisCoreBundle\Export\ExportManager;
+use OswisOrg\OswisCoreBundle\Export\ExportRequest;
+use OswisOrg\OswisCoreBundle\Export\ExportResponseFactory;
+use OswisOrg\OswisCoreBundle\Utils\StringUtils;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Fáze G — hromadné akce nad přihláškami vybranými ve sjednoceném web-admin seznamu.
+ *
+ * Inkrement 1: BEZPEČNÉ operace bez side-effectu na reálné lidi (žádný e-mail):
+ *  - {@see delete()} hromadné soft-delete (vratné přes „Obnovit"),
+ *  - {@see export()} export vybraných (CSV/PDF přes sdílený ExportManager).
+ * Výběr přichází jako `ids[]` z JS bulk baru v seznamu.
+ *
+ * Bezpečnost: ROLE_ADMIN, CSRF per akce, cap (smazání 100 jako reassign wizard, export 1000),
+ * per-účastník flash log, návrat do původního filtrovaného seznamu (same-origin guard).
+ * Hromadný e-mail + composer jsou záměrně Inkrement 2 (vlastní pojistky).
+ */
+#[IsGranted('ROLE_ADMIN')]
+final class WebAdminBulkParticipantsController extends AbstractController
+{
+    private const int DELETE_CAP = 100;
+    private const int EXPORT_CAP = ParticipantExportDefinition::MAX_EXPORT_ROWS;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ParticipantService $participantService,
+        private readonly ExportManager $exportManager,
+        private readonly ExportResponseFactory $exportResponseFactory,
+        private readonly ParticipantExportDefinition $participantExportDefinition,
+    ) {
+    }
+
+    /**
+     * Hromadné soft-delete vybraných přihlášek (vratné přes „Obnovit").
+     */
+    public function delete(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bulk_delete', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $return = $this->safeReturn($request);
+        $ids = $this->readIds($request);
+        if ([] === $ids) {
+            $this->addFlash('warning', 'Nebyla vybrána žádná přihláška.');
+
+            return new RedirectResponse($return);
+        }
+        if (count($ids) > self::DELETE_CAP) {
+            $this->addFlash('error', sprintf(
+                'Najednou lze smazat nejvýše %d přihlášek (vybráno %d). Rozděl do menších dávek.',
+                self::DELETE_CAP,
+                count($ids),
+            ));
+
+            return new RedirectResponse($return);
+        }
+
+        $deleted = [];
+        $failed = [];
+        foreach ($ids as $id) {
+            $participant = $this->em->find(Participant::class, $id);
+            if (!$participant instanceof Participant) {
+                $failed[] = "#$id (nenalezen)";
+                continue;
+            }
+            if (null !== $participant->getDeletedAt()) {
+                continue; // už smazaný — tiše přeskočit
+            }
+            try {
+                $this->participantService->delete($participant);
+                $deleted[] = '#'.$id;
+            } catch (\Throwable $e) {
+                $failed[] = sprintf('#%d (%s)', $id, $e->getMessage());
+            }
+        }
+        if ([] !== $deleted) {
+            $this->addFlash('success', sprintf(
+                'Smazáno %d přihlášek (lze obnovit): %s',
+                count($deleted),
+                implode(', ', $deleted),
+            ));
+        }
+        if ([] !== $failed) {
+            $this->addFlash('warning', sprintf('Nesmazáno %d: %s', count($failed), implode(', ', $failed)));
+        }
+
+        return new RedirectResponse($return);
+    }
+
+    /**
+     * Export vybraných přihlášek (CSV/PDF) — sdílená ExportManager pipeline, jen filtr na vybraná ID.
+     */
+    public function export(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('bulk_export', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $ids = $this->readIds($request);
+        if ([] === $ids) {
+            $this->addFlash('warning', 'Nebyla vybrána žádná přihláška.');
+
+            return new RedirectResponse($this->safeReturn($request));
+        }
+        if (count($ids) > self::EXPORT_CAP) {
+            $this->addFlash('error', sprintf(
+                'Export je omezen na %d záznamů (vybráno %d). Zužte výběr.',
+                self::EXPORT_CAP,
+                count($ids),
+            ));
+
+            return new RedirectResponse($this->safeReturn($request));
+        }
+
+        $participants = $this->participantService->getRepository()->findBy(['id' => $ids]);
+        usort(
+            $participants,
+            static fn (Participant $a, Participant $b): int => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
+        );
+        $exportRequest = new ExportRequest(
+            ExportFormat::fromRequest($request->request->getString('format')),
+            null,
+            sprintf('Vybrané přihlášky (%d)', count($participants)),
+        );
+
+        return $this->exportResponseFactory->toResponse(
+            $this->exportManager->render(
+                $this->participantExportDefinition,
+                new ArrayCollection($participants),
+                $exportRequest,
+            ),
+        );
+    }
+
+    /**
+     * Vybraná ID z POST `ids[]` → deduplikovaný seznam kladných intů.
+     *
+     * @return list<int>
+     */
+    private function readIds(Request $request): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $v): int => is_numeric($v) ? (int) $v : 0,
+            $request->request->all('ids'),
+        ))));
+    }
+
+    /**
+     * Návratová URL z POST `return`; jen same-origin relativní cesta (žádný open-redirect).
+     */
+    private function safeReturn(Request $request): string
+    {
+        $return = $request->request->getString('return');
+        if ('' !== $return && str_starts_with($return, '/') && !str_starts_with($return, '//')) {
+            return $return;
+        }
+
+        return $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list');
+    }
+}

--- a/Controller/WebAdmin/WebAdminBulkReassignController.php
+++ b/Controller/WebAdmin/WebAdminBulkReassignController.php
@@ -59,14 +59,28 @@ final class WebAdminBulkReassignController extends AbstractController
         $categories = $this->categoryRepository->findAll();
         $offers = $this->em->getRepository(RegistrationOffer::class)->findBy([], ['createdAt' => 'DESC'], 100);
 
-        $participants = $sourceEvent
-            ? iterator_to_array($this->participantService->getParticipants([
+        // "Přesunout" ze sjednoceného seznamu pošle vybraná ID jako preselectIds[] (bez zdrojového
+        // rozsahu) → načteme přesně je a předzaškrtneme. Na re-render po neúspěšném execute použijeme
+        // odeslané participantIds[], ať se výběr neztratí.
+        $preselectIds = $this->intIds($request->request->all('preselectIds'));
+        $displayIds = $preselectIds;
+        if ([] === $displayIds && $request->isMethod('POST') && 'execute' === $request->request->get('_action')) {
+            $displayIds = $this->intIds($participantIds);
+        }
+        $preselectMode = [] !== $displayIds && null === $sourceEvent;
+        if ($preselectMode) {
+            $participants = $this->participantService->getRepository()->findBy(['id' => $displayIds]);
+        } elseif (null !== $sourceEvent) {
+            $participants = iterator_to_array($this->participantService->getParticipants([
                 ParticipantRepository::CRITERIA_EVENT                 => $sourceEvent,
                 ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY  => $sourceCategory,
                 ParticipantRepository::CRITERIA_INCLUDE_DELETED       => false,
                 ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 2,
-            ]), false)
-            : [];
+            ]), false);
+        } else {
+            $participants = [];
+        }
+        $preselectedIds = $preselectMode ? $displayIds : [];
 
         if ($request->isMethod('POST') && 'execute' === $request->request->get('_action')) {
             if (!$this->isCsrfTokenValid('bulk_reassign', (string) $token)) {
@@ -78,16 +92,13 @@ final class WebAdminBulkReassignController extends AbstractController
             if (!$targetOffer instanceof RegistrationOffer) {
                 $this->addFlash('error', 'Nebyla vybrána cílová přihláška.');
 
-                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory);
+                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory, $preselectMode, $preselectedIds);
             }
-            $ids = array_values(array_filter(array_map(
-                static fn (mixed $v): int => is_numeric($v) ? (int) $v : 0,
-                $participantIds,
-            )));
+            $ids = $this->intIds($participantIds);
             if (count($ids) === 0) {
                 $this->addFlash('error', 'Nebyl označen žádný účastník.');
 
-                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory);
+                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory, $preselectMode, $preselectedIds);
             }
             if (count($ids) > self::HARD_CAP) {
                 $this->addFlash('error', sprintf(
@@ -95,7 +106,7 @@ final class WebAdminBulkReassignController extends AbstractController
                     count($ids), self::HARD_CAP,
                 ));
 
-                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory);
+                return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory, $preselectMode, $preselectedIds);
             }
 
             $moved = [];
@@ -145,7 +156,7 @@ final class WebAdminBulkReassignController extends AbstractController
             ));
         }
 
-        return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory);
+        return $this->renderWizard($events, $categories, $offers, $participants, $sourceEvent, $sourceCategory, $preselectMode, $preselectedIds);
     }
 
     /**
@@ -153,6 +164,7 @@ final class WebAdminBulkReassignController extends AbstractController
      * @param list<\OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory> $categories
      * @param list<RegistrationOffer> $offers
      * @param list<Participant> $participants
+     * @param list<int> $preselectedIds
      */
     private function renderWizard(
         array $events,
@@ -161,6 +173,8 @@ final class WebAdminBulkReassignController extends AbstractController
         array $participants,
         ?\OswisOrg\OswisCalendarBundle\Entity\Event\Event $sourceEvent,
         ?\OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory $sourceCategory,
+        bool $preselectMode = false,
+        array $preselectedIds = [],
     ): Response {
         return $this->render('@OswisOrgOswisCalendar/web_admin/bulk_reassign.html.twig', [
             'events'          => $events,
@@ -169,9 +183,26 @@ final class WebAdminBulkReassignController extends AbstractController
             'participants'    => $participants,
             'sourceEvent'     => $sourceEvent,
             'sourceCategory'  => $sourceCategory,
+            'preselectMode'   => $preselectMode,
+            'preselectedIds'  => $preselectedIds,
             'hardCap'         => self::HARD_CAP,
             'pageTitle'       => 'Hromadný přesun přihlášek',
             'page_title'      => 'Hromadný přesun přihlášek :: ADMIN',
         ]);
+    }
+
+    /**
+     * POST id pole → deduplikovaný seznam kladných intů.
+     *
+     * @param array<mixed> $raw
+     *
+     * @return list<int>
+     */
+    private function intIds(array $raw): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $v): int => is_numeric($v) ? (int) $v : 0,
+            $raw,
+        ))));
     }
 }

--- a/Controller/WebAdmin/WebAdminMailConfigController.php
+++ b/Controller/WebAdmin/WebAdminMailConfigController.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailCategory;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailGroup;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ParticipantMailCategoryEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ParticipantMailGroupEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\TwigTemplateEditType;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService;
 use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -31,6 +34,8 @@ final class WebAdminMailConfigController extends AbstractController
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
+        private readonly MailPreviewService $mailPreview,
+        private readonly ParticipantRepository $participantRepository,
     ) {
     }
 
@@ -116,11 +121,50 @@ final class WebAdminMailConfigController extends AbstractController
         }
 
         return $this->render('@OswisOrgOswisCalendar/web_admin/mail_config/edit.html.twig', [
-            'form'       => $form,
-            'entity'     => $template,
-            'kind'       => 'template',
-            'pageTitle'  => sprintf('Twig šablona: %s', $template->getName() ?? '#'.$id),
-            'page_title' => sprintf('Twig šablona: %s :: ADMIN', $template->getName() ?? '#'.$id),
+            'form'               => $form,
+            'entity'             => $template,
+            'kind'               => 'template',
+            'sampleParticipants' => $this->participantRepository->findSampleParticipants(30),
+            'pageTitle'          => sprintf('Twig šablona: %s', $template->getName() ?? '#'.$id),
+            'page_title'         => sprintf('Twig šablona: %s :: ADMIN', $template->getName() ?? '#'.$id),
         ]);
+    }
+
+    /**
+     * Live preview of a mail template through the real MJML pipeline (#139 used to edit blind). POST,
+     * CSRF. Renders the POSTed (unsaved) source when present — trusted Twig, same trust the editor
+     * already grants — else the persisted template; against a chosen / most-recent sample participant.
+     * Returns an HTML fragment for the editor's preview iframe; render errors come back as a readable
+     * block, never a 500. {@see MailPreviewService}.
+     */
+    public function previewTemplate(Request $request, int $id): Response
+    {
+        if (!$this->isCsrfTokenValid('mail_template_preview', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $template = $this->em->find(TwigTemplate::class, $id);
+        if (!$template instanceof TwigTemplate) {
+            return new Response(
+                '<p style="font-family:sans-serif;color:#666">Šablona nenalezena.</p>',
+                Response::HTTP_NOT_FOUND,
+            );
+        }
+        // Not getInt(): the sample selector's "— nejnovější —" option posts an empty string, which
+        // InputBag::getInt() rejects with a 400. Empty / non-numeric → null → pick the latest sample.
+        $participantIdRaw = (string) $request->request->get('participantId', '');
+        $participantId = ctype_digit($participantIdRaw) ? (int) $participantIdRaw : 0;
+        $participant = $this->mailPreview->pickSampleParticipant($participantId > 0 ? $participantId : null);
+        if (!$participant instanceof Participant) {
+            return new Response(
+                '<p style="font-family:sans-serif;color:#666">Náhled nelze vytvořit – není k dispozici žádný vzorový účastník (přihláška).</p>',
+            );
+        }
+        $source = trim((string) $request->request->get('source', ''));
+        $subject = $template->getName();
+        $result = '' !== $source
+            ? $this->mailPreview->renderSource($source, $participant, [], $subject)
+            : $this->mailPreview->renderTemplate($template->getTemplateName(), $participant, [], $subject);
+
+        return new Response($result['html']);
     }
 }

--- a/Controller/WebAdmin/WebAdminMailConfigController.php
+++ b/Controller/WebAdmin/WebAdminMailConfigController.php
@@ -106,6 +106,37 @@ final class WebAdminMailConfigController extends AbstractController
         ]);
     }
 
+    /**
+     * Create a new TwigTemplate (e.g. a kind=snippet block or a new campaign). Reuses the edit form;
+     * on save it redirects to the editor so the admin immediately gets the live preview. Closes the
+     * loop for snippets (the bulk composer inserts them by slug) without needing direct DB access.
+     */
+    public function newTemplate(Request $request): Response
+    {
+        $template = new TwigTemplate();
+        $form = $this->createForm(TwigTemplateEditType::class, $template);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->em->persist($template);
+            $this->em->flush();
+            $this->addFlash('success', sprintf('Twig šablona „%s" vytvořena.', $template->getName() ?? '#'.$template->getId()));
+
+            return new RedirectResponse($this->generateUrl(
+                'oswis_org_oswis_calendar_web_admin_mail_template_edit',
+                ['id' => $template->getId()],
+            ));
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/mail_config/edit.html.twig', [
+            'form'               => $form,
+            'entity'             => $template,
+            'kind'               => 'template',
+            'sampleParticipants' => [],
+            'pageTitle'          => 'Nová Twig šablona',
+            'page_title'         => 'Nová Twig šablona :: ADMIN',
+        ]);
+    }
+
     public function editTemplate(Request $request, int $id): Response
     {
         $template = $this->em->find(TwigTemplate::class, $id)

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -112,8 +112,12 @@ final class WebAdminParticipantsController extends AbstractController
      * @throws OswisException
      */
     #[IsGranted('ROLE_ADMIN')]
-    public function sendAutoMails(int $limit = 100, ?string $type = null): Response
+    public function sendAutoMails(Request $request, int $limit = 100, ?string $type = null): Response
     {
+        // State-changing real-mail send: POST + CSRF only (was a CSRF-able GET).
+        if (!$this->isCsrfTokenValid('send_automails', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
         $this->participantService->sendAutoMails(null, $type, $limit);
 
         // Admin message skeleton (keeps the admin menu) — not the public message page.

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -5,6 +5,7 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Communication\CommunicationTimelineService;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantChangeService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantMailService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantService;
 use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
@@ -24,6 +25,7 @@ final class WebAdminParticipantsController extends AbstractController
         private readonly ParticipantService $participantService,
         private readonly CommunicationTimelineService $timelineService,
         private readonly ParticipantMailService $participantMailService,
+        private readonly ParticipantChangeService $changeService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -87,6 +89,14 @@ final class WebAdminParticipantsController extends AbstractController
             // Timeline failures must not prevent the detail page from rendering.
         }
 
+        // Registration history (read-only) — full chronology reconstructed from the versioned
+        // junction entities. Best-effort: a reconstruction failure must not break the detail page.
+        $history = [];
+        try {
+            $history = $this->changeService->buildHistory($participant);
+        } catch (\Throwable) {
+        }
+
         // Only ParticipantMail (system + ad-hoc) rows are resend-able.
         // IMAP-imported and manual-note rows have no underlying mailer.
         $resendableMailIds = [];
@@ -99,6 +109,7 @@ final class WebAdminParticipantsController extends AbstractController
         return $this->render('@OswisOrgOswisCalendar/web_admin/participant.html.twig', [
             'participant'        => $participant,
             'entries'            => $entries,
+            'history'            => $history,
             'isAdmin'            => true,
             'showFullDetail'     => true,
             'participantId'      => $participantId,

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -31,8 +31,10 @@ use OswisOrg\OswisCoreBundle\Exceptions\NotFoundException;
 use OswisOrg\OswisCoreBundle\Export\ExportManager;
 use OswisOrg\OswisCoreBundle\Export\ExportRequest;
 use OswisOrg\OswisCoreBundle\Export\ExportResponseFactory;
+use OswisOrg\OswisCoreBundle\Service\ExportService;
 use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -102,6 +104,7 @@ class WebAdminParticipantsListController extends AbstractController
         public ParticipantExportDefinition $participantExportDefinition,
         public ParticipantFilterEvaluator $filterEvaluator,
         public RegistrationFlagRepository $registrationFlagRepository,
+        public ExportService $exportService,
     ) {
     }
 
@@ -873,8 +876,65 @@ class WebAdminParticipantsListController extends AbstractController
      */
     public function showParticipantsCsv(Request $request): Response
     {
-        // Export the same scoped set the list shows (multi-event + depth aware). Unscoped
-        // (no event, no category) exports everything.
+        $scope = $this->loadExportScope($request);
+        if ($scope instanceof Response) {
+            return $scope; // over-cap redirect
+        }
+        $columnKeys = array_values(array_filter($request->query->all('columns'), 'is_string'));
+        $exportRequest = new ExportRequest(
+            ExportFormat::fromRequest($request->query->getString('format')),
+            [] === $columnKeys ? null : $columnKeys,
+            $scope['subtitle'],
+        );
+
+        return $this->exportResponseFactory->toResponse(
+            $this->exportManager->render(
+                $this->participantExportDefinition,
+                new ArrayCollection($scope['participants']),
+                $exportRequest,
+            ),
+        );
+    }
+
+    /**
+     * Rich "browse-style" PDF of the participant list — the same visual content as the web admin
+     * screen (coloured flag badges with prices, payment status, notes, contact), rendered
+     * server-side through the branded PDF chrome. Distinct from the tabular CSV/PDF export.
+     *
+     * @throws \Mpdf\MpdfException
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function showParticipantsListPdf(Request $request): Response
+    {
+        $scope = $this->loadExportScope($request);
+        if ($scope instanceof Response) {
+            return $scope; // over-cap redirect
+        }
+        $html = $this->renderView('@OswisOrgOswisCalendar/web_admin/participants-list-pdf.html.twig', [
+            'participants' => $scope['participants'],
+            'subtitle'     => $scope['subtitle'],
+        ]);
+        $pdf = $this->exportService->getPdfFromHtml($html, false, 'Přehled přihlášek', $scope['subtitle'], ['přehled', 'přihlášky']);
+        $filename = 'prehled-prihlasek_'.date('Y-m-d_His').'.pdf';
+
+        return new Response($pdf, Response::HTTP_OK, [
+            'Content-Type'        => 'application/pdf',
+            'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $filename),
+        ]);
+    }
+
+    /**
+     * Resolve + load + sort the scoped participant set for any export, applying the shared
+     * {@see EXPORT_MAX_ROWS} cap. Returns the sorted participants + a human scope subtitle, or a
+     * RedirectResponse (with a flash) when the scope exceeds the cap — never a silent truncation.
+     *
+     * @return array{participants: list<Participant>, subtitle: string}|RedirectResponse
+     */
+    private function loadExportScope(Request $request): array|RedirectResponse
+    {
+        // Same scoped set the list shows (multi-event + depth aware). Unscoped = everything.
         [$events, ] = $this->resolveEventsFromRequest($request);
         // Default the participant type to "Účastník" (the everyday view) when none is given;
         // an explicit empty value (the "— typ účastníka —" option) means *all types*.
@@ -916,9 +976,7 @@ class WebAdminParticipantsListController extends AbstractController
             $participantsArray,
             static fn (Participant $a, Participant $b): int => StringUtils::compareCzech($a->getSortableName(), $b->getSortableName()),
         );
-        $participants = new ArrayCollection($participantsArray);
-        $columnKeys = array_values(array_filter($request->query->all('columns'), 'is_string'));
-        // Podtitulek PDF: scope (akce/typ) + počet — ať je export jednoznačně identifikovatelný.
+        // Human scope subtitle: akce/typ + počet — ať je výstup jednoznačně identifikovatelný.
         $scopeBits = [];
         if (1 === count($events)) {
             $scopeBits[] = (string) ($events[0]->getShortName() ?: $events[0]->getName());
@@ -931,15 +989,8 @@ class WebAdminParticipantsListController extends AbstractController
             $scopeBits[] = (string) $participantCategory->getName();
         }
         $scopeBits[] = count($participantsArray).' záznamů';
-        $exportRequest = new ExportRequest(
-            ExportFormat::fromRequest($request->query->getString('format')),
-            [] === $columnKeys ? null : $columnKeys,
-            implode(' · ', $scopeBits),
-        );
 
-        return $this->exportResponseFactory->toResponse(
-            $this->exportManager->render($this->participantExportDefinition, $participants, $exportRequest),
-        );
+        return ['participants' => $participantsArray, 'subtitle' => implode(' · ', $scopeBits)];
     }
 
     public function showYearsCompare(?string $eventSeriesSlug = null): Response

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -75,6 +75,16 @@ class WebAdminParticipantsListController extends AbstractController
     /** Page size for the unscoped (all-participants) paginated view. */
     private const int PER_PAGE = 100;
 
+    /**
+     * Hard ceiling on rows in a single export (CSV/PDF). A full export hydrates the whole heavy
+     * Participant graph per row; an unscoped all-years dump (thousands of rows) exhausts memory.
+     * We load at most EXPORT_MAX_ROWS+1 (true SQL LIMIT → never hydrate beyond the cap) and, when
+     * the scope exceeds the cap, REFUSE the export with a clear error rather than silently
+     * truncating — the user is told to narrow the scope (pick an event/year). Scoped exports
+     * (per turnus/ročník) sit well under this, so the everyday path is unaffected.
+     */
+    private const int EXPORT_MAX_ROWS = 1000;
+
     /** Default participant type when none is requested — the everyday "Účastník" view. */
     private const string DEFAULT_PARTICIPANT_CATEGORY = 'ucastnik';
 
@@ -296,14 +306,14 @@ class WebAdminParticipantsListController extends AbstractController
      *
      * @return ArrayCollection<int, Participant>
      */
-    private function loadScopedParticipants(array $events, ?ParticipantCategory $category, ?int $depthOverride, bool $includeDeleted = true): ArrayCollection
+    private function loadScopedParticipants(array $events, ?ParticipantCategory $category, ?int $depthOverride, bool $includeDeleted = true, ?int $limit = null): ArrayCollection
     {
         if ([] === $events) {
             $collection = $this->participantService->getParticipants([
                 ParticipantRepository::CRITERIA_INCLUDE_DELETED      => $includeDeleted,
                 ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY => $category,
                 ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 0,
-            ]);
+            ], true, $limit);
 
             return new ArrayCollection($collection->toArray());
         }
@@ -316,12 +326,17 @@ class WebAdminParticipantsListController extends AbstractController
                 ParticipantRepository::CRITERIA_EVENT                 => $event,
                 ParticipantRepository::CRITERIA_PARTICIPANT_CATEGORY  => $category,
                 ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => $depth,
-            ]);
+            ], true, $limit);
             foreach ($collection as $participant) {
                 $id = $participant->getId();
                 if (null !== $id) {
                     $byId[$id] = $participant;
                 }
+            }
+            // Stop merging once the cap is exceeded — we already know the export must be refused,
+            // and this bounds memory across a many-event multi-select.
+            if (null !== $limit && count($byId) >= $limit) {
+                break;
             }
         }
 
@@ -867,13 +882,28 @@ class WebAdminParticipantsListController extends AbstractController
         $depthOverride = (null !== $depthRaw && '' !== $depthRaw) ? max(0, (int) $depthRaw) : null;
         $includeDeleted = $request->query->getBoolean('includeDeleted');
 
+        // Load at most EXPORT_MAX_ROWS+1 (true SQL LIMIT → memory never blows up on a huge scope).
+        // The +1 is the overflow sentinel: if it comes back, the real set is over the cap.
+        $loadLimit = self::EXPORT_MAX_ROWS + 1;
         if ([] !== $events || null !== $participantCategory) {
-            $participants = $this->loadScopedParticipants($events, $participantCategory, $depthOverride, $includeDeleted);
+            $participants = $this->loadScopedParticipants($events, $participantCategory, $depthOverride, $includeDeleted, $loadLimit);
         } else {
             $participants = $this->participantService->getParticipants([
                 ParticipantRepository::CRITERIA_INCLUDE_DELETED       => $includeDeleted,
                 ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 0,
-            ]);
+            ], true, $loadLimit);
+        }
+        // Over the cap → refuse with a clear error (never silently truncate). Bounce back to the
+        // list (which paginates, so it renders fine) with the same scope so the user can narrow it.
+        if ($participants->count() > self::EXPORT_MAX_ROWS) {
+            $this->addFlash('danger', sprintf(
+                'Export je omezen na %d záznamů a tento výběr je překračuje. Zužte rozsah – vyberte konkrétní akci nebo ročník (případně typ účastníka) – a export opakujte.',
+                self::EXPORT_MAX_ROWS,
+            ));
+            $redirectParams = $request->query->all();
+            unset($redirectParams['format'], $redirectParams['columns']);
+
+            return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_participants_list', $redirectParams);
         }
         $participantsArray = $participants->toArray();
         usort(

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -334,9 +334,13 @@ class WebAdminParticipantsListController extends AbstractController
                     $byId[$id] = $participant;
                 }
             }
-            // Stop merging once the cap is exceeded — we already know the export must be refused,
-            // and this bounds memory across a many-event multi-select.
-            if (null !== $limit && count($byId) >= $limit) {
+            // Stop loading further events once the cap is reached — the export will be refused
+            // anyway. Break on EITHER the merged unique count OR this single event already hitting
+            // the sentinel (a lone event over the cap → the whole export is over it). This bounds
+            // hydration at ~2× the cap regardless of how many events are multi-selected, without
+            // any silent truncation: every break path leaves count($byId) ≥ limit, so the caller's
+            // over-cap check fires.
+            if (null !== $limit && (count($byId) >= $limit || $collection->count() >= $limit)) {
                 break;
             }
         }

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -267,11 +267,31 @@ class WebAdminParticipantsListController extends AbstractController
             'q'                   => $q,
             'depthOverride'       => $depthOverride,
             'participantCategorySlug' => $participantCategorySlug,
-            'participantCategories'   => $this->participantCategoryService->getRepository()->findBy([], ['name' => 'ASC']),
+            'participantCategories'   => $this->sortedParticipantCategories(),
             'yearEvents'              => $yearEvents,
             'defaultEvent'            => $this->eventService->getDefaultEvent(),
             'exportPresets'           => $this->participantExportDefinition->getPresets(),
         ]);
+    }
+
+    /**
+     * Participant categories for the filter dropdown, sorted Czech-alphabetically in PHP.
+     * (findBy()'s DB ORDER BY uses utf8mb4_unicode_ci, which sorts Č/Š/Ř… after Z.)
+     *
+     * @return list<ParticipantCategory>
+     */
+    private function sortedParticipantCategories(): array
+    {
+        $categories = $this->participantCategoryService->getRepository()->findBy([]);
+        usort(
+            $categories,
+            static fn (ParticipantCategory $a, ParticipantCategory $b): int => StringUtils::compareCzech(
+                $a->getName(),
+                $b->getName(),
+            ),
+        );
+
+        return $categories;
     }
 
     /**

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -267,6 +267,7 @@ class WebAdminParticipantsListController extends AbstractController
             'participantCategories'   => $this->participantCategoryService->getRepository()->findBy([], ['name' => 'ASC']),
             'yearEvents'              => $yearEvents,
             'defaultEvent'            => $this->eventService->getDefaultEvent(),
+            'exportPresets'           => $this->participantExportDefinition->getPresets(),
         ]);
     }
 

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -76,14 +76,15 @@ class WebAdminParticipantsListController extends AbstractController
     private const int PER_PAGE = 100;
 
     /**
-     * Hard ceiling on rows in a single export (CSV/PDF). A full export hydrates the whole heavy
-     * Participant graph per row; an unscoped all-years dump (thousands of rows) exhausts memory.
-     * We load at most EXPORT_MAX_ROWS+1 (true SQL LIMIT → never hydrate beyond the cap) and, when
-     * the scope exceeds the cap, REFUSE the export with a clear error rather than silently
-     * truncating — the user is told to narrow the scope (pick an event/year). Scoped exports
-     * (per turnus/ročník) sit well under this, so the everyday path is unaffected.
+     * Hard ceiling on rows in a single export (CSV/PDF) — shared with the API export controller.
+     * A full export hydrates the whole heavy Participant graph per row; an unscoped all-years dump
+     * (thousands of rows) exhausts memory. We load at most EXPORT_MAX_ROWS+1 (true SQL LIMIT →
+     * never hydrate beyond the cap) and, when the scope exceeds the cap, REFUSE the export with a
+     * clear error rather than silently truncating — the user is told to narrow the scope (pick an
+     * event/year). Scoped exports (per turnus/ročník) sit well under this, so the everyday path is
+     * unaffected. {@see ParticipantExportDefinition::MAX_EXPORT_ROWS}.
      */
-    private const int EXPORT_MAX_ROWS = 1000;
+    private const int EXPORT_MAX_ROWS = ParticipantExportDefinition::MAX_EXPORT_ROWS;
 
     /** Default participant type when none is requested — the everyday "Účastník" view. */
     private const string DEFAULT_PARTICIPANT_CATEGORY = 'ucastnik';

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -882,9 +882,23 @@ class WebAdminParticipantsListController extends AbstractController
         );
         $participants = new ArrayCollection($participantsArray);
         $columnKeys = array_values(array_filter($request->query->all('columns'), 'is_string'));
+        // Podtitulek PDF: scope (akce/typ) + počet — ať je export jednoznačně identifikovatelný.
+        $scopeBits = [];
+        if (1 === count($events)) {
+            $scopeBits[] = (string) ($events[0]->getShortName() ?: $events[0]->getName());
+        } elseif (count($events) > 1) {
+            $scopeBits[] = count($events).' akcí';
+        } else {
+            $scopeBits[] = 'všechny akce';
+        }
+        if (null !== $participantCategory) {
+            $scopeBits[] = (string) $participantCategory->getName();
+        }
+        $scopeBits[] = count($participantsArray).' záznamů';
         $exportRequest = new ExportRequest(
             ExportFormat::fromRequest($request->query->getString('format')),
             [] === $columnKeys ? null : $columnKeys,
+            implode(' · ', $scopeBits),
         );
 
         return $this->exportResponseFactory->toResponse(

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -915,6 +915,9 @@ class WebAdminParticipantsListController extends AbstractController
         $html = $this->renderView('@OswisOrgOswisCalendar/web_admin/participants-list-pdf.html.twig', [
             'participants' => $scope['participants'],
             'subtitle'     => $scope['subtitle'],
+            'categoryName' => $scope['categoryName'],
+            'eventNames'   => $scope['eventNames'],
+            'count'        => $scope['count'],
         ]);
         $pdf = $this->exportService->getPdfFromHtml($html, false, 'Přehled přihlášek', $scope['subtitle'], ['přehled', 'přihlášky']);
         $filename = 'prehled-prihlasek_'.date('Y-m-d_His').'.pdf';
@@ -930,7 +933,7 @@ class WebAdminParticipantsListController extends AbstractController
      * {@see EXPORT_MAX_ROWS} cap. Returns the sorted participants + a human scope subtitle, or a
      * RedirectResponse (with a flash) when the scope exceeds the cap — never a silent truncation.
      *
-     * @return array{participants: list<Participant>, subtitle: string}|RedirectResponse
+     * @return array{participants: list<Participant>, subtitle: string, categoryName: string|null, eventNames: list<string>, count: int}|RedirectResponse
      */
     private function loadExportScope(Request $request): array|RedirectResponse
     {
@@ -990,7 +993,18 @@ class WebAdminParticipantsListController extends AbstractController
         }
         $scopeBits[] = count($participantsArray).' záznamů';
 
-        return ['participants' => $participantsArray, 'subtitle' => implode(' · ', $scopeBits)];
+        $eventNames = array_map(
+            static fn (Event $e): string => (string) ($e->getShortName() ?: $e->getName()),
+            $events,
+        );
+
+        return [
+            'participants' => $participantsArray,
+            'subtitle'     => implode(' · ', $scopeBits),
+            'categoryName' => $participantCategory?->getName(),
+            'eventNames'   => $eventNames,
+            'count'        => count($participantsArray),
+        ];
     }
 
     public function showYearsCompare(?string $eventSeriesSlug = null): Response

--- a/Entity/ParticipantMail/ParticipantMail.php
+++ b/Entity/ParticipantMail/ParticipantMail.php
@@ -58,6 +58,8 @@ class ParticipantMail extends AbstractMail implements CommunicationEntryInterfac
     public const TYPE_ACTIVATION_REQUEST = 'activation-request';
     public const TYPE_SUMMARY = 'summary';
     public const TYPE_PAYMENT = 'payment';
+    /** Sent on an UPDATE to an existing registration (not the initial confirmation) — lists what changed. */
+    public const TYPE_REGISTRATION_CHANGED = 'registration-changed';
 
     #[ManyToOne(targetEntity: Participant::class, fetch: 'EAGER', inversedBy: 'eMails')]
     #[JoinColumn(name: 'participant_id', referencedColumnName: 'id')]

--- a/Entity/ParticipantMail/ParticipantMail.php
+++ b/Entity/ParticipantMail/ParticipantMail.php
@@ -51,6 +51,7 @@ use OswisOrg\OswisCoreBundle\Interfaces\Communication\CommunicationEntryInterfac
 #[Entity]
 #[Table(name: 'calendar_participant_mail')]
 #[Index(name: 'IDX_PARTICIPANT_MAIL_THREAD_KEY', columns: ['thread_key'])]
+#[Index(name: 'IDX_PARTICIPANT_MAIL_BULK', columns: ['bulk_id'])]
 #[Cache(usage: 'NONSTRICT_READ_WRITE', region: 'calendar_participant_mail')]
 class ParticipantMail extends AbstractMail implements CommunicationEntryInterface
 {
@@ -73,6 +74,11 @@ class ParticipantMail extends AbstractMail implements CommunicationEntryInterfac
     #[ManyToOne(targetEntity: ParticipantToken::class, fetch: 'EAGER')]
     #[JoinColumn(name: 'participant_token_id', referencedColumnName: 'id')]
     protected ?ParticipantToken $participantToken = null;
+
+    /** Bulk this mail was sent as part of (ad-hoc bulk outbox), null for system/individual mails. */
+    #[ManyToOne(targetEntity: ParticipantMailBulk::class)]
+    #[JoinColumn(name: 'bulk_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    protected ?ParticipantMailBulk $bulk = null;
 
     #[\Doctrine\ORM\Mapping\Column(type: 'string', length: 64, nullable: true)]
     protected ?string $threadKey = null;
@@ -143,6 +149,16 @@ class ParticipantMail extends AbstractMail implements CommunicationEntryInterfac
     public function setParticipantMailCategory(?ParticipantMailCategory $participantMailCategory): void
     {
         $this->participantMailCategory = $participantMailCategory;
+    }
+
+    public function getBulk(): ?ParticipantMailBulk
+    {
+        return $this->bulk;
+    }
+
+    public function setBulk(?ParticipantMailBulk $bulk): void
+    {
+        $this->bulk = $bulk;
     }
 
     public function getThreadKey(): ?string

--- a/Entity/ParticipantMail/ParticipantMailBulk.php
+++ b/Entity/ParticipantMail/ParticipantMailBulk.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * @noinspection PhpUnused
+ * @noinspection MethodShouldBeFinalInspection
+ */
+
+namespace OswisOrg\OswisCalendarBundle\Entity\ParticipantMail;
+
+use DateTime;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository;
+
+/**
+ * Durable outbox for ad-hoc bulk e-mails composed in web admin. A bulk row holds the message (subject
+ * + verbatim HTML body) plus a snapshot of recipient participant IDs; it is drained in capped batches
+ * by a cron command / JS auto-drain (synchronous SMTP can't loop over hundreds in one request).
+ *
+ * Deliberately a PLAIN entity — no Gedmo Blameable relation. It is persisted/updated from a CLI drain
+ * where the Blameable security actor is absent; a Blameable relation there triggered the persist
+ * recursion class that caused the IMAP OOM. The composing admin is stored as a plain string instead.
+ *
+ * @author Jakub Zak <mail@jakubzak.eu>
+ */
+#[Entity(repositoryClass: ParticipantMailBulkRepository::class)]
+#[Table(name: 'calendar_participant_mail_bulk')]
+#[Index(name: 'IDX_PARTICIPANT_MAIL_BULK_STATUS', columns: ['status'])]
+class ParticipantMailBulk
+{
+    public const STATUS_QUEUED = 'queued';
+
+    public const STATUS_SENDING = 'sending';
+
+    public const STATUS_DONE = 'done';
+
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    protected ?int $id = null;
+
+    #[Column(type: 'string', length: 255)]
+    protected string $subject;
+
+    #[Column(type: 'text')]
+    protected string $bodyHtml;
+
+    #[Column(type: 'string', length: 255, nullable: true)]
+    protected ?string $adminName = null;
+
+    #[Column(type: 'datetime')]
+    protected DateTime $createdAt;
+
+    #[Column(type: 'string', length: 16)]
+    protected string $status = self::STATUS_QUEUED;
+
+    /** @var list<int> Snapshot of recipient participant IDs (resolved from the list filter/selection at compose time). */
+    #[Column(type: 'json')]
+    protected array $participantIds = [];
+
+    /** Cursor into participantIds — how many have been processed (sent or failed). Resumable. */
+    #[Column(type: 'integer')]
+    protected int $processedCount = 0;
+
+    #[Column(type: 'integer')]
+    protected int $sentCount = 0;
+
+    #[Column(type: 'integer')]
+    protected int $failedCount = 0;
+
+    #[Column(type: 'text', nullable: true)]
+    protected ?string $failedNote = null;
+
+    /**
+     * @param array<int> $participantIds normalized to a 0-indexed list (callers may pass filtered/keyed arrays)
+     */
+    public function __construct(string $subject, string $bodyHtml, array $participantIds, ?string $adminName = null)
+    {
+        $this->subject = $subject;
+        $this->bodyHtml = $bodyHtml;
+        $this->participantIds = array_values($participantIds);
+        $this->adminName = $adminName;
+        $this->createdAt = new DateTime();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSubject(): string
+    {
+        return $this->subject;
+    }
+
+    public function getBodyHtml(): string
+    {
+        return $this->bodyHtml;
+    }
+
+    public function getAdminName(): ?string
+    {
+        return $this->adminName;
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function isDone(): bool
+    {
+        return self::STATUS_DONE === $this->status;
+    }
+
+    /** @return list<int> */
+    public function getParticipantIds(): array
+    {
+        return $this->participantIds;
+    }
+
+    public function getTotalCount(): int
+    {
+        return count($this->participantIds);
+    }
+
+    public function getProcessedCount(): int
+    {
+        return $this->processedCount;
+    }
+
+    public function setProcessedCount(int $processedCount): void
+    {
+        $this->processedCount = max(0, $processedCount);
+    }
+
+    public function getRemainingCount(): int
+    {
+        return max(0, $this->getTotalCount() - $this->processedCount);
+    }
+
+    public function getSentCount(): int
+    {
+        return $this->sentCount;
+    }
+
+    public function recordSent(): void
+    {
+        ++$this->sentCount;
+    }
+
+    public function getFailedCount(): int
+    {
+        return $this->failedCount;
+    }
+
+    public function recordFailed(?string $note = null): void
+    {
+        ++$this->failedCount;
+        if (null !== $note && '' !== trim($note)) {
+            $this->failedNote = mb_substr(trim(($this->failedNote ?? '')."\n".trim($note)), 0, 60000);
+        }
+    }
+
+    public function getFailedNote(): ?string
+    {
+        return $this->failedNote;
+    }
+}

--- a/Entity/ParticipantMail/ParticipantMailBulk.php
+++ b/Entity/ParticipantMail/ParticipantMailBulk.php
@@ -49,6 +49,13 @@ class ParticipantMailBulk
     #[Column(type: 'text')]
     protected string $bodyHtml;
 
+    /**
+     * Optional renderable template name (a `core_twig_template` slug resolved by the DatabaseLoader, or
+     * a file path) of a stored campaign/snippet to send instead of the free body. NULL = free body.
+     */
+    #[Column(type: 'string', length: 255, nullable: true)]
+    protected ?string $templateSlug = null;
+
     #[Column(type: 'string', length: 255, nullable: true)]
     protected ?string $adminName = null;
 
@@ -78,12 +85,18 @@ class ParticipantMailBulk
     /**
      * @param array<int> $participantIds normalized to a 0-indexed list (callers may pass filtered/keyed arrays)
      */
-    public function __construct(string $subject, string $bodyHtml, array $participantIds, ?string $adminName = null)
-    {
+    public function __construct(
+        string $subject,
+        string $bodyHtml,
+        array $participantIds,
+        ?string $adminName = null,
+        ?string $templateSlug = null,
+    ) {
         $this->subject = $subject;
         $this->bodyHtml = $bodyHtml;
         $this->participantIds = array_values($participantIds);
         $this->adminName = $adminName;
+        $this->templateSlug = (null !== $templateSlug && '' !== trim($templateSlug)) ? trim($templateSlug) : null;
         $this->createdAt = new DateTime();
     }
 
@@ -100,6 +113,16 @@ class ParticipantMailBulk
     public function getBodyHtml(): string
     {
         return $this->bodyHtml;
+    }
+
+    public function getTemplateSlug(): ?string
+    {
+        return $this->templateSlug;
+    }
+
+    public function hasTemplate(): bool
+    {
+        return null !== $this->templateSlug && '' !== $this->templateSlug;
     }
 
     public function getAdminName(): ?string

--- a/Entity/ParticipantMail/ParticipantMailGroup.php
+++ b/Entity/ParticipantMail/ParticipantMailGroup.php
@@ -21,6 +21,7 @@ use Doctrine\ORM\Mapping\Table;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailGroupRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFilterEvaluator;
 use OswisOrg\OswisCoreBundle\Entity\AbstractClass\AbstractMailGroup;
 use OswisOrg\OswisCoreBundle\Entity\NonPersistent\DateTimeRange;
 use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Nameable;
@@ -69,6 +70,20 @@ class ParticipantMailGroup extends AbstractMailGroup
 
     #[Column(type: 'boolean', nullable: false)]
     protected bool $onlyActive = true;
+
+    /**
+     * Optional recipient filter — a {@see ParticipantFilterEvaluator} boolean expression
+     * (same language as the unified participant list: hasFlag('…'), hasFlagInCategory('fakulta'),
+     * isPaid(), eventSlug() …). Null/blank = no extra restriction. Lets a campaign target a segment
+     * beyond the event scope (one faculty, one accommodation type, unpaid only, …) and lets a
+     * transactional type use a segment-specific template variant (higher priority + filter) with a
+     * filterless fallback group catching the rest.
+     */
+    #[Column(type: 'text', nullable: true)]
+    protected ?string $filterExpression = null;
+
+    /** Lazily-built shared evaluator (stateless, no dependencies) for {@see isApplicableByFilter()}. */
+    private static ?ParticipantFilterEvaluator $filterEvaluator = null;
 
     public function __construct(
         ?Nameable $nameable = null,
@@ -127,6 +142,17 @@ class ParticipantMailGroup extends AbstractMailGroup
         $this->onlyActive = $onlyActive;
     }
 
+    public function getFilterExpression(): ?string
+    {
+        return $this->filterExpression;
+    }
+
+    public function setFilterExpression(?string $filterExpression): void
+    {
+        $filterExpression = null === $filterExpression ? null : trim($filterExpression);
+        $this->filterExpression = ('' === $filterExpression) ? null : $filterExpression;
+    }
+
     public function isApplicableByRestrictions(?object $entity): bool
     {
         if (!($entity instanceof Participant)) {
@@ -139,6 +165,25 @@ class ParticipantMailGroup extends AbstractMailGroup
             return false;
         }
 
-        return true;
+        return $this->isApplicableByFilter($entity);
+    }
+
+    /**
+     * Whether the participant matches the optional filter expression. No filter = applicable.
+     * FAIL-CLOSED: a broken stored expression must never widen the recipient set, so any evaluation
+     * error means "not applicable" (the edit form validates expressions on save, and the automail
+     * drain pre-validates and reports per group — this catch is the last line of defense).
+     */
+    public function isApplicableByFilter(Participant $participant): bool
+    {
+        $expression = $this->filterExpression;
+        if (null === $expression || '' === trim($expression)) {
+            return true;
+        }
+        try {
+            return (self::$filterEvaluator ??= new ParticipantFilterEvaluator())->matches($participant, $expression);
+        } catch (\Throwable) {
+            return false;
+        }
     }
 }

--- a/EventSubscriber/ParticipantSubscriber.php
+++ b/EventSubscriber/ParticipantSubscriber.php
@@ -69,7 +69,14 @@ final class ParticipantSubscriber implements EventSubscriberInterface
             return;
         }
         $this->logger->notice("ParticipantSubscriber->postWrite()");
-        $this->participantMailService->sendSummary($participant);
+        // CREATE → confirmation (summary). UPDATE → a change notice listing what actually changed
+        // since the last confirmation (or nothing, if nothing changed) — no more re-sending the full
+        // "you are registered" summary on every PUT. {@see ParticipantMailService::notifyParticipantChanged}.
+        if (Request::METHOD_POST === $method) {
+            $this->participantMailService->sendSummary($participant);
+        } else {
+            $this->participantMailService->notifyParticipantChanged($participant);
+        }
         $this->flagRangeService->updateUsages($participant);
         $regRange = $participant->getOffer();
         if ($regRange) {

--- a/Export/ParticipantExportDefinition.php
+++ b/Export/ParticipantExportDefinition.php
@@ -11,6 +11,16 @@ use OswisOrg\OswisCoreBundle\Export\ExportDefinitionInterface;
 
 final class ParticipantExportDefinition implements ExportDefinitionInterface
 {
+    /**
+     * Hard ceiling on rows in a single participant export. A full export hydrates the whole heavy
+     * Participant graph (eager associations) per row; an unscoped dump of thousands of rows
+     * exhausts memory (OOM in Doctrine's deep clone during hydration). Both export entry points
+     * (web admin list export, API export for the Ionic admin) load at most MAX_EXPORT_ROWS+1 via a
+     * true SQL LIMIT and refuse — with a clear error, never a silent truncation — when the scope
+     * exceeds it, telling the caller to narrow the scope (pick an event/year).
+     */
+    public const int MAX_EXPORT_ROWS = 1000;
+
     public function getKey(): string
     {
         return 'participants';

--- a/Export/ParticipantExportDefinition.php
+++ b/Export/ParticipantExportDefinition.php
@@ -6,6 +6,8 @@ namespace OswisOrg\OswisCalendarBundle\Export;
 
 use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractPerson;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlag;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagCategory;
 use OswisOrg\OswisCoreBundle\Export\ExportColumn;
 use OswisOrg\OswisCoreBundle\Export\ExportDefinitionInterface;
 
@@ -49,6 +51,9 @@ final class ParticipantExportDefinition implements ExportDefinitionInterface
             new ExportColumn('email', 'E-mail', static fn (object $p): mixed => $p instanceof Participant ? $p->getContactForRead()?->getEmail() : null),
             new ExportColumn('phone', 'Telefon', static fn (object $p): mixed => $p instanceof Participant ? $p->getContactForRead()?->getPhone() : null),
             new ExportColumn('tShirt', 'Velikost trička', static fn (object $p): mixed => $p instanceof Participant ? $p->getTShirt() : null),
+            // Flag-derived provozní sloupce (nejsou ve výchozím exportu — slouží provozním listům).
+            new ExportColumn('accommodation', 'Ubytování', static fn (object $p): mixed => self::flagNames($p, RegistrationFlagCategory::TYPE_ACCOMMODATION_TYPE), false),
+            new ExportColumn('food', 'Strava', static fn (object $p): mixed => self::flagNames($p, RegistrationFlagCategory::TYPE_FOOD), false),
             new ExportColumn('createdAt', 'Datum přihlášky', static fn (object $p): mixed => $p instanceof Participant ? $p->getCreatedAt() : null, true, ExportColumn::TYPE_DATETIME),
             new ExportColumn('activated', 'Aktivováno', static fn (object $p): mixed => $p instanceof Participant ? ($p->getActivated()?->format('Y-m-d') ?? 'Ne') : null),
             new ExportColumn('price', 'Celková cena', static fn (object $p): mixed => $p instanceof Participant ? $p->getPrice() : null, true, ExportColumn::TYPE_NUMBER),
@@ -67,5 +72,60 @@ final class ParticipantExportDefinition implements ExportDefinitionInterface
         $contact = $participant->getContactForRead();
 
         return $contact instanceof AbstractPerson ? $contact : null;
+    }
+
+    /**
+     * Čárkou oddělené názvy aktivních příznaků dané kategorie/typu (např. ubytování, strava).
+     */
+    private static function flagNames(object $participant, string $flagType): ?string
+    {
+        if (!$participant instanceof Participant) {
+            return null;
+        }
+        $names = [];
+        foreach ($participant->getFlags(null, $flagType) as $flag) {
+            $name = $flag instanceof RegistrationFlag ? $flag->getName() : null;
+            if (is_string($name) && '' !== $name) {
+                $names[] = $name;
+            }
+        }
+
+        return implode(', ', $names);
+    }
+
+    /**
+     * Pojmenované sloupcové presety = provozní listy (jedno-klik export předvolené podmnožiny
+     * sloupců ve vhodném formátu). Klíče sloupců odpovídají {@see getColumns()}.
+     *
+     * @return list<array{key: string, label: string, columns: list<string>, format: string}>
+     */
+    public function getPresets(): array
+    {
+        return [
+            [
+                'key'     => 'contact',
+                'label'   => 'Kontaktní list',
+                'columns' => ['familyName', 'givenName', 'email', 'phone', 'event', 'category'],
+                'format'  => 'pdf',
+            ],
+            [
+                'key'     => 'payment',
+                'label'   => 'Platební list',
+                'columns' => ['familyName', 'givenName', 'variableSymbol', 'price', 'paidPrice', 'remainingPrice', 'paidPercentage'],
+                'format'  => 'pdf',
+            ],
+            [
+                'key'     => 'tshirt',
+                'label'   => 'Výdej triček',
+                'columns' => ['familyName', 'givenName', 'tShirt', 'event', 'paidPrice'],
+                'format'  => 'pdf',
+            ],
+            [
+                'key'     => 'accommodation',
+                'label'   => 'Ubytovací / stravovací',
+                'columns' => ['familyName', 'givenName', 'accommodation', 'food', 'event'],
+                'format'  => 'pdf',
+            ],
+        ];
     }
 }

--- a/Form/WebAdmin/ParticipantMailGroupEditType.php
+++ b/Form/WebAdmin/ParticipantMailGroupEditType.php
@@ -7,14 +7,18 @@ namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailCategory;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailGroup;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFilterEvaluator;
 use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class ParticipantMailGroupEditType extends AbstractType
 {
@@ -53,6 +57,31 @@ final class ParticipantMailGroupEditType extends AbstractType
             ->add('onlyActive', CheckboxType::class, [
                 'label'    => 'Pouze aktivní účastníci',
                 'required' => false,
+            ])
+            ->add('filterExpression', TextareaType::class, [
+                'label'    => 'Filtr příjemců (volitelný)',
+                'required' => false,
+                'attr'     => [
+                    'rows'        => 2,
+                    'maxlength'   => ParticipantFilterEvaluator::MAX_EXPRESSION_LENGTH,
+                    'placeholder' => "hasFlagInCategory('fakulta') and isPaid()",
+                    'style'       => 'font-family: monospace;',
+                ],
+                'help'     => 'Stejný jazyk jako pokročilý filtr v seznamu přihlášek: hasFlag(\'slug\'), '
+                    .'hasFlagInCategory(\'slug-kategorie\'), hasFlagOfType(\'typ\'), isPaid(), isDeleted(), '
+                    .'eventSlug(), gender() — kombinace přes and / or / not. Prázdné = bez omezení. '
+                    .'POZOR: filtr platí i pro systémové typy (summary/payment) — účastník mimo filtr pak '
+                    .'spadne do další skupiny dle priority; bez záchytné skupiny bez filtru e-mail nedostane.',
+                // Syntax-validate on save: a broken stored expression would fail-closed at send time
+                // (nobody mailed) — reject it here instead. The evaluator is stateless and dependency-free.
+                'constraints' => [
+                    new Callback(static function (?string $value, ExecutionContextInterface $context): void {
+                        $error = (new ParticipantFilterEvaluator())->validate($value);
+                        if (null !== $error) {
+                            $context->buildViolation('Neplatný filtrační výraz: '.$error)->addViolation();
+                        }
+                    }),
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Uložit',

--- a/Form/WebAdmin/TwigTemplateEditType.php
+++ b/Form/WebAdmin/TwigTemplateEditType.php
@@ -6,6 +6,7 @@ namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
 
 use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -20,6 +21,19 @@ final class TwigTemplateEditType extends AbstractType
             ->add('name', TextType::class, ['label' => 'Název', 'required' => false])
             ->add('shortName', TextType::class, ['label' => 'Krátký název', 'required' => false])
             ->add('slug', TextType::class, ['label' => 'Slug', 'required' => false])
+            ->add('kind', ChoiceType::class, [
+                'label'       => 'Druh',
+                'required'    => false,
+                'placeholder' => '— neurčeno —',
+                'choices'     => [
+                    'Systémový (transakční)' => TwigTemplate::KIND_SYSTEM,
+                    'Kampaň (celý e-mail)'   => TwigTemplate::KIND_CAMPAIGN,
+                    'Blok / snippet'         => TwigTemplate::KIND_SNIPPET,
+                    'Stránka (web)'          => TwigTemplate::KIND_PAGE,
+                    'PDF'                    => TwigTemplate::KIND_PDF,
+                ],
+                'help' => 'Kampaň = celý e-mail (infomail/feedback); Snippet = znovupoužitelný blok k vložení do těla.',
+            ])
             ->add('description', TextareaType::class, [
                 'label'    => 'Popis',
                 'required' => false,

--- a/Repository/Participant/ParticipantCategoryRepository.php
+++ b/Repository/Participant/ParticipantCategoryRepository.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory;
+use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 
 /**
  * @extends ServiceEntityRepository<ParticipantCategory>
@@ -103,7 +104,19 @@ class ParticipantCategoryRepository extends ServiceEntityRepository
     public function getParticipantTypes(?array $opts = [], ?int $limit = null, ?int $offset = null): Collection
     {
         $result = $this->getQueryBuilder($opts ?? [], $limit, $offset)->getQuery()->getResult();
+        $rows = is_array($result)
+            ? array_values(array_filter($result, static fn (mixed $r): bool => $r instanceof ParticipantCategory))
+            : [];
+        // The DB ORDER BY uses utf8mb4_unicode_ci, which sorts Czech diacritics (Č/Š/Ř…) after Z.
+        // Re-sort by name with the Czech-aware collator so categories read alphabetically.
+        usort(
+            $rows,
+            static fn (ParticipantCategory $a, ParticipantCategory $b): int => StringUtils::compareCzech(
+                $a->getName(),
+                $b->getName(),
+            ),
+        );
 
-        return new ArrayCollection(is_array($result) ? $result : []);
+        return new ArrayCollection($rows);
     }
 }

--- a/Repository/Participant/ParticipantMailBulkRepository.php
+++ b/Repository/Participant/ParticipantMailBulkRepository.php
@@ -37,6 +37,27 @@ class ParticipantMailBulkRepository extends ServiceEntityRepository
         );
     }
 
+    /**
+     * Most recent bulks (any status), newest first — for the status page.
+     *
+     * @return list<ParticipantMailBulk>
+     */
+    public function findRecent(int $limit = 30): array
+    {
+        $rows = $this->createQueryBuilder('b')
+            ->orderBy('b.createdAt', 'DESC')
+            ->setMaxResults(max(1, $limit))
+            ->getQuery()
+            ->getResult();
+
+        return array_values(
+            array_filter(
+                is_array($rows) ? $rows : [],
+                static fn (mixed $row): bool => $row instanceof ParticipantMailBulk,
+            ),
+        );
+    }
+
     final public function findOneBy(array $criteria, ?array $orderBy = null): ?ParticipantMailBulk
     {
         $result = parent::findOneBy($criteria, $orderBy);

--- a/Repository/Participant/ParticipantMailBulkRepository.php
+++ b/Repository/Participant/ParticipantMailBulkRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OswisOrg\OswisCalendarBundle\Repository\Participant;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
+
+/** @extends ServiceEntityRepository<ParticipantMailBulk> */
+class ParticipantMailBulkRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ParticipantMailBulk::class);
+    }
+
+    /**
+     * Bulks that still need draining (queued or mid-flight), oldest first.
+     *
+     * @return list<ParticipantMailBulk>
+     */
+    public function findPending(int $limit = 20): array
+    {
+        $rows = $this->createQueryBuilder('b')
+            ->where('b.status != :done')
+            ->setParameter('done', ParticipantMailBulk::STATUS_DONE)
+            ->orderBy('b.createdAt', 'ASC')
+            ->setMaxResults(max(1, $limit))
+            ->getQuery()
+            ->getResult();
+
+        return array_values(
+            array_filter(
+                is_array($rows) ? $rows : [],
+                static fn (mixed $row): bool => $row instanceof ParticipantMailBulk,
+            ),
+        );
+    }
+
+    final public function findOneBy(array $criteria, ?array $orderBy = null): ?ParticipantMailBulk
+    {
+        $result = parent::findOneBy($criteria, $orderBy);
+
+        return $result instanceof ParticipantMailBulk ? $result : null;
+    }
+}

--- a/Repository/Participant/ParticipantMailGroupRepository.php
+++ b/Repository/Participant/ParticipantMailGroupRepository.php
@@ -51,8 +51,12 @@ class ParticipantMailGroupRepository extends ServiceEntityRepository
     {
         $queryBuilder = $this->createQueryBuilder('mg')->setParameter('now', new DateTime());
         $queryBuilder->where("mg.automaticMailing = 1");
+        // Active-now window: start <= now <= end (inclusive), null = open-ended. The previous
+        // expression had inverted operators (:now < start, :now > end) AND broken precedence
+        // (A OR B AND C OR D), making it a near-no-op; grouped + corrected here. The entity-level
+        // isApplicableByDate re-check stays as defense-in-depth.
         $queryBuilder->andWhere(
-            "(mg.startDateTime IS NULL) OR (:now < mg.startDateTime) AND  (mg.endDateTime IS NULL) OR (:now > mg.endDateTime)"
+            "((mg.startDateTime IS NULL) OR (mg.startDateTime <= :now)) AND ((mg.endDateTime IS NULL) OR (mg.endDateTime >= :now))"
         );
         $queryBuilder->addOrderBy('mg.priority', 'DESC');
         if (null !== $event) {

--- a/Repository/Participant/ParticipantRepository.php
+++ b/Repository/Participant/ParticipantRepository.php
@@ -294,6 +294,40 @@ class ParticipantRepository extends ServiceEntityRepository
         return $participants;
     }
 
+    /**
+     * Load the given participants (by id) with their to-one associations (contact / event / appUser)
+     * fetch-joined — for the bulk-mail composer's recipient list + per-recipient preview. To-one joins
+     * + IN(:ids) is bounded (no row multiplication, no collection walking). Ordered by id for a stable
+     * list. {@see WebAdminBulkMailController::compose}.
+     *
+     * @param list<int> $ids
+     *
+     * @return list<Participant>
+     */
+    public function findByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+        $queryBuilder = $this->createQueryBuilder('participant')
+            ->select('participant, contact, event, contactAppUser')
+            ->leftJoin('participant.contact', 'contact')
+            ->leftJoin('contact.appUser', 'contactAppUser')
+            ->leftJoin('participant.event', 'event')
+            ->andWhere('participant.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->orderBy('participant.id', 'ASC');
+        $result = $queryBuilder->getQuery()->getResult();
+        $participants = [];
+        foreach (is_array($result) ? $result : [] as $participant) {
+            if ($participant instanceof Participant) {
+                $participants[] = $participant;
+            }
+        }
+
+        return $participants;
+    }
+
     private function setSuperEventQuery(QueryBuilder $queryBuilder, array $opts = []): void
     {
         if (!empty($opts[self::CRITERIA_EVENT]) && $opts[self::CRITERIA_EVENT] instanceof Event) {

--- a/Repository/Participant/ParticipantRepository.php
+++ b/Repository/Participant/ParticipantRepository.php
@@ -18,6 +18,7 @@ use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory;
+use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationOffer;
 use OswisOrg\OswisCoreBundle\Entity\AppUser\AppUser;
 
@@ -214,6 +215,50 @@ class ParticipantRepository extends ServiceEntityRepository
         }
 
         return $out;
+    }
+
+    /**
+     * IDs of participants of $event (+ recursive sub-events to $recursiveDepth) that have NOT yet
+     * been sent a mail of $type, capped at $limit. SQL-side dedup (correlated NOT EXISTS) + a true
+     * LIMIT on an id-only query (no fetch-joins) → no whole-cohort hydration and no lazy-collection
+     * N+1 (the bug in the old load-all → PHP filter(hasEMailOfType) → slice path). {@see ParticipantService::sendAutoMails}.
+     *
+     * @return list<int>
+     */
+    public function findUnmailedParticipantIds(
+        Event $event,
+        string $type,
+        int $limit,
+        int $recursiveDepth = 4,
+        bool $includeDeleted = false,
+    ): array {
+        $qb = $this->createQueryBuilder('p')->select('p.id');
+        // Recursive event scope (to-one superEvent joins → no row multiplication; not selected).
+        $qb->leftJoin('p.event', 'e0');
+        $eventOr = 'p.event = :ev';
+        for ($i = 0; $i < max(0, $recursiveDepth); $i++) {
+            $j = $i + 1;
+            $qb->leftJoin("e$i.superEvent", "e$j");
+            $eventOr .= " OR e$j = :ev";
+        }
+        $qb->andWhere($eventOr)->setParameter('ev', $event->getId());
+        if (!$includeDeleted) {
+            $qb->andWhere('p.deletedAt IS NULL');
+        }
+        // Already-sent dedup, SQL-side (failed rows with sent IS NULL are NOT excluded → retried).
+        $qb->andWhere(
+            'NOT EXISTS (SELECT 1 FROM '.ParticipantMail::class.' pm WHERE pm.participant = p AND pm.type = :mailType AND pm.sent IS NOT NULL)',
+        )->setParameter('mailType', $type);
+        $qb->orderBy('p.id', 'ASC')->setMaxResults(max(1, $limit));
+
+        $ids = [];
+        foreach ($qb->getQuery()->getScalarResult() as $row) {
+            if (is_array($row) && isset($row['id']) && is_numeric($row['id'])) {
+                $ids[] = (int) $row['id'];
+            }
+        }
+
+        return $ids;
     }
 
     private function setSuperEventQuery(QueryBuilder $queryBuilder, array $opts = []): void

--- a/Repository/Participant/ParticipantRepository.php
+++ b/Repository/Participant/ParticipantRepository.php
@@ -223,6 +223,11 @@ class ParticipantRepository extends ServiceEntityRepository
      * LIMIT on an id-only query (no fetch-joins) → no whole-cohort hydration and no lazy-collection
      * N+1 (the bug in the old load-all → PHP filter(hasEMailOfType) → slice path). {@see ParticipantService::sendAutoMails}.
      *
+     * $afterId is a pagination cursor (only ids > $afterId, they are returned ASC): callers whose
+     * PHP-side checks (group filter expression, isActive) reject candidates MUST page with it —
+     * permanently-rejected ids never become "mailed", so without the cursor they would clog the
+     * LIMIT window forever and recipients beyond it would never be reached.
+     *
      * @return list<int>
      */
     public function findUnmailedParticipantIds(
@@ -231,8 +236,12 @@ class ParticipantRepository extends ServiceEntityRepository
         int $limit,
         int $recursiveDepth = 4,
         bool $includeDeleted = false,
+        int $afterId = 0,
     ): array {
         $qb = $this->createQueryBuilder('p')->select('p.id');
+        if ($afterId > 0) {
+            $qb->andWhere('p.id > :afterId')->setParameter('afterId', $afterId);
+        }
         // Recursive event scope (to-one superEvent joins → no row multiplication; not selected).
         $qb->leftJoin('p.event', 'e0');
         $eventOr = 'p.event = :ev';

--- a/Repository/Participant/ParticipantRepository.php
+++ b/Repository/Participant/ParticipantRepository.php
@@ -12,9 +12,9 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
-use Excparticipanttion;
 use LogicException;
 use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
+use OswisOrg\OswisAddressBookBundle\Entity\Person;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantCategory;
@@ -259,6 +259,39 @@ class ParticipantRepository extends ServiceEntityRepository
         }
 
         return $ids;
+    }
+
+    /**
+     * The $limit most recently created active, event-bound participants, with their to-one
+     * associations (contact / event / contactAppUser) fetch-joined so the preview sample-recipient
+     * picker can show a name + event without lazy N+1. To-one joins + LIMIT is pagination-safe (no row
+     * multiplication), unlike fetch-joining the to-many collections. Filters keep the picker on real
+     * recipients: a Person (recipient-facing mail goes to people, not the organizer Organization)
+     * registered to an event. {@see MailPreviewService::pickSampleParticipant}.
+     *
+     * @return list<Participant>
+     */
+    public function findSampleParticipants(int $limit = 30): array
+    {
+        $queryBuilder = $this->createQueryBuilder('participant')
+            ->select('participant, contact, event, contactAppUser')
+            ->leftJoin('participant.contact', 'contact')
+            ->leftJoin('contact.appUser', 'contactAppUser')
+            ->leftJoin('participant.event', 'event')
+            ->andWhere('participant.deletedAt IS NULL')
+            ->andWhere('participant.event IS NOT NULL')
+            ->andWhere('contact INSTANCE OF '.Person::class)
+            ->orderBy('participant.id', 'DESC')
+            ->setMaxResults(max(1, $limit));
+        $result = $queryBuilder->getQuery()->getResult();
+        $participants = [];
+        foreach (is_array($result) ? $result : [] as $participant) {
+            if ($participant instanceof Participant) {
+                $participants[] = $participant;
+            }
+        }
+
+        return $participants;
     }
 
     private function setSuperEventQuery(QueryBuilder $queryBuilder, array $opts = []): void

--- a/Repository/Registration/RegistrationFlagOfferRepository.php
+++ b/Repository/Registration/RegistrationFlagOfferRepository.php
@@ -13,6 +13,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Exception;
 use LogicException;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagOffer;
+use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 
 class RegistrationFlagOfferRepository extends ServiceEntityRepository
 {
@@ -104,7 +105,19 @@ class RegistrationFlagOfferRepository extends ServiceEntityRepository
     public function getFlagRanges(?array $opts = [], ?int $limit = null, ?int $offset = null): Collection
     {
         $result = $this->getQueryBuilder($opts ?? [], $limit, $offset)->getQuery()->getResult();
+        $rows = is_array($result)
+            ? array_values(array_filter($result, static fn (mixed $r): bool => $r instanceof RegistrationFlagOffer))
+            : [];
+        // The DB ORDER BY uses utf8mb4_unicode_ci, which sorts Czech diacritics (Č/Š/Ř…) after Z.
+        // Re-sort by name with the Czech-aware collator so the flag catalog reads alphabetically.
+        usort(
+            $rows,
+            static fn (RegistrationFlagOffer $a, RegistrationFlagOffer $b): int => StringUtils::compareCzech(
+                $a->getName(),
+                $b->getName(),
+            ),
+        );
 
-        return new ArrayCollection(is_array($result) ? $result : []);
+        return new ArrayCollection($rows);
     }
 }

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -400,6 +400,11 @@ oswis_org_oswis_calendar_web_admin_mail_category_edit:
     id: '\d+'
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_mail_template_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::newTemplate
+  path: "/web_admin/e-maily/sablony/nova"
+  methods: [GET, POST]
+
 oswis_org_oswis_calendar_web_admin_mail_template_edit:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::editTemplate
   path: "/web_admin/e-maily/sablony/{id}/upravit"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -191,6 +191,7 @@ oswis_org_oswis_calendar_web_admin_participant_payments_import:
 oswis_org_oswis_calendar_web_admin_participant_send_automails:
   controller: oswis_org_oswis_calendar.web_admin.participants_controller::sendAutoMails
   path: "/web_admin/prihlasky/send-automails/{limit?}/{type?}"
+  methods: [POST]
 
 oswis_org_oswis_calendar_web_admin_participant_arrival:
   controller: oswis_org_oswis_calendar.web_admin.participants_controller::arrival

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -193,6 +193,32 @@ oswis_org_oswis_calendar_web_admin_participant_send_automails:
   path: "/web_admin/prihlasky/send-automails/{limit?}/{type?}"
   methods: [POST]
 
+# Ad-hoc bulk e-mail (Fáze G Ink.2a): compose → preview → queue → status (JS auto-drain).
+oswis_org_oswis_calendar_web_admin_bulk_mail_compose:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController::compose
+  path: "/web_admin/prihlasky/hromadny-email"
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_bulk_mail_preview:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController::preview
+  path: "/web_admin/prihlasky/hromadny-email/nahled"
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_bulk_mail_queue:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController::queue
+  path: "/web_admin/prihlasky/hromadny-email/zaradit"
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_bulk_mail_status:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController::status
+  path: "/web_admin/prihlasky/hromadne-emaily"
+  methods: [GET]
+
+oswis_org_oswis_calendar_web_admin_bulk_mail_drain:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController::drain
+  path: "/web_admin/prihlasky/hromadny-email/odeslat-davku"
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_participant_arrival:
   controller: oswis_org_oswis_calendar.web_admin.participants_controller::arrival
   path: "/web_admin/prijezd/{participantId}/{arrival?}"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -406,3 +406,10 @@ oswis_org_oswis_calendar_web_admin_mail_template_edit:
   requirements:
     id: '\d+'
   methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_mail_template_preview:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::previewTemplate
+  path: "/web_admin/e-maily/sablony/{id}/nahled"
+  requirements:
+    id: '\d+'
+  methods: [POST]

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -110,6 +110,11 @@ oswis_org_oswis_calendar_web_admin_participants_list_csv:
   path: "/web_admin/seznam-prihlasek-csv"
   methods: [GET]
 
+oswis_org_oswis_calendar_web_admin_participants_list_pdf:
+  controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showParticipantsListPdf
+  path: "/web_admin/seznam-prihlasek-pdf"
+  methods: [GET]
+
 oswis_org_oswis_calendar_web_admin_event:
   controller: oswis_org_oswis_calendar.web_admin.participants_list_controller::showEvent
   path: "/web_admin/udalost/{eventSlug?}"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -301,6 +301,16 @@ oswis_org_oswis_calendar_web_admin_bulk_reassign:
   path: "/web_admin/prihlasky/hromadny-presun"
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_bulk_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkParticipantsController::delete
+  path: "/web_admin/prihlasky/hromadne-smazat"
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_bulk_export:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkParticipantsController::export
+  path: "/web_admin/prihlasky/hromadny-export"
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_communication_index:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminCommunicationController::index
   path: "/web_admin/komunikace"

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -669,6 +669,14 @@ services:
       - '@doctrine.orm.entity_manager'
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository'
 
+  ## Unified e-mail preview (bulk composer + #139 template editor)
+  OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService:
+    autowire: true
+    public: true
+    arguments:
+      - '@twig'
+      - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository'
+
   ## Bulk e-mail outbox: drain service + cron command
   OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService:
     autowire: true

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -93,6 +93,11 @@ services:
     autoconfigure: true
     public: true
 
+  OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminBulkMailController:
+    autowire: true
+    autoconfigure: true
+    public: true
+
   OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminManualNoteController:
     autowire: true
     autoconfigure: true

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -474,6 +474,15 @@ services:
     tags:
       - 'doctrine.repository_service'
 
+  OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository:
+    class: OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository
+    autowire: true
+    public: true
+    arguments:
+      - '@doctrine'
+    tags:
+      - 'doctrine.repository_service'
+
   ###
   ### SUBSCRIBERS
   ###
@@ -654,3 +663,25 @@ services:
     arguments:
       - '@doctrine.orm.entity_manager'
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository'
+
+  ## Bulk e-mail outbox: drain service + cron command
+  OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService:
+    autowire: true
+    public: true
+    arguments:
+      - '@doctrine.orm.entity_manager'
+      - '@oswis_org_oswis_core.mail_service'
+      - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository'
+      - '@monolog.logger'
+  oswis_org_oswis_calendar.participant.bulk_mail_service:
+    alias: OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService
+    public: true
+
+  OswisOrg\OswisCalendarBundle\Command\SendMailCommand:
+    autowire: true
+    autoconfigure: true
+    arguments:
+      - '@OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService'
+      - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository'
+      - '@oswis_org_oswis_calendar.participant.participant_service'
+    tags: [ 'console.command' ]

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -685,6 +685,7 @@ services:
       - '@doctrine.orm.entity_manager'
       - '@oswis_org_oswis_core.mail_service'
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository'
+      - '@OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService'
       - '@monolog.logger'
   oswis_org_oswis_calendar.participant.bulk_mail_service:
     alias: OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantBulkMailService

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -342,9 +342,14 @@ services:
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailGroupRepository'
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailCategoryRepository'
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository'
+      - '@OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantChangeService'
       - '@monolog.logger'
   OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantMailService:
     alias: oswis_org_oswis_calendar.participant.participant_mail_service
+    public: true
+
+  OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantChangeService:
+    autowire: true
     public: true
 
   oswis_org_oswis_calendar.participant.participant_category_service:

--- a/Resources/views/bundles/ZakjakubOswisCoreBundle/web_admin/web-admin-homepage.html.twig
+++ b/Resources/views/bundles/ZakjakubOswisCoreBundle/web_admin/web-admin-homepage.html.twig
@@ -9,7 +9,13 @@
             <a href="{{ path('oswis_org_oswis_calendar_update_participants') }}">Aktualizace DB přihlášek</a>
         </li>
         <li>
-            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participant_send_automails') }}">Odeslat e-maily</a>
+            {# POST + CSRF + potvrzení — rozesílá reálné e-maily, dřív to byl CSRF-able GET. #}
+            <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_participant_send_automails') }}"
+                  style="display:inline;"
+                  onsubmit="return confirm('Rozeslat automatické e-maily (dávka 100) reálným příjemcům?');">
+                <input type="hidden" name="_token" value="{{ csrf_token('send_automails') }}">
+                <button type="submit" class="btn btn-link p-0 align-baseline" style="text-decoration:underline;">Odeslat e-maily</button>
+            </form>
         </li>
     </ul>
 

--- a/Resources/views/e-mail/pages/participant-registration-changed.html.twig
+++ b/Resources/views/e-mail/pages/participant-registration-changed.html.twig
@@ -1,0 +1,42 @@
+{% extends '@OswisOrgOswisCore/e-mail/pages/message.html.twig' %}
+
+{# On-update change notice. Variables (set in PHP `$data`, see ParticipantMailService::sendRegistrationChanged):
+     - participant / appUser / contact / salutationName: as in every participant mail
+     - changes: {
+         flags: { '<category>': { added: [...], removed: [...] } },
+         registrationsAdded: [...], registrationsRemoved: [...], contactUpdated: bool
+       } — the diff since the last confirmation (ParticipantChangeService::computeChanges)
+   f / a / salName come from the base message.html.twig.
+#}
+
+{% block content_inner %}
+    <p>
+        V tvé přihlášce{% if participant.event(false) %} na akci <strong>{{ participant.event(false).name }}</strong>{% endif %}
+        došlo k těmto změnám:
+    </p>
+    <ul>
+        {% for category, change in changes.flags %}
+            {% for item in change.added %}
+                <li>{{ category }}: přidáno <strong>{{ item }}</strong></li>
+            {% endfor %}
+            {% for item in change.removed %}
+                <li>{{ category }}: odebráno <strong>{{ item }}</strong></li>
+            {% endfor %}
+        {% endfor %}
+        {% for item in changes.registrationsAdded %}
+            <li>Nová registrace: <strong>{{ item }}</strong></li>
+        {% endfor %}
+        {% for item in changes.registrationsRemoved %}
+            <li>Zrušená registrace: <strong>{{ item }}</strong></li>
+        {% endfor %}
+        {% if changes.contactUpdated %}
+            <li>Byly aktualizovány tvé kontaktní údaje.</li>
+        {% endif %}
+    </ul>
+    <p>Pokud tyto změny neprovedl{{ a }} {{ f ? 'Vy' : 'ty' }}, dej{{ f ? 'te' : '' }} nám prosím vědět odpovědí na tento e-mail.</p>
+{% endblock %}
+
+{% block content_footer_inner %}
+    Aktuální stav celé přihlášky najdeš{{ f ? 'te' : '' }} ve svém účtu.
+    V případě nejasností nás neváhej{{ f ? 'te' : '' }} kontaktovat odpovědí na tento e-mail.
+{% endblock %}

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -231,40 +231,57 @@
 
         <details class="d-inline-block ms-auto" style="position: relative;">
             <summary class="btn btn-sm btn-outline-primary py-0" style="cursor: pointer;">Export ▾</summary>
-            <form method="get"
-                  action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_csv') }}"
-                  class="card card-body shadow" style="position: absolute; z-index: 1000; min-width: 16rem; text-align: left;">
-                {# Scope as hidden fields — a GET form discards its action's query string. #}
-                {% for key, value in scopeParams %}
-                    {% if key not in ['sort', 'dir'] %}
-                        {% if value is iterable %}
-                            {% for item in value %}<input type="hidden" name="{{ key }}[]" value="{{ item }}">{% endfor %}
-                        {% else %}
-                            <input type="hidden" name="{{ key }}" value="{{ value }}">
+            <div class="card card-body shadow" style="position: absolute; z-index: 1000; min-width: 18rem; text-align: left;">
+                {# Rychlé provozní listy: jeden klik = předvolené sloupce + formát, ve stávajícím scope. #}
+                {% if exportPresets|default([]) is not empty %}
+                    <div class="small text-secondary mb-1">Rychlé provozní listy (PDF):</div>
+                    <div class="d-flex flex-wrap gap-1 mb-2">
+                        {% for preset in exportPresets %}
+                            <a class="btn btn-sm btn-outline-secondary py-0"
+                               href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_csv', scopeParams|merge({columns: preset.columns, format: preset.format})) }}">{{ preset.label }}</a>
+                        {% endfor %}
+                    </div>
+                    <hr style="margin: .4rem 0;">
+                {% endif %}
+                {# Vlastní výběr sloupců. #}
+                <div class="small text-secondary mb-1">Vlastní výběr sloupců:</div>
+                <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_csv') }}">
+                    {# Scope as hidden fields — a GET form discards its action's query string. #}
+                    {% for key, value in scopeParams %}
+                        {% if key not in ['sort', 'dir'] %}
+                            {% if value is iterable %}
+                                {% for item in value %}<input type="hidden" name="{{ key }}[]" value="{{ item }}">{% endfor %}
+                            {% else %}
+                                <input type="hidden" name="{{ key }}" value="{{ value }}">
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
-                {% endfor %}
-                <div style="max-height: 14rem; overflow: auto; margin-bottom: .5rem;">
-                    {% set exportColumns = {
-                        'id': 'ID', 'familyName': 'Příjmení', 'givenName': 'Křestní jméno', 'fullName': 'Celé jméno',
-                        'variableSymbol': 'Variabilní symbol', 'event': 'Akce', 'category': 'Kategorie',
-                        'email': 'E-mail', 'phone': 'Telefon', 'tShirt': 'Velikost trička', 'createdAt': 'Datum přihlášky',
-                        'activated': 'Aktivováno', 'price': 'Celková cena', 'paidPrice': 'Zaplaceno [Kč]',
-                        'remainingPrice': 'Zbývá [Kč]', 'paidPercentage': 'Zaplaceno [%]', 'deletedAt': 'Smazáno'
-                    } %}
-                    {% for key, label in exportColumns %}
-                        <label class="d-block small" style="font-weight: normal;"><input type="checkbox" name="columns[]" value="{{ key }}" checked> {{ label }}</label>
                     {% endfor %}
-                </div>
-                <label class="small d-block mb-2">Formát:
-                    <select name="format" class="form-select form-select-sm">
-                        <option value="csv">CSV (Excel)</option>
-                        <option value="csv-rfc">CSV (RFC 4180)</option>
-                        <option value="pdf">PDF</option>
-                    </select>
-                </label>
-                <button type="submit" class="btn btn-sm btn-primary">Exportovat</button>
-            </form>
+                    <div style="max-height: 14rem; overflow: auto; margin-bottom: .5rem;">
+                        {% set exportColumns = {
+                            'id': 'ID', 'familyName': 'Příjmení', 'givenName': 'Křestní jméno', 'fullName': 'Celé jméno',
+                            'variableSymbol': 'Variabilní symbol', 'event': 'Akce', 'category': 'Kategorie',
+                            'email': 'E-mail', 'phone': 'Telefon', 'tShirt': 'Velikost trička', 'createdAt': 'Datum přihlášky',
+                            'activated': 'Aktivováno', 'price': 'Celková cena', 'paidPrice': 'Zaplaceno [Kč]',
+                            'remainingPrice': 'Zbývá [Kč]', 'paidPercentage': 'Zaplaceno [%]', 'deletedAt': 'Smazáno'
+                        } %}
+                        {% for key, label in exportColumns %}
+                            <label class="d-block small" style="font-weight: normal;"><input type="checkbox" name="columns[]" value="{{ key }}" checked> {{ label }}</label>
+                        {% endfor %}
+                        {# Flag-derived provozní sloupce — výchozí nezaškrtnuté. #}
+                        {% for key, label in {'accommodation': 'Ubytování', 'food': 'Strava'} %}
+                            <label class="d-block small" style="font-weight: normal;"><input type="checkbox" name="columns[]" value="{{ key }}"> {{ label }}</label>
+                        {% endfor %}
+                    </div>
+                    <label class="small d-block mb-2">Formát:
+                        <select name="format" class="form-select form-select-sm">
+                            <option value="csv">CSV (Excel)</option>
+                            <option value="csv-rfc">CSV (RFC 4180)</option>
+                            <option value="pdf">PDF</option>
+                        </select>
+                    </label>
+                    <button type="submit" class="btn btn-sm btn-primary">Exportovat</button>
+                </form>
+            </div>
         </details>
         {% if is_granted('ROLE_ADMIN') %}
             <a class="small text-secondary" href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}">hromadný přesun</a>

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -7,12 +7,26 @@
 <div class="container participants-page">
 
     {# ---- PAGE TITLE ----------------------------------------------------- #}
-    <h1 class="h3 mb-2 mt-1">Přehled přihlášek</h1>
+    <div class="d-flex align-items-center gap-2 mb-2 mt-1">
+        <h1 class="h3 m-0">Přehled přihlášek</h1>
+        <button type="button" class="btn btn-sm btn-outline-primary py-0 ms-auto d-print-none"
+                onclick="window.print();" title="Vytisknout / uložit do PDF přes prohlížeč">🖨 Tisk</button>
+    </div>
+
+    {# Tisk-only shrnutí rozsahu (Omezení) — na obrazovce skryté, v tisku nahrazuje scope bar. #}
+    <div class="print-only mb-2">
+        <table class="table table-sm table-bordered" style="width:auto;">
+            <tr><th colspan="2" class="bg-light">Omezení výběru</th></tr>
+            <tr><td class="text-secondary">Kategorie účastníka</td><td><strong>{{ participantCategory.name|default('— všechny typy —') }}</strong></td></tr>
+            <tr><td class="text-secondary">Událost</td><td><strong>{% if events|default([]) is empty %}všechny akce{% else %}{{ events|map(e => e.shortName|default(e.name))|join(', ') }}{% endif %}</strong></td></tr>
+            <tr><td class="text-secondary">Počet záznamů</td><td><strong>{{ participants|length }}</strong></td></tr>
+        </table>
+    </div>
 
     {# ---- SCOPE BAR — one event picker (year → turnus → all events) + the
            category switcher, grouped into a subtle toolbar so the whole scope
            reads as one clear zone instead of scattered chips + links. ------- #}
-    <div class="d-flex flex-wrap align-items-center gap-2 mb-3 px-2 py-2"
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-3 px-2 py-2 d-print-none"
          style="background:#f4f7fa; border:1px solid #e3e9f0; border-radius:6px;">
         <span class="small text-secondary fw-bold">Akce:</span>
         <select class="form-select form-select-sm w-auto" title="Výběr akce"
@@ -47,7 +61,7 @@
            insensitive. Carries the current scope + filter + flags as hidden fields so the search
            narrows *within* what's already shown. #}
         <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}"
-              class="d-flex align-items-center gap-1 ms-auto" role="search">
+              class="d-flex align-items-center gap-1 ms-auto d-print-none" role="search">
             {% for key, value in scopeParams %}
                 {% if key != 'q' %}
                     {% if value is iterable %}
@@ -93,7 +107,7 @@
             form.submit();
         }
     </script>
-    <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="mb-2"
+    <form method="get" action="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="mb-2 d-print-none"
           onsubmit="oswisStripEmptyFilter(this);">
         {% for key, value in scopeParams %}
             {% if key != 'depth' %}
@@ -225,7 +239,7 @@
     {% endif %}
 
     {# ---- LIST TOOLBAR (count + sort + export) --------------------------- #}
-    <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-1 d-print-none">
         <strong>{{ participants|length }}</strong> <span class="small text-secondary">přihlášek</span>
         {# Řazení je v klikacím záhlaví tabulky (▲/▼), proto tu dropdown „řadit" už není. #}
 
@@ -413,6 +427,20 @@
         @media (max-width: 820px) {
             .participants-page .participants-table-wrap > table.participant-list { min-width: 760px; }
         }
+        /* Tisk z prohlížeče: čistá stránka jako přehledové PDF — skrýt ovládací prvky a sloupec
+           akcí, celé řádky na jedné stránce, bez vodorovného scrollu. (Nav menu skryto skeletonem.) */
+        .print-only { display: none; }
+        @media print {
+            .print-only { display: block !important; }
+            .participants-page .actions { display: none !important; }
+            .participants-page .oswis-typeahead { display: none !important; }
+            .participants-page .participants-table-wrap { overflow: visible !important; }
+            .participants-page table.participant-list { min-width: 0 !important; font-size: 8pt; }
+            .participants-page table.participant-list tbody tr { page-break-inside: avoid; }
+            .participants-page table.participant-list thead th { background: #006FAD !important; color: #fff !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            /* zajistit tisk barev příznaků/badge */
+            .participants-page * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+        }
     </style>
     {# Scroll wrapper: on narrow screens (tablet/mobile) the dense 5-column table scrolls
        horizontally instead of crushing the columns. No effect on wide screens. #}
@@ -429,7 +457,7 @@
 
     {# ---- PAGINATION (unscoped paginated view) --------------------------- #}
     {% if pagination|default %}
-        <nav class="mt-2 d-flex gap-2 align-items-center">
+        <nav class="mt-2 d-flex gap-2 align-items-center d-print-none">
             {% if pagination.hasPrev %}
                 <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', qbase|merge({page: pagination.page - 1})) }}">← Předchozí</a>
             {% endif %}
@@ -446,7 +474,7 @@
        the textarea makes select-all + copy easy. #}
     {% set emails = participants|map(p => p.contact.email|default(''))|filter(e => e != '') %}
     {% if emails|length %}
-        <details class="mt-3">
+        <details class="mt-3 d-print-none">
             <summary style="cursor:pointer;">📋 E-mailové adresy pro hromadné rozeslání ({{ emails|length }})</summary>
             <textarea readonly rows="3" class="form-control form-control-sm mt-1" style="font-size:.8rem;"
                       onclick="this.select();">{{ emails|join(', ') }}</textarea>

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -435,7 +435,13 @@
             .participants-page .actions { display: none !important; }
             .participants-page .oswis-typeahead { display: none !important; }
             .participants-page .participants-table-wrap { overflow: visible !important; }
-            .participants-page table.participant-list { min-width: 0 !important; font-size: 8pt; }
+            .participants-page table.participant-list { min-width: 0 !important; font-size: 8pt;
+                table-layout: auto !important; word-break: normal !important; }
+            /* Badge se nesmí lámat po písmenech (úzký sloupec + fixed layout to dělalo). */
+            .participants-page .oswis-flag-badge,
+            .participants-page .oswis-flag-badge .ofb-name,
+            .participants-page .oswis-flag-badge .ofb-price,
+            .participants-page .oswis-flag-badge .ofb-text { white-space: nowrap !important; word-break: normal !important; }
             .participants-page table.participant-list tbody tr { page-break-inside: avoid; }
             .participants-page table.participant-list thead th { background: #006FAD !important; color: #fff !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
             /* zajistit tisk barev příznaků/badge */

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -468,6 +468,7 @@
         <div id="bulkBar" class="bulk-bar is-empty d-print-none"
              data-export-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_export') }}"
              data-delete-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_delete') }}"
+             data-reassign-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}"
              data-csrf-export="{{ csrf_token('bulk_export') }}"
              data-csrf-delete="{{ csrf_token('bulk_delete') }}"
              data-return="{{ app.request.requestUri }}">
@@ -475,6 +476,7 @@
             <span class="bulk-actions">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="csv" disabled>⬇ Export (CSV)</button>
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="pdf" disabled>⬇ Export (PDF)</button>
+                <button type="button" class="btn btn-sm btn-outline-warning" data-bulk-action="reassign" disabled>↪ Přesunout</button>
                 <button type="button" class="btn btn-sm btn-outline-danger" data-bulk-action="delete" disabled>🗑 Smazat vybrané</button>
             </span>
             <span class="bulk-hint small text-secondary">Zaškrtni řádky vlevo — operace platí jen pro vybrané přihlášky.</span>
@@ -553,14 +555,15 @@
             document.addEventListener('change', function (e) {
                 if (e.target && e.target.classList && e.target.classList.contains('bulk-row-check')) { refresh(); }
             });
-            function submitBulk(url, csrf, ids, extra) {
+            function submitBulk(url, csrf, ids, extra, idField) {
                 var f = document.createElement('form');
                 f.method = 'post';
                 f.action = url;
                 function hidden(name, value) { var i = document.createElement('input'); i.type = 'hidden'; i.name = name; i.value = value; f.appendChild(i); }
-                hidden('_token', csrf);
+                if (csrf) { hidden('_token', csrf); }
                 hidden('return', bar.getAttribute('data-return') || '');
-                ids.forEach(function (id) { hidden('ids[]', id); });
+                var field = (idField || 'ids') + '[]';
+                ids.forEach(function (id) { hidden(field, id); });
                 if (extra) { Object.keys(extra).forEach(function (k) { hidden(k, extra[k]); }); }
                 document.body.appendChild(f);
                 f.submit();
@@ -572,6 +575,8 @@
                     var action = btn.getAttribute('data-bulk-action');
                     if (action === 'export') {
                         submitBulk(bar.getAttribute('data-export-url'), bar.getAttribute('data-csrf-export'), ids, { format: btn.getAttribute('data-format') || 'csv' });
+                    } else if (action === 'reassign') {
+                        submitBulk(bar.getAttribute('data-reassign-url'), '', ids, null, 'preselectIds');
                     } else if (action === 'delete') {
                         if (ids.length > HARD_CAP_DELETE) { window.alert('Najednou lze smazat nejvýše ' + HARD_CAP_DELETE + ' přihlášek (vybráno ' + ids.length + ').'); return; }
                         if (!window.confirm('Smazat ' + ids.length + ' vybraných přihlášek? (lze obnovit)')) { return; }

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -448,17 +448,46 @@
             .participants-page table.participant-list thead th { background: #006FAD !important; color: #fff !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
             /* zajistit tisk barev příznaků/badge */
             .participants-page * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+            /* bulk bar nemá smysl v tisku */
+            .participants-page .bulk-bar, .participants-page .bulk-col { display: none !important; }
         }
+        /* Bulk-action bar (Fáze G): vždy přítomný; zašedlý + disabled, dokud není ≥1 řádek vybrán. */
+        .participants-page .bulk-bar { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
+            margin: .4rem 0 .5rem; padding: .4rem .65rem; border: 1px solid #cdd9e5; border-radius: 6px;
+            background: #f4f8fc; transition: opacity .12s ease; }
+        .participants-page .bulk-bar.is-empty { opacity: .5; }
+        .participants-page .bulk-bar .bulk-count { font-size: .85rem; }
+        .participants-page .bulk-bar .bulk-hint { margin-left: auto; }
+        .participants-page .bulk-bar button[disabled] { cursor: not-allowed; }
     </style>
     {# Scroll wrapper: on narrow screens (tablet/mobile) the dense 5-column table scrolls
        horizontally instead of crushing the columns. No effect on wide screens. #}
+    {# ---- BULK ACTION BAR (Fáze G) — persistentní; zašedlý/disabled, dokud není ≥1 řádek vybrán.
+         JS posbírá zaškrtnutá ID a sestaví skrytý POST formulář (vyhne se vnořeným formulářům v řádcích). #}
+    {% if is_granted('ROLE_ADMIN') %}
+        <div id="bulkBar" class="bulk-bar is-empty d-print-none"
+             data-export-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_export') }}"
+             data-delete-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_delete') }}"
+             data-csrf-export="{{ csrf_token('bulk_export') }}"
+             data-csrf-delete="{{ csrf_token('bulk_delete') }}"
+             data-return="{{ app.request.requestUri }}">
+            <span class="bulk-count">Vybráno: <strong id="bulkCount">0</strong></span>
+            <span class="bulk-actions">
+                <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="csv" disabled>⬇ Export (CSV)</button>
+                <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="pdf" disabled>⬇ Export (PDF)</button>
+                <button type="button" class="btn btn-sm btn-outline-danger" data-bulk-action="delete" disabled>🗑 Smazat vybrané</button>
+            </span>
+            <span class="bulk-hint small text-secondary">Zaškrtni řádky vlevo — operace platí jen pro vybrané přihlášky.</span>
+        </div>
+    {% endif %}
+
     <div class="participants-table-wrap">
     <table class="list participant-list" style="table-layout: fixed; word-break: break-word;">
         {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-head.html.twig' %}
         {% for participant in participants %}
             {% include '@OswisOrgOswisCalendar/other/participant-list/parts/participant-list-inner.html.twig' %}
         {% else %}
-            <tbody><tr><td colspan="5" class="text-center bold">Žádné přihlášky odpovídající filtru.</td></tr></tbody>
+            <tbody><tr><td colspan="{{ is_granted('ROLE_ADMIN') ? 6 : 5 }}" class="text-center bold">Žádné přihlášky odpovídající filtru.</td></tr></tbody>
         {% endfor %}
     </table>
     </div>
@@ -489,6 +518,70 @@
             <div class="small text-secondary mt-1">Klikni do pole (vše se označí) a zkopíruj (Ctrl+C) do pole příjemců v e-mailovém klientovi.</div>
         </details>
     {% endif %}
+
+    {# Bulk-action bar wiring (Fáze G): track checked rows, toggle the persistent bar's enabled
+       state, and on a bulk button build+submit a hidden POST form with the checked IDs (avoids
+       nesting a form around the per-row delete/restore forms). Cap mirrors the reassign wizard. #}
+    <script>
+        (function () {
+            var bar = document.getElementById('bulkBar');
+            if (!bar) { return; }
+            var all = document.getElementById('bulkSelectAll');
+            var count = document.getElementById('bulkCount');
+            var actionBtns = [].slice.call(bar.querySelectorAll('[data-bulk-action]'));
+            var HARD_CAP_DELETE = 100;
+            function checks() { return [].slice.call(document.querySelectorAll('.bulk-row-check')); }
+            function checkedIds() { return checks().filter(function (c) { return c.checked; }).map(function (c) { return c.value; }); }
+            function refresh() {
+                var ids = checkedIds();
+                if (count) { count.textContent = String(ids.length); }
+                var empty = ids.length === 0;
+                bar.classList.toggle('is-empty', empty);
+                actionBtns.forEach(function (b) { b.disabled = empty; });
+                if (all) {
+                    var cs = checks();
+                    all.checked = cs.length > 0 && ids.length === cs.length;
+                    all.indeterminate = ids.length > 0 && ids.length < cs.length;
+                }
+            }
+            if (all) {
+                all.addEventListener('change', function () {
+                    checks().forEach(function (c) { c.checked = all.checked; });
+                    refresh();
+                });
+            }
+            document.addEventListener('change', function (e) {
+                if (e.target && e.target.classList && e.target.classList.contains('bulk-row-check')) { refresh(); }
+            });
+            function submitBulk(url, csrf, ids, extra) {
+                var f = document.createElement('form');
+                f.method = 'post';
+                f.action = url;
+                function hidden(name, value) { var i = document.createElement('input'); i.type = 'hidden'; i.name = name; i.value = value; f.appendChild(i); }
+                hidden('_token', csrf);
+                hidden('return', bar.getAttribute('data-return') || '');
+                ids.forEach(function (id) { hidden('ids[]', id); });
+                if (extra) { Object.keys(extra).forEach(function (k) { hidden(k, extra[k]); }); }
+                document.body.appendChild(f);
+                f.submit();
+            }
+            actionBtns.forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    var ids = checkedIds();
+                    if (ids.length === 0) { return; }
+                    var action = btn.getAttribute('data-bulk-action');
+                    if (action === 'export') {
+                        submitBulk(bar.getAttribute('data-export-url'), bar.getAttribute('data-csrf-export'), ids, { format: btn.getAttribute('data-format') || 'csv' });
+                    } else if (action === 'delete') {
+                        if (ids.length > HARD_CAP_DELETE) { window.alert('Najednou lze smazat nejvýše ' + HARD_CAP_DELETE + ' přihlášek (vybráno ' + ids.length + ').'); return; }
+                        if (!window.confirm('Smazat ' + ids.length + ' vybraných přihlášek? (lze obnovit)')) { return; }
+                        submitBulk(bar.getAttribute('data-delete-url'), bar.getAttribute('data-csrf-delete'), ids, null);
+                    }
+                });
+            });
+            refresh();
+        })();
+    </script>
 
     {# Instant typeahead over the rows already on the page: previews/jumps to a participant.
        Real filtering stays server-side (Enter without a highlighted suggestion submits ?q=).

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -471,11 +471,14 @@
              data-reassign-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign') }}"
              data-csrf-export="{{ csrf_token('bulk_export') }}"
              data-csrf-delete="{{ csrf_token('bulk_delete') }}"
+             data-mail-url="{{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_compose') }}"
+             data-csrf-mail="{{ csrf_token('bulk_mail') }}"
              data-return="{{ app.request.requestUri }}">
             <span class="bulk-count">Vybráno: <strong id="bulkCount">0</strong></span>
             <span class="bulk-actions">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="csv" disabled>⬇ Export (CSV)</button>
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bulk-action="export" data-format="pdf" disabled>⬇ Export (PDF)</button>
+                <button type="button" class="btn btn-sm btn-outline-success" data-bulk-action="mail" disabled>✉ Hromadný e-mail</button>
                 <button type="button" class="btn btn-sm btn-outline-warning" data-bulk-action="reassign" disabled>↪ Přesunout</button>
                 <button type="button" class="btn btn-sm btn-outline-danger" data-bulk-action="delete" disabled>🗑 Smazat vybrané</button>
             </span>
@@ -575,6 +578,8 @@
                     var action = btn.getAttribute('data-bulk-action');
                     if (action === 'export') {
                         submitBulk(bar.getAttribute('data-export-url'), bar.getAttribute('data-csrf-export'), ids, { format: btn.getAttribute('data-format') || 'csv' });
+                    } else if (action === 'mail') {
+                        submitBulk(bar.getAttribute('data-mail-url'), bar.getAttribute('data-csrf-mail'), ids, null);
                     } else if (action === 'reassign') {
                         submitBulk(bar.getAttribute('data-reassign-url'), '', ids, null, 'preselectIds');
                     } else if (action === 'delete') {

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -438,10 +438,12 @@
             .participants-page table.participant-list { min-width: 0 !important; font-size: 8pt;
                 table-layout: auto !important; word-break: normal !important; }
             /* Badge se nesmí lámat po písmenech (úzký sloupec + fixed layout to dělalo). */
-            .participants-page .oswis-flag-badge,
             .participants-page .oswis-flag-badge .ofb-name,
             .participants-page .oswis-flag-badge .ofb-price,
             .participants-page .oswis-flag-badge .ofb-text { white-space: nowrap !important; word-break: normal !important; }
+            /* Každý příznak na vlastním řádku, pilulka hugging obsah (jako referenční PDF). */
+            .participants-page .oswis-flag-badge { display: flex !important; width: -moz-fit-content !important;
+                width: fit-content !important; white-space: nowrap !important; margin: 0 0 2px 0 !important; }
             .participants-page table.participant-list tbody tr { page-break-inside: avoid; }
             .participants-page table.participant-list thead th { background: #006FAD !important; color: #fff !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
             /* zajistit tisk barev příznaků/badge */

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -232,6 +232,9 @@
         <details class="d-inline-block ms-auto" style="position: relative;">
             <summary class="btn btn-sm btn-outline-primary py-0" style="cursor: pointer;">Export ▾</summary>
             <div class="card card-body shadow" style="position: absolute; z-index: 1000; min-width: 18rem; text-align: left;">
+                {# Přehledový PDF: bohatý „prohlížecí" seznam jako na obrazovce (příznaky, platba, poznámky). #}
+                <a class="btn btn-sm btn-primary mb-2"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list_pdf', scopeParams) }}">📄 Přehledový PDF (jako na obrazovce)</a>
                 {# Rychlé provozní listy: jeden klik = předvolené sloupce + formát, ve stávajícím scope. #}
                 {% if exportPresets|default([]) is not empty %}
                     <div class="small text-secondary mb-1">Rychlé provozní listy (PDF):</div>

--- a/Resources/views/other/participant-list/parts/participant-list-head.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-head.html.twig
@@ -11,7 +11,13 @@
 
 <thead>
 <tr>
-    <th style="width: 18%;">
+    {% if is_granted('ROLE_ADMIN') %}
+        {# Bulk-select column (Fáze G). Header checkbox = select/deselect all rendered rows. #}
+        <th class="bulk-col" style="width: 3%; text-align: center; vertical-align: middle;">
+            <input type="checkbox" id="bulkSelectAll" title="Vybrat / odznačit vše na stránce" aria-label="Vybrat vše">
+        </th>
+    {% endif %}
+    <th style="width: 15%;">
         {{ _self.sortHeader('ID', 'id', sort|default('name'), dir|default('asc'), qbase) }}
         <span class="block small">{{ _self.sortHeader('Vytvořeno', 'created', sort|default('name'), dir|default('asc'), qbase) }}</span>
     </th>

--- a/Resources/views/other/participant-list/parts/participant-list-head.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-head.html.twig
@@ -26,7 +26,7 @@
         {{ _self.sortHeader('Zaplaceno', 'payment', sort|default('name'), dir|default('asc'), qbase) }}
         <span class="block small">{{ _self.sortHeader('Cena', 'price', sort|default('name'), dir|default('asc'), qbase) }}</span>
     </th>
-    <th style="width: 9%;">
+    <th class="actions" style="width: 9%;">
         Akce
     </th>
 </tr>

--- a/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
@@ -8,6 +8,13 @@
     data-ta-name="{{ participant.name|default(participant.cachedContact.name|default('#' ~ participant.id)) }}"
     data-ta-event="{{ event.shortName|default }}"
     data-ta-href="{{ path('oswis_org_oswis_calendar_web_admin_participant_detail', { participantId: participant.id }) }}">
+    {% if is_granted('ROLE_ADMIN') %}
+        {# Bulk-select checkbox (Fáze G). JS collects checked values into the bulk-action bar. #}
+        <td class="bulk-col" style="border: 1px solid grey; text-align: center; vertical-align: middle;">
+            <input type="checkbox" class="bulk-row-check" value="{{ participant.id }}"
+                   aria-label="Vybrat přihlášku #{{ participant.id }}">
+        </td>
+    {% endif %}
     <td style="border: 1px solid grey; padding: .3em .6em; text-align: right;">
         {% if participant.deletedAt|default %}
             <div class="block small" style="color:red;">

--- a/Resources/views/other/summary/participant-summary.html.twig
+++ b/Resources/views/other/summary/participant-summary.html.twig
@@ -1,4 +1,9 @@
 {% set isInternal = isInternal|default(false) %}
+{# Self-contained default for the formal-address flag: e-mail layouts seed `f` in their prelude,
+   but the web check-in/arrival page includes this partial bare — without this it 500s ("Variable
+   f does not exist"), which also broke the restore/resend-activation redirects that land there.
+   `is defined` (NOT |default) so a legitimate f=false (informal) from e-mail context survives. #}
+{% set f = f is defined ? f : (participant.formal is defined ? participant.formal : true) %}
 
 {% set participantRegistrations = participant.participantRegistrations(false, false) %}
 {% set activeEvent = participant.event(false)|default %}

--- a/Resources/views/web_admin/bulk_mail/compose.html.twig
+++ b/Resources/views/web_admin/bulk_mail/compose.html.twig
@@ -26,19 +26,66 @@
                 <label for="bm_subject" class="form-label">Předmět</label>
                 <input type="text" class="form-control" id="bm_subject" name="subject" maxlength="255" required>
             </div>
+
+            {# Mode: free body (Twig) vs. send a stored campaign/snippet as the whole mail. #}
             <div class="mb-3">
-                <label for="bm_body" class="form-label">Text (HTML + proměnné)</label>
-                <textarea class="form-control" id="bm_body" name="body" rows="12" required
-                          style="font-family: monospace;"
-                          placeholder="&lt;p&gt;Ahoj…&lt;/p&gt;"></textarea>
-                <small class="text-muted">
-                    {% verbatim %}Tělo je <strong>šablona</strong>: smíš použít proměnné <code>{{ contact.salutationName }}</code>,
-                    <code>{{ participant.event(false).name }}</code> a podmínkové bloky
-                    <code>{% if participant.event(false).slug == 'seznamovak-up-2026-1' %}…{% endif %}</code>
-                    (např. blok jen pro 1. turnus). Oslovení (<code>{{ salName }}</code>, <code>f</code>/<code>a</code>) je k dispozici.{% endverbatim %}
-                    Výsledek se vykreslí pro každého příjemce zvlášť a sanitizuje (bezpečné značky +
-                    odkazy http/https/mailto/tel). Zkontroluj náhledem.
-                </small>
+                <div class="btn-group" role="group" aria-label="Režim">
+                    <input type="radio" class="btn-check" name="mailMode" id="bmModeBody" value="body" checked>
+                    <label class="btn btn-outline-primary btn-sm" for="bmModeBody">✍ Vlastní text</label>
+                    <input type="radio" class="btn-check" name="mailMode" id="bmModeTemplate" value="template"{{ campaigns|length == 0 ? ' disabled' : '' }}>
+                    <label class="btn btn-outline-primary btn-sm" for="bmModeTemplate">📄 Uložená kampaň</label>
+                </div>
+            </div>
+
+            {# Stored-template mode #}
+            <div class="mb-3" id="bmTemplateSection" style="display:none;">
+                <label for="bm_template" class="form-label">Uložená šablona (kampaň)</label>
+                <select class="form-select" id="bm_template" name="templateSlug">
+                    <option value="">— vyber kampaň —</option>
+                    {% for t in campaigns|default([]) %}
+                        <option value="{{ t.slug }}">{{ t.name|default(t.slug) }}{{ t.slug ? ' ('~t.slug~')' : '' }}</option>
+                    {% endfor %}
+                </select>
+                <small class="text-muted">Odešle se celá uložená kampaň (vykreslená pro každého příjemce). Vlastní text se ignoruje.</small>
+            </div>
+
+            {# Free-body mode #}
+            <div id="bmBodySection">
+                <div class="row">
+                    <div class="col-md-8 mb-3">
+                        <label for="bm_body" class="form-label">Text (HTML + proměnné)</label>
+                        <textarea class="form-control" id="bm_body" name="body" rows="14" required
+                                  style="font-family: monospace;"
+                                  placeholder="&lt;p&gt;Ahoj…&lt;/p&gt;"></textarea>
+                        <small class="text-muted">
+                            {% verbatim %}Tělo je <strong>šablona</strong>: proměnné <code>{{ contact.salutationName }}</code>,
+                            <code>{{ participant.event(false).name }}</code> a podmínkové bloky
+                            <code>{% if participant.event(false).slug == '…' %}…{% endif %}</code>.{% endverbatim %}
+                            Vykreslí se pro každého příjemce zvlášť a sanitizuje. Zkontroluj náhledem.
+                        </small>
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label class="form-label">Vložit (klikni)</label>
+                        <div id="bmInsertPanel" style="border:1px solid #dee2e6;border-radius:.375rem;padding:.5rem;max-height:420px;overflow:auto;">
+                            {% for group, items in variableCatalog|default({}) %}
+                                <div style="font-size:.8em;color:#6c757d;text-transform:uppercase;margin:.3rem 0 .15rem;">{{ group }}</div>
+                                {% for item in items %}
+                                    <button type="button" class="btn btn-sm btn-outline-secondary bm-insert"
+                                            style="margin:.1rem;font-size:.85em;"
+                                            data-token="{{ item.token|e('html_attr') }}">{{ item.label }}</button>
+                                {% endfor %}
+                            {% endfor %}
+                            {% if snippets|default([])|length > 0 %}
+                                <div style="font-size:.8em;color:#6c757d;text-transform:uppercase;margin:.5rem 0 .15rem;">Bloky (snippety)</div>
+                                {% for s in snippets %}
+                                    <button type="button" class="btn btn-sm btn-outline-info bm-insert"
+                                            style="margin:.1rem;font-size:.85em;"
+                                            data-token="{{ ("{% include '" ~ s.slug ~ "' %}")|e('html_attr') }}">{{ s.name|default(s.slug) }}</button>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <div class="mb-3">
@@ -61,8 +108,43 @@
 
     <script>
         (function () {
+            var body = document.getElementById('bm_body');
+            var tplSelect = document.getElementById('bm_template');
+            var bodySection = document.getElementById('bmBodySection');
+            var tplSection = document.getElementById('bmTemplateSection');
+
+            // Mode toggle: show body+panel OR the stored-template picker. Keep `required` correct so
+            // the browser doesn't block a valid submit in the inactive mode.
+            function applyMode(mode) {
+                var isTemplate = mode === 'template';
+                tplSection.style.display = isTemplate ? '' : 'none';
+                bodySection.style.display = isTemplate ? 'none' : '';
+                body.required = !isTemplate;
+                tplSelect.required = isTemplate;
+                if (!isTemplate) { tplSelect.value = ''; }
+            }
+            Array.prototype.forEach.call(document.querySelectorAll('input[name=mailMode]'), function (r) {
+                r.addEventListener('change', function () { if (r.checked) { applyMode(r.value); } });
+            });
+
+            // Insert-at-cursor for the variable/block/snippet chips.
+            function insertAtCursor(el, text) {
+                var s = el.selectionStart, e = el.selectionEnd;
+                el.value = el.value.slice(0, s) + text + el.value.slice(e);
+                el.selectionStart = el.selectionEnd = s + text.length;
+                el.focus();
+            }
+            Array.prototype.forEach.call(document.querySelectorAll('.bm-insert'), function (b) {
+                b.addEventListener('click', function () { insertAtCursor(body, b.getAttribute('data-token')); });
+            });
+
+            // Code-editor feel without a dependency: Tab inserts two spaces instead of leaving the field.
+            body.addEventListener('keydown', function (ev) {
+                if (ev.key === 'Tab') { ev.preventDefault(); insertAtCursor(body, '  '); }
+            });
+
+            // Live preview (body OR stored template) for the first recipient.
             var btn = document.getElementById('bmPreviewBtn');
-            if (!btn) { return; }
             var PREVIEW_URL = {{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_preview')|json_encode|raw }};
             var TOKEN = {{ csrf_token('bulk_mail_preview')|json_encode|raw }};
             var shell = document.getElementById('bmPreviewShell');
@@ -78,7 +160,8 @@
                 fd.append('_token', TOKEN);
                 fd.append('idsCsv', document.querySelector('#bulkMailForm [name=idsCsv]').value);
                 fd.append('subject', document.getElementById('bm_subject').value);
-                fd.append('body', document.getElementById('bm_body').value);
+                fd.append('body', body.value);
+                fd.append('templateSlug', tplSelect.value);
                 btn.disabled = true;
                 btn.textContent = 'Generuji náhled…';
                 fetch(PREVIEW_URL, { method: 'POST', body: fd, credentials: 'same-origin' })

--- a/Resources/views/web_admin/bulk_mail/compose.html.twig
+++ b/Resources/views/web_admin/bulk_mail/compose.html.twig
@@ -1,0 +1,75 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ pageTitle }}{% endblock %}
+
+{% block body_content %}
+    <main class="container">
+        <h2>✉ {{ pageTitle }}</h2>
+        <p>
+            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="btn btn-sm btn-link">← Zpět na seznam přihlášek</a>
+            · <a href="{{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_status') }}" class="btn btn-sm btn-link">Stav hromadných e-mailů</a>
+        </p>
+
+        <div class="alert alert-info">
+            <strong>Příjemců: {{ recipientCount }}</strong> {{ recipientCount == 1 ? 'přihláška' : 'přihlášek' }}.
+            Každá přihláška = nejméně 1 e-mailová adresa (organizace může mít více).
+            Jde o <strong>reálné odeslání</strong> živým lidem — zkontrolujte text a náhled.
+        </div>
+
+        <form method="post" id="bulkMailForm"
+              action="{{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_queue') }}"
+              onsubmit="return confirm('Zařadit hromadný e-mail pro {{ recipientCount }} příjemců a spustit odesílání?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('bulk_mail') }}">
+            <input type="hidden" name="idsCsv" value="{{ idsCsv }}">
+
+            <div class="mb-3">
+                <label for="bm_subject" class="form-label">Předmět</label>
+                <input type="text" class="form-control" id="bm_subject" name="subject" maxlength="255" required>
+            </div>
+            <div class="mb-3">
+                <label for="bm_body" class="form-label">Text (HTML)</label>
+                <textarea class="form-control" id="bm_body" name="body" rows="12" required placeholder="&lt;p&gt;Ahoj…&lt;/p&gt;"></textarea>
+                <small class="text-muted">
+                    Tělo se sanitizuje (bezpečné značky + odkazy http/https/mailto/tel) a vloží do OSWIS šablony.
+                    Oslovení personalizuje šablona automaticky.
+                </small>
+            </div>
+
+            <div class="mb-3">
+                <button type="button" class="btn btn-outline-secondary" id="bmPreviewBtn">👁 Náhled (1. příjemce)</button>
+                <button type="submit" class="btn btn-primary">✉ Zařadit a odeslat ({{ recipientCount }})</button>
+            </div>
+        </form>
+
+        <div id="bmPreviewWrap" style="display:none;">
+            <h3>Náhled</h3>
+            <iframe id="bmPreviewFrame" title="Náhled e-mailu" style="width:100%;height:600px;border:1px solid #ccc;background:#fff;"></iframe>
+        </div>
+    </main>
+
+    <script>
+        (function () {
+            var btn = document.getElementById('bmPreviewBtn');
+            if (!btn) { return; }
+            var PREVIEW_URL = {{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_preview')|json_encode|raw }};
+            var TOKEN = {{ csrf_token('bulk_mail_preview')|json_encode|raw }};
+            btn.addEventListener('click', function () {
+                var fd = new FormData();
+                fd.append('_token', TOKEN);
+                fd.append('idsCsv', document.querySelector('#bulkMailForm [name=idsCsv]').value);
+                fd.append('subject', document.getElementById('bm_subject').value);
+                fd.append('body', document.getElementById('bm_body').value);
+                btn.disabled = true;
+                btn.textContent = 'Generuji náhled…';
+                fetch(PREVIEW_URL, { method: 'POST', body: fd, credentials: 'same-origin' })
+                    .then(function (r) { return r.text(); })
+                    .then(function (html) {
+                        document.getElementById('bmPreviewWrap').style.display = 'block';
+                        document.getElementById('bmPreviewFrame').srcdoc = html;
+                    })
+                    .catch(function () { alert('Náhled se nepodařilo vytvořit.'); })
+                    .finally(function () { btn.disabled = false; btn.textContent = '👁 Náhled (1. příjemce)'; });
+            });
+        })();
+    </script>
+{% endblock %}

--- a/Resources/views/web_admin/bulk_mail/compose.html.twig
+++ b/Resources/views/web_admin/bulk_mail/compose.html.twig
@@ -16,6 +16,41 @@
             Jde o <strong>reálné odeslání</strong> živým lidem — zkontrolujte text a náhled.
         </div>
 
+        {# Recipient list — see exactly who gets the mail + preview it for any specific one. #}
+        <details class="mb-3"{{ recipientCount <= 25 ? ' open' : '' }}>
+            <summary style="cursor:pointer;font-weight:600;">📋 Seznam příjemců ({{ recipientCount }}) — zobrazit / skrýt</summary>
+            <div style="max-height:320px;overflow:auto;border:1px solid #dee2e6;border-radius:.375rem;margin-top:.5rem;">
+                <table class="list" style="width:100%;margin:0;">
+                    <thead>
+                        <tr>
+                            <th style="width:3rem;">#</th>
+                            <th>Jméno</th>
+                            <th>Akce</th>
+                            <th>E-mail</th>
+                            <th style="width:6rem;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for r in recipients|default([]) %}
+                            <tr>
+                                <td>{{ r.id }}</td>
+                                <td>{{ r.contact ? (r.contact.name|default('(bez jména)')) : '(bez kontaktu)' }}</td>
+                                <td>{{ r.event ? (r.event.shortName|default(r.event.name)|default('—')) : '—' }}</td>
+                                <td><small>{{ (r.contact and r.contact.appUser) ? r.contact.appUser.email : '—' }}</small></td>
+                                <td>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary bm-preview-one"
+                                            data-pid="{{ r.id }}"
+                                            data-name="{{ (r.contact ? (r.contact.name|default('#'~r.id)) : ('#'~r.id))|e('html_attr') }}">👁 Náhled</button>
+                                </td>
+                            </tr>
+                        {% else %}
+                            <tr><td colspan="5" style="text-align:center;color:#6c757d;">Žádní příjemci.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </details>
+
         <form method="post" id="bulkMailForm"
               action="{{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_queue') }}"
               onsubmit="return confirm('Zařadit hromadný e-mail pro {{ recipientCount }} příjemců a spustit odesílání?');">
@@ -95,7 +130,7 @@
         </form>
 
         <div id="bmPreviewWrap" style="display:none;">
-            <h3>Náhled</h3>
+            <h3>Náhled <small class="text-muted" id="bmPreviewFor"></small></h3>
             <div class="btn-group" role="group" aria-label="Šířka náhledu" style="margin-bottom:.5rem;">
                 <button type="button" class="btn btn-sm btn-outline-secondary active" id="bmWidthDesktop">🖥 Desktop</button>
                 <button type="button" class="btn btn-sm btn-outline-secondary" id="bmWidthMobile">📱 Mobil</button>
@@ -143,7 +178,7 @@
                 if (ev.key === 'Tab') { ev.preventDefault(); insertAtCursor(body, '  '); }
             });
 
-            // Live preview (body OR stored template) for the first recipient.
+            // Live preview (body OR stored template) for a chosen recipient (or the first).
             var btn = document.getElementById('bmPreviewBtn');
             var PREVIEW_URL = {{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_preview')|json_encode|raw }};
             var TOKEN = {{ csrf_token('bulk_mail_preview')|json_encode|raw }};
@@ -155,23 +190,34 @@
             }
             document.getElementById('bmWidthDesktop').addEventListener('click', function () { setWidth('640px', true); });
             document.getElementById('bmWidthMobile').addEventListener('click', function () { setWidth('360px', false); });
-            btn.addEventListener('click', function () {
+
+            function runPreview(pid, who, sourceBtn) {
                 var fd = new FormData();
                 fd.append('_token', TOKEN);
                 fd.append('idsCsv', document.querySelector('#bulkMailForm [name=idsCsv]').value);
                 fd.append('subject', document.getElementById('bm_subject').value);
                 fd.append('body', body.value);
                 fd.append('templateSlug', tplSelect.value);
-                btn.disabled = true;
-                btn.textContent = 'Generuji náhled…';
+                fd.append('previewParticipantId', pid || '');
+                var label = sourceBtn ? sourceBtn.textContent : '';
+                if (sourceBtn) { sourceBtn.disabled = true; sourceBtn.textContent = 'Generuji…'; }
                 fetch(PREVIEW_URL, { method: 'POST', body: fd, credentials: 'same-origin' })
                     .then(function (r) { return r.text(); })
                     .then(function (html) {
-                        document.getElementById('bmPreviewWrap').style.display = 'block';
+                        var wrap = document.getElementById('bmPreviewWrap');
+                        wrap.style.display = 'block';
+                        document.getElementById('bmPreviewFor').textContent = who ? '— ' + who : '';
                         document.getElementById('bmPreviewFrame').srcdoc = html;
+                        wrap.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     })
                     .catch(function () { alert('Náhled se nepodařilo vytvořit.'); })
-                    .finally(function () { btn.disabled = false; btn.textContent = '👁 Náhled (1. příjemce)'; });
+                    .finally(function () { if (sourceBtn) { sourceBtn.disabled = false; sourceBtn.textContent = label; } });
+            }
+
+            btn.addEventListener('click', function () { runPreview('', '1. příjemce', btn); });
+            // Per-recipient preview from the recipient list.
+            Array.prototype.forEach.call(document.querySelectorAll('.bm-preview-one'), function (b) {
+                b.addEventListener('click', function () { runPreview(b.getAttribute('data-pid'), b.getAttribute('data-name'), b); });
             });
         })();
     </script>

--- a/Resources/views/web_admin/bulk_mail/compose.html.twig
+++ b/Resources/views/web_admin/bulk_mail/compose.html.twig
@@ -43,7 +43,13 @@
 
         <div id="bmPreviewWrap" style="display:none;">
             <h3>Náhled</h3>
-            <iframe id="bmPreviewFrame" title="Náhled e-mailu" style="width:100%;height:600px;border:1px solid #ccc;background:#fff;"></iframe>
+            <div class="btn-group" role="group" aria-label="Šířka náhledu" style="margin-bottom:.5rem;">
+                <button type="button" class="btn btn-sm btn-outline-secondary active" id="bmWidthDesktop">🖥 Desktop</button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" id="bmWidthMobile">📱 Mobil</button>
+            </div>
+            <div id="bmPreviewShell" style="background:#e9ecef;padding:.5rem;border:1px solid #ccc;max-width:640px;">
+                <iframe id="bmPreviewFrame" title="Náhled e-mailu" style="display:block;width:100%;height:600px;border:1px solid #ccc;background:#fff;"></iframe>
+            </div>
         </div>
     </main>
 
@@ -53,6 +59,14 @@
             if (!btn) { return; }
             var PREVIEW_URL = {{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_preview')|json_encode|raw }};
             var TOKEN = {{ csrf_token('bulk_mail_preview')|json_encode|raw }};
+            var shell = document.getElementById('bmPreviewShell');
+            function setWidth(px, desktopActive) {
+                shell.style.maxWidth = px;
+                document.getElementById('bmWidthDesktop').classList.toggle('active', desktopActive);
+                document.getElementById('bmWidthMobile').classList.toggle('active', !desktopActive);
+            }
+            document.getElementById('bmWidthDesktop').addEventListener('click', function () { setWidth('640px', true); });
+            document.getElementById('bmWidthMobile').addEventListener('click', function () { setWidth('360px', false); });
             btn.addEventListener('click', function () {
                 var fd = new FormData();
                 fd.append('_token', TOKEN);

--- a/Resources/views/web_admin/bulk_mail/compose.html.twig
+++ b/Resources/views/web_admin/bulk_mail/compose.html.twig
@@ -27,11 +27,17 @@
                 <input type="text" class="form-control" id="bm_subject" name="subject" maxlength="255" required>
             </div>
             <div class="mb-3">
-                <label for="bm_body" class="form-label">Text (HTML)</label>
-                <textarea class="form-control" id="bm_body" name="body" rows="12" required placeholder="&lt;p&gt;Ahoj…&lt;/p&gt;"></textarea>
+                <label for="bm_body" class="form-label">Text (HTML + proměnné)</label>
+                <textarea class="form-control" id="bm_body" name="body" rows="12" required
+                          style="font-family: monospace;"
+                          placeholder="&lt;p&gt;Ahoj…&lt;/p&gt;"></textarea>
                 <small class="text-muted">
-                    Tělo se sanitizuje (bezpečné značky + odkazy http/https/mailto/tel) a vloží do OSWIS šablony.
-                    Oslovení personalizuje šablona automaticky.
+                    {% verbatim %}Tělo je <strong>šablona</strong>: smíš použít proměnné <code>{{ contact.salutationName }}</code>,
+                    <code>{{ participant.event(false).name }}</code> a podmínkové bloky
+                    <code>{% if participant.event(false).slug == 'seznamovak-up-2026-1' %}…{% endif %}</code>
+                    (např. blok jen pro 1. turnus). Oslovení (<code>{{ salName }}</code>, <code>f</code>/<code>a</code>) je k dispozici.{% endverbatim %}
+                    Výsledek se vykreslí pro každého příjemce zvlášť a sanitizuje (bezpečné značky +
+                    odkazy http/https/mailto/tel). Zkontroluj náhledem.
                 </small>
             </div>
 

--- a/Resources/views/web_admin/bulk_mail/status.html.twig
+++ b/Resources/views/web_admin/bulk_mail/status.html.twig
@@ -1,0 +1,109 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ pageTitle }}{% endblock %}
+
+{% block body_content %}
+    <main class="container">
+        <h2>{{ pageTitle }}</h2>
+        <p>
+            <a href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list') }}" class="btn btn-sm btn-link">← Zpět na seznam přihlášek</a>
+        </p>
+
+        {% if bulks is empty %}
+            <p class="text-muted">Žádné hromadné e-maily.</p>
+        {% else %}
+            <table class="table table-sm table-hover">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Předmět</th>
+                        <th>Vytvořeno</th>
+                        <th>Stav</th>
+                        <th>Postup</th>
+                        <th>Odesláno / chyby</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for bulk in bulks %}
+                        <tr data-bulk-id="{{ bulk.id }}" data-sent="{{ bulk.sentCount }}" data-failed="{{ bulk.failedCount }}"
+                            {% if bulk.id == highlight %}style="background:#fffbe6"{% endif %}>
+                            <td>{{ bulk.id }}</td>
+                            <td>
+                                {{ bulk.subject }}
+                                {% if bulk.adminName %}<br><small class="text-muted">{{ bulk.adminName }}</small>{% endif %}
+                            </td>
+                            <td><small>{{ bulk.createdAt|date('Y-m-d H:i') }}</small></td>
+                            <td class="bm-status">{{ bulk.status }}</td>
+                            <td class="bm-progress">{{ bulk.processedCount }}/{{ bulk.totalCount }}</td>
+                            <td class="bm-tally">{{ bulk.sentCount }} / {{ bulk.failedCount }}</td>
+                            <td>
+                                {% if not bulk.done %}
+                                    <button type="button" class="btn btn-sm btn-primary bm-drain-btn" data-bulk-id="{{ bulk.id }}">Odeslat teď</button>
+                                {% else %}
+                                    ✓
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <p class="text-muted"><small>Čekající dávky se odesílají automaticky po malých dávkách, dokud nejsou hotové (i bez cronu). Stránku můžete nechat otevřenou.</small></p>
+        {% endif %}
+    </main>
+
+    <script>
+        (function () {
+            var DRAIN_URL = {{ path('oswis_org_oswis_calendar_web_admin_bulk_mail_drain')|json_encode|raw }};
+            var TOKEN = {{ csrf_token('bulk_mail_drain')|json_encode|raw }};
+
+            function rowFor(id) { return document.querySelector('tr[data-bulk-id="' + id + '"]'); }
+
+            function drainOnce(id) {
+                var fd = new FormData();
+                fd.append('_token', TOKEN);
+                fd.append('bulkId', id);
+                return fetch(DRAIN_URL, { method: 'POST', body: fd, credentials: 'same-origin' }).then(function (r) { return r.json(); });
+            }
+
+            function update(row, p) {
+                if (!row) { return; }
+                row.querySelector('.bm-status').textContent = p.done ? 'done' : 'sending';
+                row.querySelector('.bm-progress').textContent = p.processed + '/' + p.total;
+                var sent = parseInt(row.getAttribute('data-sent') || '0', 10) + (p.sent || 0);
+                var failed = parseInt(row.getAttribute('data-failed') || '0', 10) + (p.failed || 0);
+                row.setAttribute('data-sent', sent);
+                row.setAttribute('data-failed', failed);
+                row.querySelector('.bm-tally').textContent = sent + ' / ' + failed;
+                if (p.done) {
+                    var cell = row.lastElementChild;
+                    if (cell) { cell.textContent = '✓'; }
+                }
+            }
+
+            function drainLoop(id) {
+                return drainOnce(id).then(function (p) {
+                    if (p.error) { return; }
+                    update(rowFor(id), p);
+                    if (!p.done) { return drainLoop(id); }
+                });
+            }
+
+            document.querySelectorAll('.bm-drain-btn').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    btn.textContent = 'Odesílám…';
+                    drainLoop(btn.getAttribute('data-bulk-id'));
+                });
+            });
+
+            // Auto-drain pending bulks on load (immediate path + fallback when no cron runs).
+            document.querySelectorAll('tr[data-bulk-id]').forEach(function (row) {
+                var status = row.querySelector('.bm-status');
+                if (status && status.textContent.trim() !== 'done') {
+                    drainLoop(row.getAttribute('data-bulk-id'));
+                }
+            });
+        })();
+    </script>
+{% endblock %}

--- a/Resources/views/web_admin/bulk_mail/status.html.twig
+++ b/Resources/views/web_admin/bulk_mail/status.html.twig
@@ -85,7 +85,15 @@
                 return drainOnce(id).then(function (p) {
                     if (p.error) { return; }
                     update(rowFor(id), p);
-                    if (!p.done) { return drainLoop(id); }
+                    if (p.done) { return; }
+                    // busy = another drain (cron / second tab) holds the per-bulk lock —
+                    // back off instead of hammering; the re-poll picks up its progress.
+                    if (p.busy) {
+                        return new Promise(function (resolve) {
+                            setTimeout(function () { resolve(drainLoop(id)); }, 3000);
+                        });
+                    }
+                    return drainLoop(id);
                 });
             }
 

--- a/Resources/views/web_admin/bulk_reassign.html.twig
+++ b/Resources/views/web_admin/bulk_reassign.html.twig
@@ -43,9 +43,17 @@
             </div>
         </form>
 
-        {% if sourceEvent %}
+        {% if preselectMode|default(false) %}
+            <div class="alert alert-info py-2">
+                Předvybráno <strong>{{ preselectedIds|default([])|length }}</strong> přihlášek ze seznamu.
+                Vyber cílovou přihlášku a potvrď přesun.
+            </div>
+        {% endif %}
+        {% if sourceEvent or preselectMode|default(false) %}
             <form method="post"
-                  action="{{ path('oswis_org_oswis_calendar_web_admin_bulk_reassign', {sourceEventSlug: sourceEvent.slug, sourceCategorySlug: sourceCategory ? sourceCategory.slug : null}) }}"
+                  action="{{ preselectMode|default(false)
+                      ? path('oswis_org_oswis_calendar_web_admin_bulk_reassign')
+                      : path('oswis_org_oswis_calendar_web_admin_bulk_reassign', {sourceEventSlug: sourceEvent.slug, sourceCategorySlug: sourceCategory ? sourceCategory.slug : null}) }}"
                   onsubmit="return confirm('Opravdu přesunout označené účastníky? Tato akce změní jejich přihlášku.');">
                 <input type="hidden" name="_token" value="{{ csrf_token('bulk_reassign') }}">
                 <input type="hidden" name="_action" value="execute">
@@ -92,7 +100,7 @@
                             {% set contact = participant.contact(false)|default %}
                             <tr>
                                 <td>
-                                    <input type="checkbox" name="participantIds[]" value="{{ participant.id }}" class="bulk-row-check">
+                                    <input type="checkbox" name="participantIds[]" value="{{ participant.id }}" class="bulk-row-check" {{ participant.id in preselectedIds|default([]) ? 'checked' : '' }}>
                                 </td>
                                 <td><strong>{{ participant.id }}</strong></td>
                                 <td>{{ contact.name|default('(bez jména)') }}</td>

--- a/Resources/views/web_admin/mail_config/edit.html.twig
+++ b/Resources/views/web_admin/mail_config/edit.html.twig
@@ -13,9 +13,10 @@
         {{ form_widget(form) }}
         {{ form_end(form, { render_rest: false }) }}
 
-        {% if kind == 'template' %}
+        {% if kind == 'template' and entity.id %}
             {# Live preview through the real MJML pipeline — #139 used to edit blind. Renders the
-               current (unsaved) textarea content against a sample participant; iframe isolates CSS. #}
+               current (unsaved) textarea content against a sample participant; iframe isolates CSS.
+               Only for a persisted template (a brand-new one has no id → no preview route yet). #}
             <hr style="margin: 1.5rem 0;">
             <div id="mtPreview" style="margin-top: 1rem;"
                  data-url="{{ path('oswis_org_oswis_calendar_web_admin_mail_template_preview', { id: entity.id }) }}"

--- a/Resources/views/web_admin/mail_config/edit.html.twig
+++ b/Resources/views/web_admin/mail_config/edit.html.twig
@@ -12,5 +12,89 @@
         {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
         {{ form_widget(form) }}
         {{ form_end(form, { render_rest: false }) }}
+
+        {% if kind == 'template' %}
+            {# Live preview through the real MJML pipeline — #139 used to edit blind. Renders the
+               current (unsaved) textarea content against a sample participant; iframe isolates CSS. #}
+            <hr style="margin: 1.5rem 0;">
+            <div id="mtPreview" style="margin-top: 1rem;"
+                 data-url="{{ path('oswis_org_oswis_calendar_web_admin_mail_template_preview', { id: entity.id }) }}"
+                 data-token="{{ csrf_token('mail_template_preview') }}">
+                <h3>👁 Náhled e-mailu</h3>
+                <p class="text-muted" style="max-width: 60rem;">
+                    Vykreslí <strong>aktuální (i neuložený) obsah</strong> šablony přes stejnou MJML cestu,
+                    kterou používá reálné odeslání. Vyber vzorového příjemce (např. z 1. vs 2. turnusu)
+                    pro ověření podmínkových bloků. QR platby a přílohy se v náhledu nezobrazují.
+                </p>
+
+                <div style="display: flex; gap: 1rem; align-items: flex-end; flex-wrap: wrap; margin-bottom: .75rem;">
+                    <div>
+                        <label for="mtSampleSelect" class="form-label" style="margin-bottom: .15rem;">Vzorový příjemce</label>
+                        <select id="mtSampleSelect" class="form-select form-select-sm" style="min-width: 22rem;">
+                            <option value="">— nejnovější aktivní přihláška —</option>
+                            {% for p in sampleParticipants|default([]) %}
+                                <option value="{{ p.id }}">
+                                    #{{ p.id }} ·
+                                    {{ p.contact ? (p.contact.name|default('(bez jména)')) : '(bez kontaktu)' }}
+                                    {%- if p.event %} · {{ p.event.shortName|default(p.event.name)|default('') }}{% endif %}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="btn-group" role="group" aria-label="Šířka náhledu">
+                        <button type="button" class="btn btn-sm btn-outline-secondary active" id="mtWidthDesktop">🖥 Desktop</button>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="mtWidthMobile">📱 Mobil</button>
+                    </div>
+                    <button type="button" class="btn btn-sm btn-primary" id="mtPreviewBtn">Vykreslit náhled</button>
+                </div>
+
+                <div id="mtPreviewWrap" style="display: none;">
+                    <div style="background:#e9ecef; padding:.5rem; border:1px solid #ccc; border-bottom:0; max-width:640px;">
+                        <iframe id="mtPreviewFrame" title="Náhled e-mailu"
+                                style="display:block; width:100%; height:640px; border:1px solid #ccc; background:#fff;"></iframe>
+                    </div>
+                </div>
+            </div>
+
+            <script>
+                (function () {
+                    var root = document.getElementById('mtPreview');
+                    var btn = document.getElementById('mtPreviewBtn');
+                    if (!root || !btn) { return; }
+                    var URL = root.getAttribute('data-url');
+                    var TOKEN = root.getAttribute('data-token');
+                    var frame = document.getElementById('mtPreviewFrame');
+                    var wrap = document.getElementById('mtPreviewWrap');
+                    var shell = wrap.firstElementChild;
+                    // Symfony form block prefix "twig_template_edit" → textarea id below.
+                    var sourceEl = document.getElementById('twig_template_edit_textValue');
+
+                    function setWidth(px, desktopActive) {
+                        shell.style.maxWidth = px;
+                        document.getElementById('mtWidthDesktop').classList.toggle('active', desktopActive);
+                        document.getElementById('mtWidthMobile').classList.toggle('active', !desktopActive);
+                    }
+                    document.getElementById('mtWidthDesktop').addEventListener('click', function () { setWidth('640px', true); });
+                    document.getElementById('mtWidthMobile').addEventListener('click', function () { setWidth('360px', false); });
+
+                    btn.addEventListener('click', function () {
+                        var fd = new FormData();
+                        fd.append('_token', TOKEN);
+                        fd.append('source', sourceEl ? sourceEl.value : '');
+                        fd.append('participantId', document.getElementById('mtSampleSelect').value);
+                        btn.disabled = true;
+                        btn.textContent = 'Generuji náhled…';
+                        fetch(URL, { method: 'POST', body: fd, credentials: 'same-origin' })
+                            .then(function (r) { return r.text(); })
+                            .then(function (html) {
+                                wrap.style.display = 'block';
+                                frame.srcdoc = html;
+                            })
+                            .catch(function () { alert('Náhled se nepodařilo vytvořit.'); })
+                            .finally(function () { btn.disabled = false; btn.textContent = 'Vykreslit náhled'; });
+                    });
+                })();
+            </script>
+        {% endif %}
     </main>
 {% endblock %}

--- a/Resources/views/web_admin/mail_config/edit.html.twig
+++ b/Resources/views/web_admin/mail_config/edit.html.twig
@@ -13,6 +13,20 @@
         {{ form_widget(form) }}
         {{ form_end(form, { render_rest: false }) }}
 
+        {% if kind == 'group' and entity.filterExpression %}
+            {# Filter sanity-check: the unified participant list evaluates the SAME expression language,
+               so one click shows exactly who the group currently applies to (before enabling automail). #}
+            <p style="margin-top: .75rem;">
+                {% set listParams = entity.event
+                    ? { expr: entity.filterExpression, eventSlug: entity.event.slug }
+                    : { expr: entity.filterExpression } %}
+                <a class="btn btn-sm btn-outline-secondary" target="_blank"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_participants_list', listParams) }}">
+                    👥 Zobrazit účastníky odpovídající filtru v seznamu přihlášek
+                </a>
+            </p>
+        {% endif %}
+
         {% if kind == 'template' and entity.id %}
             {# Live preview through the real MJML pipeline — #139 used to edit blind. Renders the
                current (unsaved) textarea content against a sample participant; iframe isolates CSS.

--- a/Resources/views/web_admin/mail_config/edit.html.twig
+++ b/Resources/views/web_admin/mail_config/edit.html.twig
@@ -13,9 +13,11 @@
         {{ form_widget(form) }}
         {{ form_end(form, { render_rest: false }) }}
 
-        {% if kind == 'group' and entity.filterExpression %}
+        {% if kind == 'group' and entity.filterExpression and (not form.vars.submitted or form.vars.valid) %}
             {# Filter sanity-check: the unified participant list evaluates the SAME expression language,
-               so one click shows exactly who the group currently applies to (before enabling automail). #}
+               so one click shows exactly who the group currently applies to (before enabling automail).
+               Hidden after an invalid submit — the bound entity then holds the rejected expression and
+               the link would just 400 on the list. #}
             <p style="margin-top: .75rem;">
                 {% set listParams = entity.event
                     ? { expr: entity.filterExpression, eventSlug: entity.event.slug }

--- a/Resources/views/web_admin/mail_config/index.html.twig
+++ b/Resources/views/web_admin/mail_config/index.html.twig
@@ -105,6 +105,7 @@
                     <tr>
                         <th style="width: 3rem;">ID</th>
                         <th>Název</th>
+                        <th style="width: 8rem;">Druh</th>
                         <th style="width: 18rem;">Slug</th>
                         <th>Cesta</th>
                         <th style="width: 11rem; text-align: center;">Inline obsah?</th>
@@ -116,6 +117,12 @@
                         <tr>
                             <td>{{ t.id }}</td>
                             <td><strong>{{ t.name|default('—') }}</strong></td>
+                            <td>
+                                {% set kindLabels = {'system': 'Systémový', 'campaign': 'Kampaň', 'snippet': 'Blok', 'page': 'Stránka', 'pdf': 'PDF'} %}
+                                {% if t.kind %}
+                                    <span class="badge" style="background:#e7f1ff;color:#0a58ca;border:1px solid #b6d4fe;border-radius:.4em;padding:.1em .5em;font-size:.8em;">{{ kindLabels[t.kind]|default(t.kind) }}</span>
+                                {% else %}—{% endif %}
+                            </td>
                             <td><code style="font-size: .85em;">{{ t.slug|default('—') }}</code></td>
                             <td><code style="font-size: .85em;">{{ t.regularTemplateName|default('—') }}</code></td>
                             <td style="text-align: center;">
@@ -131,7 +138,7 @@
                             </td>
                         </tr>
                     {% else %}
-                        <tr><td colspan="6" style="text-align: center; color: #6c757d;">Žádné šablony.</td></tr>
+                        <tr><td colspan="7" style="text-align: center; color: #6c757d;">Žádné šablony.</td></tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/Resources/views/web_admin/mail_config/index.html.twig
+++ b/Resources/views/web_admin/mail_config/index.html.twig
@@ -100,6 +100,10 @@
                 </tbody>
             </table>
         {% elseif activeTab == 'templates' %}
+            <p style="margin-bottom: .75rem;">
+                <a class="btn btn-sm btn-success"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_mail_template_new') }}">+ Nová šablona / blok</a>
+            </p>
             <table class="list" style="width: 100%;">
                 <thead>
                     <tr>

--- a/Resources/views/web_admin/mail_config/index.html.twig
+++ b/Resources/views/web_admin/mail_config/index.html.twig
@@ -45,6 +45,7 @@
                         <th>Událost</th>
                         <th style="width: 4rem; text-align: center;" title="Automatické odeslání">Auto</th>
                         <th style="width: 6rem; text-align: center;" title="Posílat jen aktivním účastníkům">Jen aktivní</th>
+                        <th style="width: 10rem;" title="Volitelný filtr příjemců (výrazový jazyk seznamu přihlášek)">Filtr</th>
                         <th style="width: 6rem;"></th>
                     </tr>
                 </thead>
@@ -60,12 +61,19 @@
                             <td style="text-align: center;">{{ g.automaticMailing ? '✓' : '—' }}</td>
                             <td style="text-align: center;">{{ g.onlyActive ? '✓' : '—' }}</td>
                             <td>
+                                {% if g.filterExpression %}
+                                    <code style="font-size: .8em;" title="{{ g.filterExpression }}">{{ g.filterExpression|u.truncate(28, '…') }}</code>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
+                            <td>
                                 <a class="btn btn-sm btn-outline-primary"
                                    href="{{ path('oswis_org_oswis_calendar_web_admin_mail_group_edit', { id: g.id }) }}">✎ Upravit</a>
                             </td>
                         </tr>
                     {% else %}
-                        <tr><td colspan="9" style="text-align: center; color: #6c757d;">Žádné mail-skupiny.</td></tr>
+                        <tr><td colspan="10" style="text-align: center; color: #6c757d;">Žádné mail-skupiny.</td></tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/Resources/views/web_admin/participant.html.twig
+++ b/Resources/views/web_admin/participant.html.twig
@@ -375,6 +375,53 @@
                 </div>
             </div>
 
+            {# Historie přihlášky — read-only chronologie změn z verzovaných junction entit (#142). #}
+            <div class="card" style="margin-bottom: 1rem;" id="historie">
+                <div class="card-body">
+                    <details>
+                        <summary style="cursor: pointer; list-style: none;">
+                            <h5 class="card-title" style="display: inline; border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">
+                                Historie přihlášky
+                                <span class="text-secondary" style="font-weight: normal; font-size: .85rem;">
+                                    ({{ history|default([])|length }} {{ (history|default([])|length == 1) ? 'záznam' : 'záznamů' }}) ▾
+                                </span>
+                            </h5>
+                        </summary>
+                        {% set historyRows = history|default([]) %}
+                        {% if historyRows|length == 0 %}
+                            <p class="text-muted" style="margin: .75rem 0 0;">Žádná zaznamenaná historie.</p>
+                        {% else %}
+                            <table class="table table-sm" style="margin: .75rem 0 0;">
+                                <tbody>
+                                    {% for event in historyRows %}
+                                        {% set verbColor = {'created': '#006FAD', 'added': '#198754', 'removed': '#b02a37'} %}
+                                        {% set verbIcon  = {'created': '✚', 'added': '＋', 'removed': '✗'} %}
+                                        {% set kindLabel = {'participant': 'Přihláška', 'registration': 'Akce / turnus', 'flag': 'Příznak'} %}
+                                        <tr>
+                                            <td style="width: 11rem; white-space: nowrap; color: #6c757d; font-size: .85rem;">
+                                                {{ event.at|date('j. n. Y H:i', 'Europe/Prague') }}
+                                            </td>
+                                            <td style="width: 1.5rem; text-align: center; color: {{ verbColor[event.verb]|default('#6c757d') }};">
+                                                {{ verbIcon[event.verb]|default('•') }}
+                                            </td>
+                                            <td style="width: 8rem; white-space: nowrap; color: #6c757d; font-size: .85rem;">
+                                                {{ kindLabel[event.kind]|default(event.kind) }}{% if event.category %}<br><small>{{ event.category }}</small>{% endif %}
+                                            </td>
+                                            <td{% if event.verb == 'removed' %} style="text-decoration: line-through; color: #6c757d;"{% endif %}>
+                                                {{ event.label }}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                            <p class="text-muted" style="margin: .25rem 0 0; font-size: .8rem;">
+                                Rekonstruováno z časových značek příznaků a registrací (přidáno = vznik, přeškrtnuto = smazáno). Změny jednotlivých polí kontaktu se zde nezobrazují.
+                            </p>
+                        {% endif %}
+                    </details>
+                </div>
+            </div>
+
             {# Komunikace timeline #}
             <div class="card" style="margin-bottom: 1rem;" id="komunikace">
                 <div class="card-body">

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -24,15 +24,17 @@
     .bad { color: #c0392b; font-weight: bold; }
     .note { color: #c8730a; }
     .strike { text-decoration: line-through; }
-    /* Flag badges: každý příznak na vlastním řádku (pod sebou) = čistě, jako na obrazovce.
-       Pilulka = název (barva příznaku) + volitelně cena (+ červená / − zelená). */
-    .fb-row { margin-bottom: 2.5px; }
-    .fb { display: inline-block; border-radius: 3px; font-size: 7pt; font-weight: bold;
-        background: #17a2b8; color: #fff; padding: 1px 6px; }
-    .fb-price { display: inline-block; border-radius: 3px; font-size: 7pt; font-weight: bold;
-        padding: 1px 6px; margin-left: 2px; }
+    /* Flag badges: každý příznak na vlastním řádku (pod sebou), soudržná zaoblená pilulka =
+       název (barva příznaku) + volitelná cena na navazující polovině (+ červená / − zelená). */
+    .fb-row { margin-bottom: 3px; line-height: 1.5; }
+    .fb { display: inline-block; border-radius: 8px; font-size: 7pt; font-weight: bold;
+        background: #17a2b8; color: #fff; padding: 1.5px 8px; }
+    .fb.has-price { border-radius: 8px 0 0 8px; padding-right: 6px; }
+    .fb-price { display: inline-block; border-radius: 0 8px 8px 0; font-size: 7pt; font-weight: bold;
+        padding: 1.5px 8px; }
     .fb-pos { background: #c0392b; color: #fff; }
     .fb-neg { background: #1a7a3c; color: #fff; }
+    .gi { font-size: 8pt; } .gi-f { color: #c0398a; } .gi-m { color: #2b6cb0; }
     .pay-badge { color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; font-size: 7pt; }
     .c-success { background: #1a7a3c; } .c-danger { background: #c0392b; }
     .c-warning { background: #c87f0a; } .c-info { background: #006FAD; }
@@ -97,7 +99,8 @@
             </td>
             <td>
                 {% for participantContact in participant.participantContacts(false, false) %}
-                    <div class="nm {{ participantContact.active|default ? '' : 'strike' }}">{{ participantContact.contact.name|default }}</div>
+                    {% set g = participantContact.contact.gender|default %}
+                    <div class="nm {{ participantContact.active|default ? '' : 'strike' }}"><span class="gi {{ 'female' == g ? 'gi-f' : ('male' == g ? 'gi-m' : '') }}">{{ 'female' == g ? '♀' : ('male' == g ? '♂' : '•') }}</span> {{ participantContact.contact.name|default }}</div>
                 {% endfor %}
                 {% for participantRange in participant.participantRegistrations(false, false) %}
                     <div class="{{ participantRange.active|default ? '' : 'strike' }}">{{ participantRange.event.shortName|default }}{% if participantRange.offer.shortName|default %} · {{ participantRange.offer.shortName }}{% endif %}</div>
@@ -111,8 +114,9 @@
                     {% for participantFlag in flagGroup.participantFlags %}
                         {% set fc = participantFlag.deletedAt ? '#9aa3ad' : (participantFlag.flag.color|default ?: '#17a2b8') %}
                         {% set ff = participantFlag.deletedAt ? '#5f6b7a' : (participantFlag.flag.foregroundColor|default ?: '#ffffff') %}
+                        {% set hasPrice = participantFlag.flagOffer.price|default(0) != 0 %}
                         <div class="fb-row">
-                            <span class="fb {{ participantFlag.deletedAt ? 'strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if participantFlag.flagOffer.price|default(0) != 0 %}<span class="fb-price {{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }},- Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
+                            <span class="fb{{ hasPrice ? ' has-price' : '' }}{{ participantFlag.deletedAt ? ' strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if hasPrice %}<span class="fb-price {{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }},- Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
                         </div>
                     {% endfor %}
                 {% endfor %}

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -5,41 +5,44 @@
   is added by ExportService::getPdfFromHtml. Rendered by WebAdminParticipantsListController::showParticipantsListPdf.
 #}
 <style>
-    body { font-family: DejaVu Sans, sans-serif; font-size: 7.5pt; color: #1a2533; }
+    body { font-family: DejaVu Sans, sans-serif; font-size: 8pt; color: #1a2533; line-height: 1.4; }
     .doc-head { border-bottom: 1.5px solid #006FAD; padding-bottom: 3px; margin-bottom: 6px; }
-    .doc-head h1 { font-size: 13pt; margin: 0; color: #006FAD; }
-    .doc-head .sub { font-size: 8.5pt; color: #555; margin-top: 1px; }
+    .doc-head h1 { font-size: 14pt; margin: 0; color: #006FAD; }
+    .doc-head .sub { font-size: 9pt; color: #555; margin-top: 1px; }
     table.plist { width: 100%; border-collapse: collapse; }
-    table.plist thead th { background: #006FAD; color: #fff; font-size: 7pt; font-weight: bold;
-        text-align: left; padding: 3px 5px; border: 0.5px solid #2b6f96; }
-    table.plist td { border: 0.5px solid #c2cad3; padding: 3px 5px; vertical-align: top; }
+    table.plist thead th { background: #006FAD; color: #fff; font-size: 7.5pt; font-weight: bold;
+        text-align: left; padding: 4px 7px; border: 0.5px solid #2b6f96; }
+    table.plist td { border: 0.5px solid #d4dbe3; padding: 5px 7px; vertical-align: top; }
     /* Celá položka (řádek) vždy na jedné stránce — mPDF nesmí řádek rozdělit přes zlom. */
     table.plist tbody tr { page-break-inside: avoid; }
-    table.plist tr.zebra td { background: #f4f8fb; }
+    table.plist tr.zebra td { background: #f6f9fc; }
     table.plist tr.deleted td { background: #fbe3e3; }
     .muted { color: #5f6b7a; }
-    .nm { font-size: 8.5pt; font-weight: bold; color: #1a2533; }
-    .id-badge { background: #006FAD; color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; }
+    .nm { font-size: 9pt; font-weight: bold; color: #1a2533; }
+    .id-badge { background: #006FAD; color: #fff; font-weight: bold; padding: 1px 6px; border-radius: 9px; font-size: 7.5pt; }
     .ok { color: #1a7a3c; font-weight: bold; }
     .bad { color: #c0392b; font-weight: bold; }
     .note { color: #c8730a; }
     .strike { text-decoration: line-through; }
     /* Flag badges: každý příznak na vlastním řádku (pod sebou), soudržná zaoblená pilulka =
        název (barva příznaku) + volitelná cena na navazující polovině (+ červená / − zelená). */
-    .fb-row { margin-bottom: 3px; line-height: 1.5; }
-    .fb { display: inline-block; border-radius: 8px; font-size: 7pt; font-weight: bold;
-        background: #17a2b8; color: #fff; padding: 1.5px 8px; }
-    .fb.has-price { border-radius: 8px 0 0 8px; padding-right: 6px; }
-    .fb-price { display: inline-block; border-radius: 0 8px 8px 0; font-size: 7pt; font-weight: bold;
-        padding: 1.5px 8px; }
+    .fb-row { margin-bottom: 4px; line-height: 1.6; }
+    .fb { display: inline-block; border-radius: 9px; font-size: 7.5pt; font-weight: bold;
+        background: #17a2b8; color: #fff; padding: 2px 9px; }
+    .fb.has-price { border-radius: 9px 0 0 9px; padding-right: 7px; }
+    .fb-price { display: inline-block; border-radius: 0 9px 9px 0; font-size: 7.5pt; font-weight: bold;
+        padding: 2px 9px; }
     .fb-pos { background: #c0392b; color: #fff; }
     .fb-neg { background: #1a7a3c; color: #fff; }
-    .gi { font-size: 8pt; } .gi-f { color: #c0398a; } .gi-m { color: #2b6cb0; }
-    .pay-badge { color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; font-size: 7pt; }
+    .gi { font-size: 9pt; } .gi-f { color: #c0398a; } .gi-m { color: #2b6cb0; }
+    /* Platba: částka + ukazatel postupu (jako na obrazovce / v referenci). */
+    .pay-price { font-size: 9.5pt; font-weight: bold; }
+    .bar { height: 8px; background: #e6ebf1; border-radius: 5px; margin: 3px 0 2px; }
+    .bar-fill { height: 8px; border-radius: 5px; }
     .c-success { background: #1a7a3c; } .c-danger { background: #c0392b; }
-    .c-warning { background: #c87f0a; } .c-info { background: #006FAD; }
+    .c-warning { background: #c87f0a; } .c-info { background: #2b6cb0; }
     .t-success { color: #1a7a3c; } .t-danger { color: #c0392b; }
-    .t-warning { color: #c87f0a; } .t-info { color: #006FAD; }
+    .t-warning { color: #c87f0a; } .t-info { color: #2b6cb0; }
     /* Omezení (scope) — tabulka shrnující rozsah výběru, jako na obrazovce. */
     table.scope { width: 100%; border-collapse: collapse; margin: 4px 0 8px; }
     table.scope th { background: #eaf3fb; color: #1a2533; font-size: 7.5pt; text-align: left;
@@ -122,9 +125,9 @@
                 {% endfor %}
             </td>
             <td>
-                <span class="pay-badge c-{{ paidColor }}">{{ paymentLabel }}</span>{% if participant.price != 0 %} <strong class="t-{{ paidColor }}">{{ paidPercentage }} %</strong>{% endif %}<br>
-                <span class="t-{{ paidColor }}"><strong>zbývá {{ participant.remainingPrice|default(0) }},- Kč</strong></span><br>
-                <span class="muted">zaplaceno {{ participant.paidPrice|default(0) }} z {{ participant.price|default(0) }},- Kč</span><br>
+                <span class="pay-price t-{{ paidColor }}">{{ participant.paidPrice|default(0) }},- Kč</span>
+                <span class="muted">z {{ participant.price|default(0) }},- Kč</span><br>
+                <span class="t-{{ paidColor }}"><strong>{{ paymentLabel }}{% if participant.price != 0 %} ({{ paidPercentage }} %){% endif %}</strong>{% if participant.remainingPrice|default(0) != 0 %} · zbývá {{ participant.remainingPrice }},- Kč{% endif %}</span><br>
                 <span class="muted">VS: {{ participant.variableSymbol|default('—') }}</span>
             </td>
         </tr>

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -24,11 +24,15 @@
     .bad { color: #c0392b; font-weight: bold; }
     .note { color: #c8730a; }
     .strike { text-decoration: line-through; }
-    /* Flag badge: name half (flag colour via inline style) + price half (+ red / − green). */
-    .fb { border-radius: 3px; font-size: 6.8pt; font-weight: bold; background: #17a2b8; color: #fff;
-        padding: 1px 4px; margin-right: 2px; line-height: 1.9; white-space: nowrap; }
-    .fb-pos { background: #c0392b; color: #fff; border-radius: 3px; font-size: 6.8pt; font-weight: bold; padding: 1px 4px; }
-    .fb-neg { background: #1a7a3c; color: #fff; border-radius: 3px; font-size: 6.8pt; font-weight: bold; padding: 1px 4px; }
+    /* Flag badges: každý příznak na vlastním řádku (pod sebou) = čistě, jako na obrazovce.
+       Pilulka = název (barva příznaku) + volitelně cena (+ červená / − zelená). */
+    .fb-row { margin-bottom: 2.5px; }
+    .fb { display: inline-block; border-radius: 3px; font-size: 7pt; font-weight: bold;
+        background: #17a2b8; color: #fff; padding: 1px 6px; }
+    .fb-price { display: inline-block; border-radius: 3px; font-size: 7pt; font-weight: bold;
+        padding: 1px 6px; margin-left: 2px; }
+    .fb-pos { background: #c0392b; color: #fff; }
+    .fb-neg { background: #1a7a3c; color: #fff; }
     .pay-badge { color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; font-size: 7pt; }
     .c-success { background: #1a7a3c; } .c-danger { background: #c0392b; }
     .c-warning { background: #c87f0a; } .c-info { background: #006FAD; }
@@ -107,14 +111,16 @@
                     {% for participantFlag in flagGroup.participantFlags %}
                         {% set fc = participantFlag.deletedAt ? '#9aa3ad' : (participantFlag.flag.color|default ?: '#17a2b8') %}
                         {% set ff = participantFlag.deletedAt ? '#5f6b7a' : (participantFlag.flag.foregroundColor|default ?: '#ffffff') %}
-                        <span class="fb {{ participantFlag.deletedAt ? 'strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if participantFlag.flagOffer.price|default(0) != 0 %}<span class="{{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }} Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
+                        <div class="fb-row">
+                            <span class="fb {{ participantFlag.deletedAt ? 'strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if participantFlag.flagOffer.price|default(0) != 0 %}<span class="fb-price {{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }},- Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
+                        </div>
                     {% endfor %}
                 {% endfor %}
             </td>
             <td>
-                <span class="pay-badge c-{{ paidColor }}">{{ paymentLabel }}</span><br>
-                <span class="t-{{ paidColor }}"><strong>zbývá {{ participant.remainingPrice|default(0) }} Kč</strong></span><br>
-                zaplaceno {{ participant.paidPrice|default(0) }} z {{ participant.price|default(0) }} Kč{% if participant.price != 0 %} · {{ paidPercentage }} %{% endif %}<br>
+                <span class="pay-badge c-{{ paidColor }}">{{ paymentLabel }}</span>{% if participant.price != 0 %} <strong class="t-{{ paidColor }}">{{ paidPercentage }} %</strong>{% endif %}<br>
+                <span class="t-{{ paidColor }}"><strong>zbývá {{ participant.remainingPrice|default(0) }},- Kč</strong></span><br>
+                <span class="muted">zaplaceno {{ participant.paidPrice|default(0) }} z {{ participant.price|default(0) }},- Kč</span><br>
                 <span class="muted">VS: {{ participant.variableSymbol|default('—') }}</span>
             </td>
         </tr>

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -34,11 +34,30 @@
     .c-warning { background: #c87f0a; } .c-info { background: #006FAD; }
     .t-success { color: #1a7a3c; } .t-danger { color: #c0392b; }
     .t-warning { color: #c87f0a; } .t-info { color: #006FAD; }
+    /* Omezení (scope) — tabulka shrnující rozsah výběru, jako na obrazovce. */
+    table.scope { width: 100%; border-collapse: collapse; margin: 4px 0 8px; }
+    table.scope th { background: #eaf3fb; color: #1a2533; font-size: 7.5pt; text-align: left;
+        padding: 2px 6px; border: 0.5px solid #b8cfe0; }
+    table.scope td { font-size: 7.5pt; padding: 2px 6px; border: 0.5px solid #cdd6df; }
+    table.scope td.lbl { width: 28%; color: #5f6b7a; }
 </style>
 <div class="doc-head">
     <h1>Přehled přihlášek</h1>
     <div class="sub">{{ subtitle }}</div>
 </div>
+{% if categoryName is defined and (categoryName or eventNames|default([]) is not empty) %}
+    <table class="scope">
+        <tr><th colspan="2">Omezení výběru</th></tr>
+        {% if categoryName %}
+            <tr><td class="lbl">Kategorie účastníka</td><td><strong>{{ categoryName }}</strong></td></tr>
+        {% endif %}
+        <tr>
+            <td class="lbl">Událost</td>
+            <td><strong>{% if eventNames|default([]) is empty %}všechny akce{% else %}{{ eventNames|join(', ') }}{% endif %}</strong></td>
+        </tr>
+        <tr><td class="lbl">Počet záznamů</td><td><strong>{{ count|default(participants|length) }}</strong></td></tr>
+    </table>
+{% endif %}
 <table class="plist">
     <thead>
     <tr>

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -1,0 +1,104 @@
+{#
+  Rich "browse-style" participant list for PDF (mPDF). Mirrors the web-admin list screen content
+  — coloured flag badges with prices, payment status, notes, contact — but in mPDF-safe markup
+  (table layout, inline-coloured spans, no flexbox/emoji). Branded chrome (logo header + footer)
+  is added by ExportService::getPdfFromHtml. Rendered by WebAdminParticipantsListController::showParticipantsListPdf.
+#}
+<style>
+    body { font-family: DejaVu Sans, sans-serif; font-size: 7.5pt; color: #1a2533; }
+    .doc-head { border-bottom: 1.5px solid #006FAD; padding-bottom: 3px; margin-bottom: 6px; }
+    .doc-head h1 { font-size: 13pt; margin: 0; color: #006FAD; }
+    .doc-head .sub { font-size: 8.5pt; color: #555; margin-top: 1px; }
+    table.plist { width: 100%; border-collapse: collapse; }
+    table.plist thead th { background: #006FAD; color: #fff; font-size: 7pt; font-weight: bold;
+        text-align: left; padding: 3px 5px; border: 0.5px solid #2b6f96; }
+    table.plist td { border: 0.5px solid #c2cad3; padding: 3px 5px; vertical-align: top; }
+    table.plist tr.zebra td { background: #f4f8fb; }
+    table.plist tr.deleted td { background: #fbe3e3; }
+    .muted { color: #5f6b7a; }
+    .nm { font-size: 8.5pt; font-weight: bold; color: #1a2533; }
+    .id-badge { background: #006FAD; color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; }
+    .ok { color: #1a7a3c; font-weight: bold; }
+    .bad { color: #c0392b; font-weight: bold; }
+    .note { color: #c8730a; }
+    .strike { text-decoration: line-through; }
+    /* Flag badge: name half (flag colour via inline style) + price half (+ red / − green). */
+    .fb { border-radius: 3px; font-size: 6.8pt; font-weight: bold; background: #17a2b8; color: #fff;
+        padding: 1px 4px; margin-right: 2px; line-height: 1.9; white-space: nowrap; }
+    .fb-pos { background: #c0392b; color: #fff; border-radius: 3px; font-size: 6.8pt; font-weight: bold; padding: 1px 4px; }
+    .fb-neg { background: #1a7a3c; color: #fff; border-radius: 3px; font-size: 6.8pt; font-weight: bold; padding: 1px 4px; }
+    .pay-badge { color: #fff; font-weight: bold; padding: 0 4px; border-radius: 3px; font-size: 7pt; }
+    .c-success { background: #1a7a3c; } .c-danger { background: #c0392b; }
+    .c-warning { background: #c87f0a; } .c-info { background: #006FAD; }
+    .t-success { color: #1a7a3c; } .t-danger { color: #c0392b; }
+    .t-warning { color: #c87f0a; } .t-info { color: #006FAD; }
+</style>
+<div class="doc-head">
+    <h1>Přehled přihlášek</h1>
+    <div class="sub">{{ subtitle }}</div>
+</div>
+<table class="plist">
+    <thead>
+    <tr>
+        <th width="22%">ID / kontakt</th>
+        <th width="30%">Účastník · akce · poznámky</th>
+        <th width="27%">Příznaky</th>
+        <th width="21%">Zaplaceno</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for participant in participants %}
+        {% set contact = participant.contact(false)|default %}
+        {% set appUser = contact.appUser|default %}
+        {% set isDeleted = participant.deletedAt|default %}
+        {% set paidPercentage = (participant.paidPricePercentage * 100)|round %}
+        {% set paidColor = participant.remainingPrice > 0 ? 'danger' : 'success' %}
+        {% set paidColor = participant.remainingDeposit <= 0 ? 'warning' : paidColor %}
+        {% set paidColor = participant.remainingPrice < 0 ? 'info' : paidColor %}
+        {% set paidColor = participant.remainingPrice == 0 ? 'success' : paidColor %}
+        {% set paymentLabel = {'success': 'Zaplaceno', 'danger': 'Nezaplaceno', 'warning': 'Záloha uhrazena', 'info': 'Přeplaceno'}[paidColor]|default('—') %}
+        <tr class="{{ isDeleted ? 'deleted' : (loop.index is odd ? '' : 'zebra') }}">
+            <td>
+                <span class="id-badge">{{ participant.id }}</span>
+                <span class="muted">{{ participant.createdAt|date("j. n. Y, H:i") }}</span><br>
+                {% if isDeleted %}<span class="bad">smazáno {{ participant.deletedAt|date("j. n. Y") }}</span><br>{% endif %}
+                {% if appUser and appUser.activated %}
+                    <span class="ok">✓ ověřeno</span> <span class="muted">{{ appUser.activated|date("j. n. Y") }}</span><br>
+                {% else %}
+                    <span class="bad">✗ neověřeno</span><br>
+                {% endif %}
+                {% if contact.phone|default %}tel. {{ contact.phone }}<br>{% endif %}
+                {% if contact.email|default %}<span class="muted">{{ contact.email }}</span>{% endif %}
+            </td>
+            <td>
+                {% for participantContact in participant.participantContacts(false, false) %}
+                    <div class="nm {{ participantContact.active|default ? '' : 'strike' }}">{{ participantContact.contact.name|default }}</div>
+                {% endfor %}
+                {% for participantRange in participant.participantRegistrations(false, false) %}
+                    <div class="{{ participantRange.active|default ? '' : 'strike' }}">{{ participantRange.event.shortName|default }}{% if participantRange.offer.shortName|default %} · {{ participantRange.offer.shortName }}{% endif %}</div>
+                {% endfor %}
+                {% for note in participant.notes|filter(note => note.textValue|default|length > 0) %}
+                    <div class="note {{ note.deletedAt|default ? 'strike' : '' }}">{{ note.textValue }}{% if note.createdBy.shortName|default or note.createdBy.name|default %} <span class="muted">({{ note.createdBy.shortName|default(note.createdBy.name|default) }})</span>{% endif %}</div>
+                {% endfor %}
+            </td>
+            <td>
+                {% for flagGroup in participant.flagGroups|filter(flagGroup => flagGroup.participantFlags|length > 0) %}
+                    {% for participantFlag in flagGroup.participantFlags %}
+                        {% set fc = participantFlag.deletedAt ? '#9aa3ad' : (participantFlag.flag.color|default ?: '#17a2b8') %}
+                        {% set ff = participantFlag.deletedAt ? '#5f6b7a' : (participantFlag.flag.foregroundColor|default ?: '#ffffff') %}
+                        <span class="fb {{ participantFlag.deletedAt ? 'strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if participantFlag.flagOffer.price|default(0) != 0 %}<span class="{{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }} Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
+                    {% endfor %}
+                {% endfor %}
+            </td>
+            <td>
+                <span class="pay-badge c-{{ paidColor }}">{{ paymentLabel }}</span><br>
+                <span class="t-{{ paidColor }}"><strong>zbývá {{ participant.remainingPrice|default(0) }} Kč</strong></span><br>
+                zaplaceno {{ participant.paidPrice|default(0) }} z {{ participant.price|default(0) }} Kč{% if participant.price != 0 %} · {{ paidPercentage }} %{% endif %}<br>
+                <span class="muted">VS: {{ participant.variableSymbol|default('—') }}</span>
+            </td>
+        </tr>
+    {% else %}
+        <tr><td colspan="4">Žádné přihlášky odpovídající filtru.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -13,6 +13,8 @@
     table.plist thead th { background: #006FAD; color: #fff; font-size: 7pt; font-weight: bold;
         text-align: left; padding: 3px 5px; border: 0.5px solid #2b6f96; }
     table.plist td { border: 0.5px solid #c2cad3; padding: 3px 5px; vertical-align: top; }
+    /* Celá položka (řádek) vždy na jedné stránce — mPDF nesmí řádek rozdělit přes zlom. */
+    table.plist tbody tr { page-break-inside: avoid; }
     table.plist tr.zebra td { background: #f4f8fb; }
     table.plist tr.deleted td { background: #fbe3e3; }
     .muted { color: #5f6b7a; }

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -24,14 +24,14 @@
     .bad { color: #c0392b; font-weight: bold; }
     .note { color: #c8730a; }
     .strike { text-decoration: line-through; }
-    /* Flag badges: každý příznak na vlastním řádku (pod sebou), soudržná zaoblená pilulka =
-       název (barva příznaku) + volitelná cena na navazující polovině (+ červená / − zelená). */
-    .fb-row { margin-bottom: 4px; line-height: 1.6; }
-    .fb { display: inline-block; border-radius: 9px; font-size: 7.5pt; font-weight: bold;
-        background: #17a2b8; color: #fff; padding: 2px 9px; }
-    .fb.has-price { border-radius: 9px 0 0 9px; padding-right: 7px; }
-    .fb-price { display: inline-block; border-radius: 0 9px 9px 0; font-size: 7.5pt; font-weight: bold;
-        padding: 2px 9px; }
+    /* Flag badges: každý příznak na vlastním řádku (pod sebou). mPDF NEzaobluje border-radius
+       uvnitř buňky tabulky (viz docs/OSWIS_1_PDF_BADGES_MPDF_RESEARCH_2026-06-05.md) → čisté
+       hranaté štítky: název (barva příznaku) + cena jako oddělený štítek s mezerou (ne slepené). */
+    .fb-row { margin-bottom: 4px; line-height: 1.65; }
+    .fb { display: inline-block; font-size: 7.5pt; font-weight: bold;
+        background: #17a2b8; color: #fff; padding: 1.5px 7px; }
+    .fb-price { display: inline-block; font-size: 7.5pt; font-weight: bold;
+        padding: 1.5px 7px; margin-left: 2px; }
     .fb-pos { background: #c0392b; color: #fff; }
     .fb-neg { background: #1a7a3c; color: #fff; }
     .gi { font-size: 9pt; } .gi-f { color: #c0398a; } .gi-m { color: #2b6cb0; }
@@ -119,7 +119,7 @@
                         {% set ff = participantFlag.deletedAt ? '#5f6b7a' : (participantFlag.flag.foregroundColor|default ?: '#ffffff') %}
                         {% set hasPrice = participantFlag.flagOffer.price|default(0) != 0 %}
                         <div class="fb-row">
-                            <span class="fb{{ hasPrice ? ' has-price' : '' }}{{ participantFlag.deletedAt ? ' strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if hasPrice %}<span class="fb-price {{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }},- Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
+                            <span class="fb{{ participantFlag.deletedAt ? ' strike' : '' }}" style="background-color:{{ fc }}; color:{{ ff }};">{{ participantFlag.flag.shortName|default }}</span>{% if hasPrice %}<span class="fb-price {{ participantFlag.flagOffer.price > 0 ? 'fb-pos' : 'fb-neg' }}">{{ participantFlag.flagOffer.price > 0 ? '+' : '−' }}{{ participantFlag.flagOffer.price|abs }},- Kč</span>{% endif %}{% if participantFlag.textValue|default|length > 0 %} <span class="muted">{{ participantFlag.textValue }}</span>{% endif %}
                         </div>
                     {% endfor %}
                 {% endfor %}

--- a/Service/Participant/MailPreviewService.php
+++ b/Service/Participant/MailPreviewService.php
@@ -43,6 +43,37 @@ final class MailPreviewService
     }
 
     /**
+     * Curated catalog of insertable Twig tokens for the composer's "click to insert" panel — grouped,
+     * each entry a [label, snippet] pair. Tokens are the entity-API accessors actually used across the
+     * mail templates (verified), kept English. Block snippets use a literal turnus slug as a hint the
+     * admin edits. Static so both the bulk composer and (later) the #139 editor can render the same set.
+     *
+     * @return array<string, list<array{label: string, token: string}>>
+     */
+    public static function variableCatalog(): array
+    {
+        return [
+            'Příjemce' => [
+                ['label' => 'Oslovení (5. pád)', 'token' => '{{ contact.salutationName }}'],
+                ['label' => 'Jméno', 'token' => '{{ contact.name }}'],
+            ],
+            'Akce / turnus' => [
+                ['label' => 'Název akce', 'token' => '{{ participant.event(false).name }}'],
+                ['label' => 'Slug akce (turnus)', 'token' => '{{ participant.event(false).slug }}'],
+            ],
+            'Platba' => [
+                ['label' => 'Variabilní symbol', 'token' => '{{ participant.variableSymbol }}'],
+                ['label' => 'Cena', 'token' => '{{ participant.price }}'],
+                ['label' => 'Zbývá zaplatit', 'token' => '{{ participant.remainingPrice }}'],
+            ],
+            'Podmínkové bloky' => [
+                ['label' => 'Jen 1. turnus', 'token' => "{% if participant.event(false).slug == 'seznamovak-up-2026-1-turnus' %}\n  …\n{% endif %}"],
+                ['label' => 'Jen nezaplacení', 'token' => "{% if participant.remainingPrice > 0 %}\n  …\n{% endif %}"],
+            ],
+        ];
+    }
+
+    /**
      * Pick a sample recipient for a preview: an explicit participant id wins; otherwise the most
      * recently created active participant. Returns null when the id is unknown or there are no
      * participants at all (callers render a friendly "no sample" message).

--- a/Service/Participant/MailPreviewService.php
+++ b/Service/Participant/MailPreviewService.php
@@ -8,6 +8,8 @@ use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
 use OswisOrg\OswisAddressBookBundle\Entity\Person;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Twig\Environment;
 
 /**
@@ -25,6 +27,15 @@ use Twig\Environment;
  */
 final class MailPreviewService
 {
+    /**
+     * Mirrors the f / a / salName seeding at the top of message.html.twig so a free body FRAGMENT
+     * (which does not extend that base) still has the Czech salutation helpers in scope.
+     */
+    private const string SALUTATION_PRELUDE =
+        "{% set f = f is defined ? f : (contact.formal|default(appUser.formal|default(true))) %}"
+        ."{% set a = a is defined ? a : (contact.czechSuffixA|default(appUser.czechSuffixA|default(''))) %}"
+        ."{% set salName = salutationName|default(contact.salutationName|default(appUser.salutationName|default)) %}";
+
     public function __construct(
         private readonly Environment $twig,
         private readonly ParticipantRepository $participantRepository,
@@ -128,6 +139,40 @@ final class MailPreviewService
         } catch (\Throwable $exception) {
             return ['html' => $this->errorHtml($exception), 'subject' => $subject, 'error' => $exception->getMessage()];
         }
+    }
+
+    /**
+     * Render a TRUSTED body FRAGMENT (not a full template — it does not extend message.html.twig) as
+     * Twig against the recipient context, then sanitize the rendered HTML. The fragment may use
+     * entity-API variables and conditional blocks — e.g. {{ contact.salutationName }} or
+     * {% if participant.event(false).slug == 'seznamovak-up-2026-1' %}…{% endif %} — and the Czech
+     * salutation helpers (f / a / salName) thanks to the prepended prelude. Throws on a Twig error so
+     * the caller can decide (queue-validation rejects; the drain falls back to the raw body). The
+     * sanitized output is then wrapped by the ad-hoc template's content_inner via {{ bodyHtml|raw }}.
+     *
+     * @param array<string, mixed> $extra overrides (e.g. the specific recipient appUser of an org)
+     */
+    public function renderBodyFragment(string $bodyTwig, Participant $participant, array $extra = []): string
+    {
+        $context = $this->buildContext($participant, $extra);
+
+        return $this->sanitizeHtml($this->twig->createTemplate(self::SALUTATION_PRELUDE.$bodyTwig)->render($context));
+    }
+
+    /**
+     * Sanitize rendered body HTML — safe elements + http/https/mailto/tel links only. Applied to the
+     * Twig OUTPUT (not the trusted source), so admins keep full Twig power while the delivered markup
+     * stays safe. Same config the bulk composer used on input before bodies became trusted Twig.
+     */
+    public function sanitizeHtml(string $html): string
+    {
+        return (new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowLinkSchemes(['http', 'https', 'mailto', 'tel'])
+                ->allowRelativeLinks(false)
+                ->allowRelativeMedias(false),
+        ))->sanitize($html);
     }
 
     /**

--- a/Service/Participant/MailPreviewService.php
+++ b/Service/Participant/MailPreviewService.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Service\Participant;
+
+use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
+use OswisOrg\OswisAddressBookBundle\Entity\Person;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use Twig\Environment;
+
+/**
+ * Faithful, server-side e-mail PREVIEW — the single source of truth shared by the bulk composer and
+ * the #139 template editor (which until now edited blind). Renders either a named template (file path
+ * such as '@OswisOrgOswisCalendar/…' or a DB-stored slug resolved by the DatabaseLoader) OR an
+ * arbitrary, TRUSTED Twig source (the unsaved editor textarea) against a real sample participant,
+ * through the exact same MJML pipeline that real sends use. So "the preview is what the recipient
+ * gets" holds — minus client-specific quirks (Gmail/Outlook) and per-recipient attachments (QR codes
+ * are embedded via cid: only at send time → empty here).
+ *
+ * Trusted render = same trust level the #139 editor already grants (only ROLE_ADMIN can reach this).
+ * Render errors are caught and returned as a readable HTML block so a syntax/runtime error surfaces
+ * inside the preview iframe instead of bubbling up as a 500. No send, no persistence, no side effects.
+ */
+final class MailPreviewService
+{
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly ParticipantRepository $participantRepository,
+    ) {
+    }
+
+    /**
+     * Pick a sample recipient for a preview: an explicit participant id wins; otherwise the most
+     * recently created active participant. Returns null when the id is unknown or there are no
+     * participants at all (callers render a friendly "no sample" message).
+     */
+    public function pickSampleParticipant(?int $participantId = null): ?Participant
+    {
+        if (null !== $participantId && $participantId > 0) {
+            $participant = $this->participantRepository->find($participantId);
+
+            return $participant instanceof Participant ? $participant : null;
+        }
+        $samples = $this->participantRepository->findSampleParticipants(1);
+
+        return $samples[0] ?? null;
+    }
+
+    /**
+     * Superset render context covering every mail kind (summary / payment / campaign / ad-hoc), with
+     * send-neutral safe defaults for the per-recipient bits that cannot exist in a preview (the QR
+     * payment images are embedded via cid: at real send time → empty strings here). $extra overrides
+     * the defaults (e.g. the ad-hoc body, the composing admin's name). Mirrors the $data arrays built
+     * by {@see ParticipantMailService} so the preview matches the real send.
+     *
+     * @param array<string, mixed> $extra
+     *
+     * @return array<string, mixed>
+     */
+    public function buildContext(Participant $participant, array $extra = []): array
+    {
+        $contact = $participant->getContact();
+        $appUser = null;
+        foreach ($participant->getContactPersons(true) as $contactPerson) {
+            if ($contactPerson instanceof AbstractContact && null !== $contactPerson->getAppUser()) {
+                $appUser = $contactPerson->getAppUser();
+                break;
+            }
+        }
+        $base = [
+            'participant'      => $participant,
+            'appUser'          => $appUser,
+            'contact'          => $contact,
+            'salutationName'   => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
+            'type'             => 'preview',
+            'category'         => null,
+            'participantToken' => null,
+            'isIS'             => false,
+            'registrations'    => $participant->getParticipantRegistrations(true),
+            'payment'          => null,
+            'depositQr'        => '',
+            'restQr'           => '',
+        ];
+
+        return array_merge($base, $extra);
+    }
+
+    /**
+     * Render a named template (file path or DB-stored slug) for the sample participant.
+     *
+     * @param array<string, mixed> $extra
+     *
+     * @return array{html: string, subject: ?string, error: ?string}
+     */
+    public function renderTemplate(string $templateName, Participant $participant, array $extra = [], ?string $subject = null): array
+    {
+        $context = $this->buildContext($participant, $extra);
+        try {
+            return [
+                'html'    => $this->twig->render($templateName, $context),
+                'subject' => $this->renderSubject($subject, $context),
+                'error'   => null,
+            ];
+        } catch (\Throwable $exception) {
+            return ['html' => $this->errorHtml($exception), 'subject' => $subject, 'error' => $exception->getMessage()];
+        }
+    }
+
+    /**
+     * Render arbitrary TRUSTED Twig source (e.g. the unsaved content of the #139 editor textarea) for
+     * the sample participant — same trust level as the persisted template the admin is editing.
+     *
+     * @param array<string, mixed> $extra
+     *
+     * @return array{html: string, subject: ?string, error: ?string}
+     */
+    public function renderSource(string $source, Participant $participant, array $extra = [], ?string $subject = null): array
+    {
+        $context = $this->buildContext($participant, $extra);
+        try {
+            return [
+                'html'    => $this->twig->createTemplate($source)->render($context),
+                'subject' => $this->renderSubject($subject, $context),
+                'error'   => null,
+            ];
+        } catch (\Throwable $exception) {
+            return ['html' => $this->errorHtml($exception), 'subject' => $subject, 'error' => $exception->getMessage()];
+        }
+    }
+
+    /**
+     * Render a subject line — as trusted Twig source when it contains Twig markup, else verbatim.
+     * A broken subject template falls back to the raw string (the body preview is what matters).
+     *
+     * @param array<string, mixed> $context
+     */
+    private function renderSubject(?string $subject, array $context): ?string
+    {
+        if (null === $subject || '' === trim($subject)) {
+            return $subject;
+        }
+        if (!str_contains($subject, '{{') && !str_contains($subject, '{%')) {
+            return $subject;
+        }
+        try {
+            return trim($this->twig->createTemplate($subject)->render($context));
+        } catch (\Throwable) {
+            return $subject;
+        }
+    }
+
+    private function errorHtml(\Throwable $exception): string
+    {
+        return sprintf(
+            '<div style="font-family:monospace;color:#842029;background:#f8d7da;border:1px solid #f5c2c7;'
+            .'border-radius:.375rem;padding:1rem;white-space:pre-wrap;">'
+            .'<strong>Chyba při vykreslení náhledu:</strong><br><br>%s</div>',
+            htmlspecialchars($exception->getMessage(), ENT_QUOTES),
+        );
+    }
+}

--- a/Service/Participant/ParticipantBulkMailService.php
+++ b/Service/Participant/ParticipantBulkMailService.php
@@ -90,6 +90,35 @@ class ParticipantBulkMailService
     }
 
     /**
+     * Twig context for rendering {@see AD_HOC_TEMPLATE} as a PREVIEW for one participant (the first
+     * contact person, if any). Same shape the drain uses, so the preview is faithful. No send.
+     *
+     * @return array<string, mixed>
+     */
+    public function previewContext(Participant $participant, string $subject, string $bodyHtml, ?string $adminName): array
+    {
+        $contact = $participant->getContact();
+        $appUser = null;
+        foreach ($participant->getContactPersons(true) as $contactPerson) {
+            if ($contactPerson instanceof AbstractContact && null !== $contactPerson->getAppUser()) {
+                $appUser = $contactPerson->getAppUser();
+                break;
+            }
+        }
+
+        return [
+            'participant'    => $participant,
+            'appUser'        => $appUser,
+            'contact'        => $contact,
+            'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
+            'subject'        => $subject,
+            'bodyHtml'       => $bodyHtml,
+            'adminName'      => $adminName,
+            'type'           => 'ad-hoc-bulk-preview',
+        ];
+    }
+
+    /**
      * Send the bulk's message to one participant's contact persons (Person = 1 address, Org = N).
      * Returns true if at least one address was actually delivered (isSent).
      */

--- a/Service/Participant/ParticipantBulkMailService.php
+++ b/Service/Participant/ParticipantBulkMailService.php
@@ -94,43 +94,69 @@ class ParticipantBulkMailService
      * (cursor advanced per recipient → a crash re-sends at most one). Marks the bulk done when the
      * cursor reaches the end.
      *
-     * @return array{sent: int, failed: int, processed: int, total: int, done: bool}
+     * Concurrency: the status-page JS auto-drain and the cron command (and two admin tabs) can call
+     * this for the SAME bulk at the same time — two drains reading the same cursor would send the
+     * same slice twice (duplicate mail to real recipients). A per-bulk MariaDB advisory lock
+     * (GET_LOCK, non-blocking, connection-scoped, auto-released on disconnect) serializes drains
+     * without holding a DB transaction across SMTP sends. A caller that does not get the lock
+     * returns immediately with busy=true and NO progress (the JS backs off and re-polls; the cron
+     * breaks on zero progress and resumes next tick). The entity is refresh()ed AFTER acquiring the
+     * lock — the caller may hold a cursor that another drain has meanwhile advanced.
+     *
+     * @return array{sent: int, failed: int, processed: int, total: int, done: bool, busy: bool}
      */
     public function drainBatch(ParticipantMailBulk $bulk, int $batchSize = 15): array
     {
         if ($bulk->isDone()) {
             return $this->progress($bulk, 0, 0);
         }
-        if (ParticipantMailBulk::STATUS_SENDING !== $bulk->getStatus()) {
-            $bulk->setStatus(ParticipantMailBulk::STATUS_SENDING);
-            $this->em->flush();
-        }
-        $ids = $bulk->getParticipantIds();
-        $start = $bulk->getProcessedCount();
-        $slice = array_slice($ids, $start, max(1, $batchSize));
-        $sent = 0;
-        $failed = 0;
+        $lockName = sprintf('oswis_bulk_drain_%d', $bulk->getId() ?? 0);
+        $connection = $this->em->getConnection();
+        $acquired = $connection->fetchOne('SELECT GET_LOCK(?, 0)', [$lockName]);
+        if (!is_numeric($acquired) || 1 !== (int) $acquired) {
+            $this->logger->info(sprintf('Bulk #%d: drain already running elsewhere, skipping.', $bulk->getId() ?? 0));
 
-        foreach ($slice as $position => $participantId) {
-            $participant = $this->em->find(Participant::class, $participantId);
-            $delivered = $participant instanceof Participant && $this->sendToParticipant($bulk, $participant);
-            if ($delivered) {
-                $bulk->recordSent();
-                ++$sent;
-            } else {
-                $bulk->recordFailed(sprintf('#%d: nedoručeno', (int) $participantId));
-                ++$failed;
+            return $this->progress($bulk, 0, 0, busy: true);
+        }
+        try {
+            // Fresh cursor: our entity may predate a drain that just finished on another connection.
+            $this->em->refresh($bulk);
+            if ($bulk->isDone()) {
+                return $this->progress($bulk, 0, 0);
             }
-            $bulk->setProcessedCount($start + (int) $position + 1);
-            $this->em->flush();
-        }
+            if (ParticipantMailBulk::STATUS_SENDING !== $bulk->getStatus()) {
+                $bulk->setStatus(ParticipantMailBulk::STATUS_SENDING);
+                $this->em->flush();
+            }
+            $ids = $bulk->getParticipantIds();
+            $start = $bulk->getProcessedCount();
+            $slice = array_slice($ids, $start, max(1, $batchSize));
+            $sent = 0;
+            $failed = 0;
 
-        if ($bulk->getProcessedCount() >= $bulk->getTotalCount()) {
-            $bulk->setStatus(ParticipantMailBulk::STATUS_DONE);
-            $this->em->flush();
-        }
+            foreach ($slice as $position => $participantId) {
+                $participant = $this->em->find(Participant::class, $participantId);
+                $delivered = $participant instanceof Participant && $this->sendToParticipant($bulk, $participant);
+                if ($delivered) {
+                    $bulk->recordSent();
+                    ++$sent;
+                } else {
+                    $bulk->recordFailed(sprintf('#%d: nedoručeno', (int) $participantId));
+                    ++$failed;
+                }
+                $bulk->setProcessedCount($start + (int) $position + 1);
+                $this->em->flush();
+            }
 
-        return $this->progress($bulk, $sent, $failed);
+            if ($bulk->getProcessedCount() >= $bulk->getTotalCount()) {
+                $bulk->setStatus(ParticipantMailBulk::STATUS_DONE);
+                $this->em->flush();
+            }
+
+            return $this->progress($bulk, $sent, $failed);
+        } finally {
+            $connection->executeQuery('SELECT RELEASE_LOCK(?)', [$lockName]);
+        }
     }
 
     /**
@@ -213,9 +239,9 @@ class ParticipantBulkMailService
     }
 
     /**
-     * @return array{sent: int, failed: int, processed: int, total: int, done: bool}
+     * @return array{sent: int, failed: int, processed: int, total: int, done: bool, busy: bool}
      */
-    private function progress(ParticipantMailBulk $bulk, int $sent, int $failed): array
+    private function progress(ParticipantMailBulk $bulk, int $sent, int $failed, bool $busy = false): array
     {
         return [
             'sent'      => $sent,
@@ -223,6 +249,7 @@ class ParticipantBulkMailService
             'processed' => $bulk->getProcessedCount(),
             'total'     => $bulk->getTotalCount(),
             'done'      => $bulk->isDone(),
+            'busy'      => $busy,
         ];
     }
 }

--- a/Service/Participant/ParticipantBulkMailService.php
+++ b/Service/Participant/ParticipantBulkMailService.php
@@ -4,11 +4,11 @@ namespace OswisOrg\OswisCalendarBundle\Service\Participant;
 
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
-use OswisOrg\OswisAddressBookBundle\Entity\Person;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository;
+use OswisOrg\OswisCoreBundle\Exceptions\OswisException;
 use OswisOrg\OswisCoreBundle\Service\MailService;
 use Psr\Log\LoggerInterface;
 
@@ -27,22 +27,66 @@ class ParticipantBulkMailService
         protected EntityManagerInterface $em,
         protected MailService $mailService,
         protected ParticipantMailRepository $participantMailRepository,
+        protected MailPreviewService $mailPreview,
         protected LoggerInterface $logger,
     ) {
     }
 
     /**
-     * Create a queued bulk (snapshot of recipient IDs). Sends nothing.
+     * Create a queued bulk (snapshot of recipient IDs). Sends nothing. The optional $templateSlug
+     * selects a stored campaign/snippet to send instead of the free body. Queue-validation renders the
+     * message against the first recipient and throws {@see OswisException} if the Twig won't compile —
+     * a typo is caught here, never delivered to real recipients via the drain.
      *
      * @param array<int> $participantIds
+     *
+     * @throws OswisException when the message fails to render against the first recipient
      */
-    public function queue(string $subject, string $bodyHtml, array $participantIds, ?string $adminName = null): ParticipantMailBulk
-    {
-        $bulk = new ParticipantMailBulk($subject, $bodyHtml, $participantIds, $adminName);
+    public function queue(
+        string $subject,
+        string $bodyHtml,
+        array $participantIds,
+        ?string $adminName = null,
+        ?string $templateSlug = null,
+    ): ParticipantMailBulk {
+        $this->validateRender($bodyHtml, $templateSlug, $participantIds);
+        $bulk = new ParticipantMailBulk($subject, $bodyHtml, $participantIds, $adminName, $templateSlug);
         $this->em->persist($bulk);
         $this->em->flush();
 
         return $bulk;
+    }
+
+    /**
+     * Render the message (stored template, or free body fragment) against the FIRST recipient and throw
+     * on a Twig error. With no resolvable recipient there is nothing to validate (the empty-recipient
+     * guard lives in the controller). {@see queue}.
+     *
+     * @param array<int> $participantIds
+     *
+     * @throws OswisException
+     */
+    private function validateRender(string $bodyHtml, ?string $templateSlug, array $participantIds): void
+    {
+        $firstId = array_values($participantIds)[0] ?? null;
+        $participant = null !== $firstId ? $this->em->find(Participant::class, (int) $firstId) : null;
+        if (!$participant instanceof Participant) {
+            return;
+        }
+        try {
+            if (null !== $templateSlug && '' !== trim($templateSlug)) {
+                $result = $this->mailPreview->renderTemplate(trim($templateSlug), $participant);
+                if (null !== $result['error']) {
+                    throw new OswisException($result['error']);
+                }
+            } else {
+                $this->mailPreview->renderBodyFragment($bodyHtml, $participant);
+            }
+        } catch (OswisException $exception) {
+            throw $exception;
+        } catch (\Throwable $exception) {
+            throw new OswisException($exception->getMessage());
+        }
     }
 
     /**
@@ -91,12 +135,16 @@ class ParticipantBulkMailService
 
     /**
      * Send the bulk's message to one participant's contact persons (Person = 1 address, Org = N).
-     * Returns true if at least one address was actually delivered (isSent).
+     * Renders per recipient: a stored campaign/snippet template (template_slug) as a full mail, OR the
+     * free body as a trusted Twig fragment (entity-API variables + conditional blocks) into the ad-hoc
+     * wrapper. A body render error for one recipient falls back to the raw (sanitized) body + a log
+     * line, so one recipient missing a field never blocks the rest of the bulk. Returns true if at
+     * least one address was actually delivered (isSent).
      */
     private function sendToParticipant(ParticipantMailBulk $bulk, Participant $participant): bool
     {
-        $contact = $participant->getContact();
         $type = sprintf('ad-hoc-bulk-%d', $bulk->getId() ?? 0);
+        $usesTemplate = $bulk->hasTemplate();
         $anyDelivered = false;
 
         foreach ($participant->getContactPersons(true) as $contactPerson) {
@@ -112,18 +160,41 @@ class ParticipantBulkMailService
                 $participantMail->setBulk($bulk);
                 $participantMail->setPastMails($this->participantMailRepository->findByParticipant($participant));
                 $participantMail->markAsManual();
-                $data = [
-                    'participant'    => $participant,
-                    'appUser'        => $appUser,
-                    'contact'        => $contact,
-                    'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
-                    'subject'        => $bulk->getSubject(),
-                    'bodyHtml'       => $bulk->getBodyHtml(),
-                    'adminName'      => $bulk->getAdminName(),
-                    'type'           => $type,
-                ];
+
+                if ($usesTemplate) {
+                    $templateName = (string) $bulk->getTemplateSlug();
+                    $data = $this->mailPreview->buildContext($participant, [
+                        'appUser'   => $appUser,
+                        'adminName' => $bulk->getAdminName(),
+                        'type'      => $type,
+                    ]);
+                } else {
+                    try {
+                        $renderedBody = $this->mailPreview->renderBodyFragment(
+                            $bulk->getBodyHtml(),
+                            $participant,
+                            ['appUser' => $appUser],
+                        );
+                    } catch (\Throwable $bodyError) {
+                        $renderedBody = $this->mailPreview->sanitizeHtml($bulk->getBodyHtml());
+                        $this->logger->warning(sprintf(
+                            'Bulk #%d → participant #%d: body Twig render failed, raw fallback used: %s',
+                            $bulk->getId() ?? 0,
+                            $participant->getId() ?? 0,
+                            $bodyError->getMessage(),
+                        ));
+                    }
+                    $templateName = self::AD_HOC_TEMPLATE;
+                    $data = $this->mailPreview->buildContext($participant, [
+                        'appUser'   => $appUser,
+                        'adminName' => $bulk->getAdminName(),
+                        'type'      => $type,
+                        'bodyHtml'  => $renderedBody,
+                    ]);
+                }
+
                 $this->em->persist($participantMail);
-                $this->mailService->sendEMail($participantMail, self::AD_HOC_TEMPLATE, $data);
+                $this->mailService->sendEMail($participantMail, $templateName, $data);
                 if ($participantMail->isSent()) {
                     $anyDelivered = true;
                 }

--- a/Service/Participant/ParticipantBulkMailService.php
+++ b/Service/Participant/ParticipantBulkMailService.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace OswisOrg\OswisCalendarBundle\Service\Participant;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
+use OswisOrg\OswisAddressBookBundle\Entity\Person;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
+use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMailBulk;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailRepository;
+use OswisOrg\OswisCoreBundle\Service\MailService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Queue + drain of the ad-hoc bulk e-mail outbox ({@see ParticipantMailBulk}). Sending is synchronous
+ * blocking SMTP, so a bulk is drained in capped batches (cron command / JS auto-drain), never in one
+ * request. Per-recipient send replicates {@see ParticipantMailService::sendAdHoc} but tags each mail
+ * with the bulk (audit), is failure-aware (counts only real isSent deliveries), and advances the bulk
+ * cursor per recipient so a crash re-sends at most one.
+ */
+class ParticipantBulkMailService
+{
+    public const AD_HOC_TEMPLATE = '@OswisOrgOswisCalendar/e-mail/pages/participant-ad-hoc.html.twig';
+
+    public function __construct(
+        protected EntityManagerInterface $em,
+        protected MailService $mailService,
+        protected ParticipantMailRepository $participantMailRepository,
+        protected LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Create a queued bulk (snapshot of recipient IDs). Sends nothing.
+     *
+     * @param array<int> $participantIds
+     */
+    public function queue(string $subject, string $bodyHtml, array $participantIds, ?string $adminName = null): ParticipantMailBulk
+    {
+        $bulk = new ParticipantMailBulk($subject, $bodyHtml, $participantIds, $adminName);
+        $this->em->persist($bulk);
+        $this->em->flush();
+
+        return $bulk;
+    }
+
+    /**
+     * Drain up to $batchSize recipients of $bulk, starting from its cursor. Idempotent + resumable
+     * (cursor advanced per recipient → a crash re-sends at most one). Marks the bulk done when the
+     * cursor reaches the end.
+     *
+     * @return array{sent: int, failed: int, processed: int, total: int, done: bool}
+     */
+    public function drainBatch(ParticipantMailBulk $bulk, int $batchSize = 15): array
+    {
+        if ($bulk->isDone()) {
+            return $this->progress($bulk, 0, 0);
+        }
+        if (ParticipantMailBulk::STATUS_SENDING !== $bulk->getStatus()) {
+            $bulk->setStatus(ParticipantMailBulk::STATUS_SENDING);
+            $this->em->flush();
+        }
+        $ids = $bulk->getParticipantIds();
+        $start = $bulk->getProcessedCount();
+        $slice = array_slice($ids, $start, max(1, $batchSize));
+        $sent = 0;
+        $failed = 0;
+
+        foreach ($slice as $position => $participantId) {
+            $participant = $this->em->find(Participant::class, $participantId);
+            $delivered = $participant instanceof Participant && $this->sendToParticipant($bulk, $participant);
+            if ($delivered) {
+                $bulk->recordSent();
+                ++$sent;
+            } else {
+                $bulk->recordFailed(sprintf('#%d: nedoručeno', (int) $participantId));
+                ++$failed;
+            }
+            $bulk->setProcessedCount($start + (int) $position + 1);
+            $this->em->flush();
+        }
+
+        if ($bulk->getProcessedCount() >= $bulk->getTotalCount()) {
+            $bulk->setStatus(ParticipantMailBulk::STATUS_DONE);
+            $this->em->flush();
+        }
+
+        return $this->progress($bulk, $sent, $failed);
+    }
+
+    /**
+     * Send the bulk's message to one participant's contact persons (Person = 1 address, Org = N).
+     * Returns true if at least one address was actually delivered (isSent).
+     */
+    private function sendToParticipant(ParticipantMailBulk $bulk, Participant $participant): bool
+    {
+        $contact = $participant->getContact();
+        $type = sprintf('ad-hoc-bulk-%d', $bulk->getId() ?? 0);
+        $anyDelivered = false;
+
+        foreach ($participant->getContactPersons(true) as $contactPerson) {
+            if (!$contactPerson instanceof AbstractContact) {
+                continue;
+            }
+            $appUser = $contactPerson->getAppUser();
+            if (null === $appUser) {
+                continue;
+            }
+            try {
+                $participantMail = new ParticipantMail($participant, $appUser, $bulk->getSubject(), $type);
+                $participantMail->setBulk($bulk);
+                $participantMail->setPastMails($this->participantMailRepository->findByParticipant($participant));
+                $participantMail->markAsManual();
+                $data = [
+                    'participant'    => $participant,
+                    'appUser'        => $appUser,
+                    'contact'        => $contact,
+                    'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
+                    'subject'        => $bulk->getSubject(),
+                    'bodyHtml'       => $bulk->getBodyHtml(),
+                    'adminName'      => $bulk->getAdminName(),
+                    'type'           => $type,
+                ];
+                $this->em->persist($participantMail);
+                $this->mailService->sendEMail($participantMail, self::AD_HOC_TEMPLATE, $data);
+                if ($participantMail->isSent()) {
+                    $anyDelivered = true;
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(sprintf(
+                    'Bulk #%d → participant #%d (%s): %s',
+                    $bulk->getId() ?? 0,
+                    $participant->getId() ?? 0,
+                    (string) $appUser->getEmail(),
+                    $e->getMessage(),
+                ));
+            }
+        }
+
+        return $anyDelivered;
+    }
+
+    /**
+     * @return array{sent: int, failed: int, processed: int, total: int, done: bool}
+     */
+    private function progress(ParticipantMailBulk $bulk, int $sent, int $failed): array
+    {
+        return [
+            'sent'      => $sent,
+            'failed'    => $failed,
+            'processed' => $bulk->getProcessedCount(),
+            'total'     => $bulk->getTotalCount(),
+            'done'      => $bulk->isDone(),
+        ];
+    }
+}

--- a/Service/Participant/ParticipantBulkMailService.php
+++ b/Service/Participant/ParticipantBulkMailService.php
@@ -90,35 +90,6 @@ class ParticipantBulkMailService
     }
 
     /**
-     * Twig context for rendering {@see AD_HOC_TEMPLATE} as a PREVIEW for one participant (the first
-     * contact person, if any). Same shape the drain uses, so the preview is faithful. No send.
-     *
-     * @return array<string, mixed>
-     */
-    public function previewContext(Participant $participant, string $subject, string $bodyHtml, ?string $adminName): array
-    {
-        $contact = $participant->getContact();
-        $appUser = null;
-        foreach ($participant->getContactPersons(true) as $contactPerson) {
-            if ($contactPerson instanceof AbstractContact && null !== $contactPerson->getAppUser()) {
-                $appUser = $contactPerson->getAppUser();
-                break;
-            }
-        }
-
-        return [
-            'participant'    => $participant,
-            'appUser'        => $appUser,
-            'contact'        => $contact,
-            'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
-            'subject'        => $subject,
-            'bodyHtml'       => $bodyHtml,
-            'adminName'      => $adminName,
-            'type'           => 'ad-hoc-bulk-preview',
-        ];
-    }
-
-    /**
      * Send the bulk's message to one participant's contact persons (Person = 1 address, Org = N).
      * Returns true if at least one address was actually delivered (isSent).
      */

--- a/Service/Participant/ParticipantChangeService.php
+++ b/Service/Participant/ParticipantChangeService.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Service\Participant;
+
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+
+/**
+ * Reconstructs what changed in a Participant's registration since a given moment, purely from the
+ * versioned junction entities — ParticipantFlag(Group) and ParticipantRegistration carry BasicTrait
+ * (createdAt) + DeletedTrait (deletedAt), so an entry is "added" when createdAt > since and "removed"
+ * when deletedAt > since. No snapshot is stored. Used by the on-update change e-mail (diff since the
+ * last confirmation) and, later, the admin registration-history timeline (same logic, earlier "since").
+ *
+ * A flag/registration created AND deleted within the window is transient (net no change) → skipped.
+ */
+final class ParticipantChangeService
+{
+    /**
+     * @return array{
+     *     hasChanges: bool,
+     *     flags: array<string, array{added: list<string>, removed: list<string>}>,
+     *     registrationsAdded: list<string>,
+     *     registrationsRemoved: list<string>,
+     *     contactUpdated: bool
+     * } flags keyed by flag-category name
+     */
+    public function computeChanges(Participant $participant, \DateTimeInterface $since): array
+    {
+        $flags = [];
+        foreach ($participant->getFlagGroups(null, null, false) as $group) {
+            foreach ($group->getParticipantFlags(false) as $flag) {
+                $label = $flag->getFlag()?->getName() ?? $flag->getFlagOffer()?->getName();
+                if (null === $label) {
+                    continue;
+                }
+                $verb = $this->changeVerb($flag->getCreatedAt(), $flag->getDeletedAt(), $since);
+                if (null === $verb) {
+                    continue;
+                }
+                $category = $flag->getFlagCategory()?->getName() ?? $group->getFlagCategory()?->getName() ?? 'Ostatní';
+                $flags[$category] ??= ['added' => [], 'removed' => []];
+                $flags[$category][$verb][] = $label;
+            }
+        }
+
+        $registrationsAdded = [];
+        $registrationsRemoved = [];
+        foreach ($participant->getParticipantRegistrations(false, false) as $reg) {
+            $label = $reg->getEventName();
+            if (null === $label) {
+                continue;
+            }
+            $verb = $this->changeVerb($reg->getCreatedAt(), $reg->getDeletedAt(), $since);
+            if ('added' === $verb) {
+                $registrationsAdded[] = $label;
+            } elseif ('removed' === $verb) {
+                $registrationsRemoved[] = $label;
+            }
+        }
+
+        $contactUpdatedAt = $participant->getContactForRead()?->getUpdatedAt();
+        $contactUpdated = null !== $contactUpdatedAt && $contactUpdatedAt > $since;
+
+        $hasChanges = [] !== $flags || [] !== $registrationsAdded || [] !== $registrationsRemoved || $contactUpdated;
+
+        return [
+            'hasChanges'           => $hasChanges,
+            'flags'                => $flags,
+            'registrationsAdded'   => $registrationsAdded,
+            'registrationsRemoved' => $registrationsRemoved,
+            'contactUpdated'       => $contactUpdated,
+        ];
+    }
+
+    /**
+     * 'added' when created after $since and still active; 'removed' when deleted after $since but
+     * created at-or-before it; null otherwise (unchanged, or created-and-deleted within the window).
+     *
+     * @return 'added'|'removed'|null
+     */
+    private function changeVerb(?\DateTimeInterface $created, ?\DateTimeInterface $deleted, \DateTimeInterface $since): ?string
+    {
+        if (null !== $created && $created > $since && null === $deleted) {
+            return 'added';
+        }
+        if (null !== $deleted && $deleted > $since && (null === $created || $created <= $since)) {
+            return 'removed';
+        }
+
+        return null;
+    }
+}

--- a/Service/Participant/ParticipantChangeService.php
+++ b/Service/Participant/ParticipantChangeService.php
@@ -5,15 +5,20 @@ declare(strict_types=1);
 namespace OswisOrg\OswisCalendarBundle\Service\Participant;
 
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlag;
 
 /**
- * Reconstructs what changed in a Participant's registration since a given moment, purely from the
- * versioned junction entities — ParticipantFlag(Group) and ParticipantRegistration carry BasicTrait
- * (createdAt) + DeletedTrait (deletedAt), so an entry is "added" when createdAt > since and "removed"
- * when deletedAt > since. No snapshot is stored. Used by the on-update change e-mail (diff since the
- * last confirmation) and, later, the admin registration-history timeline (same logic, earlier "since").
+ * Reconstructs what changed in a Participant's registration, purely from the versioned junction
+ * entities — ParticipantFlag(Group) and ParticipantRegistration carry BasicTrait (createdAt) +
+ * DeletedTrait (deletedAt), so an entry is "added" at createdAt and "removed" at deletedAt. No
+ * snapshot is stored.
  *
- * A flag/registration created AND deleted within the window is transient (net no change) → skipped.
+ * Two views over the same data:
+ *  - {@see computeChanges()} — the diff *since* a moment (used by the on-update change e-mail);
+ *  - {@see buildHistory()}   — the full chronology (used by the admin registration-history timeline).
+ *
+ * In the since-view, a flag/registration created AND deleted within the window is transient
+ * (net no change) → skipped.
  */
 final class ParticipantChangeService
 {
@@ -31,7 +36,7 @@ final class ParticipantChangeService
         $flags = [];
         foreach ($participant->getFlagGroups(null, null, false) as $group) {
             foreach ($group->getParticipantFlags(false) as $flag) {
-                $label = $flag->getFlag()?->getName() ?? $flag->getFlagOffer()?->getName();
+                $label = $this->flagLabel($flag);
                 if (null === $label) {
                     continue;
                 }
@@ -72,6 +77,91 @@ final class ParticipantChangeService
             'registrationsRemoved' => $registrationsRemoved,
             'contactUpdated'       => $contactUpdated,
         ];
+    }
+
+    /**
+     * Full chronological history of a participant's registration: every versioned junction entity
+     * contributes an "added" event at its createdAt and (when soft-deleted) a "removed" event at its
+     * deletedAt, plus the participant's own "created"/"removed" lifecycle. Sorted newest-first.
+     *
+     * Read-only — for the admin "Historie přihlášky" timeline. Scalar contact edits are in-place
+     * (not versioned), so they cannot appear as discrete events here (the change e-mail surfaces them
+     * via {@see computeChanges()} as a single "contact updated" hint instead).
+     *
+     * @return list<array{
+     *     at: \DateTimeInterface,
+     *     verb: 'created'|'added'|'removed',
+     *     kind: 'participant'|'registration'|'flag',
+     *     category: string|null,
+     *     label: string
+     * }>
+     */
+    public function buildHistory(Participant $participant): array
+    {
+        $events = [];
+
+        $createdAt = $participant->getCreatedAt();
+        if (null !== $createdAt) {
+            $events[] = $this->event($createdAt, 'created', 'participant', null, 'Přihláška vytvořena');
+        }
+        $participantDeletedAt = $participant->getDeletedAt();
+        if (null !== $participantDeletedAt) {
+            $events[] = $this->event($participantDeletedAt, 'removed', 'participant', null, 'Přihláška smazána');
+        }
+
+        foreach ($participant->getFlagGroups(null, null, false) as $group) {
+            foreach ($group->getParticipantFlags(false) as $flag) {
+                $label = $this->flagLabel($flag);
+                if (null === $label) {
+                    continue;
+                }
+                $category = $flag->getFlagCategory()?->getName() ?? $group->getFlagCategory()?->getName() ?? 'Ostatní';
+                $flagCreatedAt = $flag->getCreatedAt();
+                if (null !== $flagCreatedAt) {
+                    $events[] = $this->event($flagCreatedAt, 'added', 'flag', $category, $label);
+                }
+                $flagDeletedAt = $flag->getDeletedAt();
+                if (null !== $flagDeletedAt) {
+                    $events[] = $this->event($flagDeletedAt, 'removed', 'flag', $category, $label);
+                }
+            }
+        }
+
+        foreach ($participant->getParticipantRegistrations(false, false) as $reg) {
+            $label = $reg->getEventName();
+            if (null === $label) {
+                continue;
+            }
+            $regCreatedAt = $reg->getCreatedAt();
+            if (null !== $regCreatedAt) {
+                $events[] = $this->event($regCreatedAt, 'added', 'registration', null, $label);
+            }
+            $regDeletedAt = $reg->getDeletedAt();
+            if (null !== $regDeletedAt) {
+                $events[] = $this->event($regDeletedAt, 'removed', 'registration', null, $label);
+            }
+        }
+
+        usort($events, static fn (array $a, array $b): int => $b['at']->getTimestamp() <=> $a['at']->getTimestamp());
+
+        return $events;
+    }
+
+    /**
+     * @param 'created'|'added'|'removed'           $verb
+     * @param 'participant'|'registration'|'flag'   $kind
+     *
+     * @return array{at: \DateTimeInterface, verb: 'created'|'added'|'removed', kind: 'participant'|'registration'|'flag', category: string|null, label: string}
+     */
+    private function event(\DateTimeInterface $at, string $verb, string $kind, ?string $category, string $label): array
+    {
+        return ['at' => $at, 'verb' => $verb, 'kind' => $kind, 'category' => $category, 'label' => $label];
+    }
+
+    /** Human-readable flag name (the flag's own name, falling back to the offer's). */
+    private function flagLabel(ParticipantFlag $flag): ?string
+    {
+        return $flag->getFlag()?->getName() ?? $flag->getFlagOffer()?->getName();
     }
 
     /**

--- a/Service/Participant/ParticipantMailService.php
+++ b/Service/Participant/ParticipantMailService.php
@@ -515,8 +515,9 @@ class ParticipantMailService
         foreach ($contactPersons = $participant->getContactPersons(true) as $contactPerson) {
             if ($contactPerson instanceof AbstractContact && null !== ($appUser = $contactPerson->getAppUser())) {
                 try {
-                    $this->sendMessageToUser($participant, $appUser, $group);
-                    $sent++;
+                    if ($this->sendMessageToUser($participant, $appUser, $group)) {
+                        $sent++;
+                    }
                 } catch (NotFoundException|NotImplementedException|InvalidTypeException $exception) {
                     $userId = $appUser->getId();
                     $message = $exception->getMessage();
@@ -540,7 +541,7 @@ class ParticipantMailService
      * @throws NotFoundException
      * @throws NotImplementedException
      */
-    public function sendMessageToUser(Participant $participant, AppUser $appUser, ParticipantMailGroup $group): void
+    public function sendMessageToUser(Participant $participant, AppUser $appUser, ParticipantMailGroup $group): bool
     {
         if (null === ($mailCategory = $group->getCategory())) {
             throw new NotImplementedException($group->getType(), 'u e-mailů k přihláškám');
@@ -566,6 +567,10 @@ class ParticipantMailService
         $templateName = $twigTemplate->getTemplateName();
         $this->mailService->sendEMail($participantMail, $templateName, $data);
         $this->em->flush();
+
+        // True success signal — MailService::sendEMail swallows transport errors (sets statusMessage,
+        // leaves sent = NULL). Callers must not count a failed delivery as sent.
+        return $participantMail->isSent();
     }
 
 }

--- a/Service/Participant/ParticipantMailService.php
+++ b/Service/Participant/ParticipantMailService.php
@@ -31,14 +31,111 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 
 class ParticipantMailService
 {
+    /** Standalone file template for the on-update change notice (no DB category/group config needed). */
+    public const REGISTRATION_CHANGED_TEMPLATE = '@OswisOrgOswisCalendar/e-mail/pages/participant-registration-changed.html.twig';
+
     public function __construct(
         protected EntityManagerInterface $em,
         protected MailService $mailService,
         protected ParticipantMailGroupRepository $groupRepository,
         protected ParticipantMailCategoryRepository $categoryRepository,
         protected ParticipantMailRepository $participantMailRepository,
+        protected ParticipantChangeService $changeService,
         protected LoggerInterface $logger
     ) {
+    }
+
+    /**
+     * Decide what an UPDATE to an existing registration should e-mail. Never confirmed yet (no prior
+     * summary / change mail) → send the confirmation (summary). Otherwise diff the versioned junction
+     * entities since that last mail: a real change → a "registration changed" notice listing it;
+     * nothing changed → no mail (kills the old behaviour of re-sending the full "you are registered"
+     * summary on every PUT). Notification failures are logged, never thrown — a change notice must not
+     * break the update response. {@see ParticipantSubscriber::postWrite}.
+     */
+    public function notifyParticipantChanged(Participant $participant): void
+    {
+        $since = $this->lastRegistrationMailSentAt($participant);
+        if (null === $since) {
+            try {
+                $this->sendSummary($participant);
+            } catch (\Throwable $exception) {
+                $this->logger->error(sprintf(
+                    'Participant #%d update: fallback summary failed: %s',
+                    $participant->getId() ?? 0,
+                    $exception->getMessage(),
+                ));
+            }
+
+            return;
+        }
+        $changes = $this->changeService->computeChanges($participant, $since);
+        if (false === $changes['hasChanges']) {
+            $this->logger->info(sprintf(
+                'Participant #%d updated but nothing notifiable changed since %s — no mail sent.',
+                $participant->getId() ?? 0,
+                $since->format('c'),
+            ));
+
+            return;
+        }
+        $this->sendRegistrationChanged($participant, $changes);
+    }
+
+    /**
+     * `sent` of the most recent summary / registration-changed mail for the participant — the diff
+     * baseline. Null if neither was ever sent (→ treat an update like a first confirmation).
+     */
+    private function lastRegistrationMailSentAt(Participant $participant): ?\DateTimeInterface
+    {
+        foreach ($this->participantMailRepository->findByParticipant($participant) as $mail) {
+            if (in_array($mail->getType(), [ParticipantMail::TYPE_SUMMARY, ParticipantMail::TYPE_REGISTRATION_CHANGED], true)) {
+                return $mail->getSent();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Send the "registration changed" notice (the computed diff) to each of the participant's contact
+     * persons via a standalone file template. No dedup — every real change should notify. Per-recipient
+     * failures are logged, not thrown.
+     *
+     * @param array{hasChanges: bool, flags: array<string, array{added: list<string>, removed: list<string>}>, registrationsAdded: list<string>, registrationsRemoved: list<string>, contactUpdated: bool} $changes
+     */
+    public function sendRegistrationChanged(Participant $participant, array $changes): void
+    {
+        $contact = $participant->getContact();
+        $event = $participant->getEvent();
+        $title = 'Změna v přihlášce'.(null !== $event ? ' – '.($event->getShortName() ?? $event->getName() ?? '') : '');
+        foreach ($participant->getContactPersons(true) as $contactPerson) {
+            if (!$contactPerson instanceof AbstractContact || null === ($appUser = $contactPerson->getAppUser())) {
+                continue;
+            }
+            try {
+                $participantMail = new ParticipantMail($participant, $appUser, $title, ParticipantMail::TYPE_REGISTRATION_CHANGED);
+                $participantMail->setPastMails($this->participantMailRepository->findByParticipant($participant));
+                $data = [
+                    'participant'    => $participant,
+                    'appUser'        => $appUser,
+                    'contact'        => $contact,
+                    'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
+                    'changes'        => $changes,
+                    'type'           => ParticipantMail::TYPE_REGISTRATION_CHANGED,
+                ];
+                $this->em->persist($participantMail);
+                $this->mailService->sendEMail($participantMail, self::REGISTRATION_CHANGED_TEMPLATE, $data);
+                $this->em->flush();
+            } catch (\Throwable $exception) {
+                $this->logger->error(sprintf(
+                    'Registration-changed mail for participant #%d to user #%d failed: %s',
+                    $participant->getId() ?? 0,
+                    $appUser->getId() ?? 0,
+                    $exception->getMessage(),
+                ));
+            }
+        }
     }
 
     /**

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -560,22 +560,49 @@ class ParticipantService
     }
 
     /**
-     * @throws OswisException
+     * Drain auto-mail groups: for each active group, send its mail to participants of the group's
+     * event (+ sub-events) who have NOT received it yet. Recipients come from an id-only query with
+     * SQL-side dedup + a true LIMIT ({@see ParticipantRepository::findUnmailedParticipantIds}) — no
+     * whole-cohort hydration and no lazy-collection N+1 (the old load-all → filter → slice path).
+     * Per-participant isolation: one failing recipient never aborts the batch. Returns a summary so
+     * the cron command / admin trigger can report + surface failures (no longer silently swallowed).
+     *
+     * @return array{sent: int, failed: int, errors: list<string>}
      */
-    public function sendAutoMails(?Event $event = null, ?string $type = null, int $limit = 100): void
+    public function sendAutoMails(?Event $event = null, ?string $type = null, int $limit = 100): array
     {
+        $sent = 0;
+        $failed = 0;
+        $errors = [];
         foreach ($this->participantMailService->getAutoMailGroups($event, $type) ?? new ArrayCollection() as $group) {
-            $participants = $this->getParticipants([
-                ParticipantRepository::CRITERIA_INCLUDE_DELETED => !$group->isOnlyActive(),
-                ParticipantRepository::CRITERIA_EVENT => $group->getEvent(),
-                ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 4,
-            ])->filter(static fn (Participant $p) => !$p->hasEMailOfType($group->getType()))->slice(0, $limit);
-            foreach ($participants as $participant) {
-                if ($group->isApplicable($participant)) {
+            $groupEvent = $group->getEvent();
+            $groupType = $group->getType();
+            if (!$groupEvent instanceof Event || null === $groupType) {
+                continue;
+            }
+            $ids = $this->participantRepository->findUnmailedParticipantIds(
+                $groupEvent,
+                $groupType,
+                $limit,
+                4,
+                !$group->isOnlyActive(),
+            );
+            foreach ($ids as $id) {
+                $participant = $this->em->find(Participant::class, $id);
+                if (!$participant instanceof Participant || !$group->isApplicable($participant)) {
+                    continue;
+                }
+                try {
                     $this->participantMailService->sendMessage($participant, $group);
+                    ++$sent;
+                } catch (\Throwable $e) {
+                    ++$failed;
+                    $errors[] = sprintf('#%d: %s', $id, $e->getMessage());
                 }
             }
         }
+
+        return ['sent' => $sent, 'failed' => $failed, 'errors' => $errors];
     }
 
 }

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -186,6 +186,12 @@ class ParticipantService
             $this->em->persist($participant);
             $participant->updateCachedColumns();
             $this->requestActivation($participant);
+            // Flush the new participant (and, by cascade, its ParticipantRegistration + flags)
+            // BEFORE recomputing the cached usage counters. Doctrine ORM 3 does NOT auto-flush
+            // before a DQL query, so updateUsage()/updateUsages() COUNT the DB directly: counting
+            // before this flush silently omits the row we just added, writing base_usage one too
+            // low — which lets the *next* registration overbook by one. Verified empirically.
+            $this->em->flush();
             $this->flagRangeService->updateUsages($participant);
             if (null !== $regRange) {
                 $this->registrationOfferService->updateUsage($regRange);

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -55,6 +55,7 @@ class ParticipantService
         protected readonly RegistrationFlagOfferService $flagRangeService,
         protected readonly RegistrationOfferService $registrationOfferService,
         protected readonly AppUserTypeService $appUserTypeService,
+        protected readonly ParticipantFilterEvaluator $filterEvaluator,
     ) {
     }
 
@@ -567,6 +568,16 @@ class ParticipantService
      * Per-participant isolation: one failing recipient never aborts the batch. Returns a summary so
      * the cron command / admin trigger can report + surface failures (no longer silently swallowed).
      *
+     * $limit caps send ATTEMPTS (successful or failed) per group per call — bounded SMTP work for
+     * the cron; failed recipients stay unmailed and are retried next run. Candidate ids are paged
+     * with an id cursor:
+     * participants the group never applies to (filter expression, inactive) stay "unmailed" forever,
+     * so a single LIMIT window would fill up with them and stall the campaign — the cursor walks past
+     * them to recipients further in the cohort.
+     *
+     * A group with a syntactically broken filter expression is skipped whole and reported (the
+     * entity's fail-closed evaluation would otherwise silently scan the cohort and send nothing).
+     *
      * @return array{sent: int, failed: int, errors: list<string>}
      */
     public function sendAutoMails(?Event $event = null, ?string $type = null, int $limit = 100): array
@@ -580,24 +591,45 @@ class ParticipantService
             if (!$groupEvent instanceof Event || null === $groupType) {
                 continue;
             }
-            $ids = $this->participantRepository->findUnmailedParticipantIds(
-                $groupEvent,
-                $groupType,
-                $limit,
-                4,
-                !$group->isOnlyActive(),
-            );
-            foreach ($ids as $id) {
-                $participant = $this->em->find(Participant::class, $id);
-                if (!$participant instanceof Participant || !$group->isApplicable($participant)) {
-                    continue;
+            if (null !== ($filterError = $this->filterEvaluator->validate($group->getFilterExpression()))) {
+                $errors[] = sprintf(
+                    'Skupina „%s" (%s) přeskočena — neplatný filtr: %s',
+                    $group->getName() ?? '?',
+                    $groupType,
+                    $filterError,
+                );
+                continue;
+            }
+            $remaining = max(1, $limit);
+            $afterId = 0;
+            while ($remaining > 0) {
+                $ids = $this->participantRepository->findUnmailedParticipantIds(
+                    $groupEvent,
+                    $groupType,
+                    max(1, $limit),
+                    4,
+                    !$group->isOnlyActive(),
+                    $afterId,
+                );
+                if ([] === $ids) {
+                    break;
                 }
-                try {
-                    $this->participantMailService->sendMessage($participant, $group);
-                    ++$sent;
-                } catch (\Throwable $e) {
-                    ++$failed;
-                    $errors[] = sprintf('#%d: %s', $id, $e->getMessage());
+                foreach ($ids as $id) {
+                    $afterId = $id;
+                    $participant = $this->em->find(Participant::class, $id);
+                    if (!$participant instanceof Participant || !$group->isApplicable($participant)) {
+                        continue;
+                    }
+                    try {
+                        $this->participantMailService->sendMessage($participant, $group);
+                        ++$sent;
+                    } catch (\Throwable $e) {
+                        ++$failed;
+                        $errors[] = sprintf('#%d: %s', $id, $e->getMessage());
+                    }
+                    if (--$remaining <= 0) {
+                        break;
+                    }
                 }
             }
         }

--- a/Service/Participant/PaymentMatchingService.php
+++ b/Service/Participant/PaymentMatchingService.php
@@ -18,7 +18,7 @@ use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
  *   VS appears in note / internalNote (substring)     : +60
  *   VS = last-9-digits of participant phone (project_vs_is_always_phone) : +40
  *   amount matches remainingPrice or remainingDeposit : +30
- *   payment dateTime is within 30 days of event start : +20
+ *   payment near event start (graduated by proximity) : up to +20
  *   participant not soft-deleted                      : +10
  *
  * Ambiguity rule: if the top two candidates are within AMBIGUITY_WINDOW
@@ -34,6 +34,7 @@ final readonly class PaymentMatchingService
     private const int DATE_PROXIMITY   = 20;
     private const int NOT_SOFT_DELETED = 10;
     private const int AMBIGUITY_WINDOW = 20;
+    private const int DATE_WINDOW_DAYS = 60;
 
     public function __construct(
         private ParticipantService $participantService,
@@ -126,8 +127,20 @@ final readonly class PaymentMatchingService
         $paymentAt = $payment->getDateTime();
         if (null !== $eventStart && null !== $paymentAt) {
             $diffDays = abs($eventStart->getTimestamp() - $paymentAt->getTimestamp()) / 86400;
-            if ($diffDays <= 30) {
-                $result = $result->withAddedReason('Platba ≤ 30 dní od začátku akce', self::DATE_PROXIMITY);
+            if ($diffDays <= self::DATE_WINDOW_DAYS) {
+                // Graduated by proximity: a payment close to the event start scores higher than a
+                // distant one. This is the tie-breaker for participants that share a VS (e.g. the
+                // same phone re-used across two turnus events at the same price) — the event nearest
+                // the payment is surfaced first. Capped at DATE_PROXIMITY, and two candidates both
+                // within the window differ by less than AMBIGUITY_WINDOW, so a genuinely ambiguous
+                // pair still drops to manual matching rather than being auto-applied.
+                $score = (int) round(self::DATE_PROXIMITY * (1.0 - $diffDays / self::DATE_WINDOW_DAYS));
+                if ($score > 0) {
+                    $result = $result->withAddedReason(
+                        sprintf('Platba %d dní od začátku akce', (int) round($diffDays)),
+                        $score,
+                    );
+                }
             }
         }
         if (null === $candidate->participant->getDeletedAt()) {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "bigit/vokativ": "dev-zakjakub-master",
     "endroid/qr-code": "^6.1",
     "oswis-org/oswis-address-book-bundle": "^0.1.0 || ^0.1.1",
-    "oswis-org/oswis-core-bundle": "^0.1.0 || ^0.2",
+    "oswis-org/oswis-core-bundle": "^0.2.16",
     "rikudou/czqrpayment": "^v5.0",
     "symfony/expression-language": "^8.1",
     "symfony/html-sanitizer": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "7ca9ce6204152d78f2ab7b5db026492b",
+  "content-hash": "0c728518f795315be0d8d5983783ef46",
   "packages": [
     {
       "name": "adci/full-name-parser",
@@ -4276,16 +4276,16 @@
     },
     {
       "name": "oswis-org/oswis-core-bundle",
-      "version": "v0.2.11",
+      "version": "v0.2.16",
       "source": {
         "type": "git",
         "url": "https://github.com/oswis-org/oswis-core-bundle.git",
-        "reference": "8da30f64ac4bc6129a17bed2a574193b859a1298"
+        "reference": "f5804474b4b9c2962f05224621c6e33ef80e081d"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/oswis-org/oswis-core-bundle/zipball/8da30f64ac4bc6129a17bed2a574193b859a1298",
-        "reference": "8da30f64ac4bc6129a17bed2a574193b859a1298",
+        "url": "https://api.github.com/repos/oswis-org/oswis-core-bundle/zipball/f5804474b4b9c2962f05224621c6e33ef80e081d",
+        "reference": "f5804474b4b9c2962f05224621c6e33ef80e081d",
         "shasum": ""
       },
       "require": {
@@ -4393,9 +4393,9 @@
       ],
       "support": {
         "issues": "https://github.com/oswis-org/oswis-core-bundle/issues",
-        "source": "https://github.com/oswis-org/oswis-core-bundle/tree/v0.2.11"
+        "source": "https://github.com/oswis-org/oswis-core-bundle/tree/v0.2.16"
       },
-      "time": "2026-06-01T14:17:11+00:00"
+      "time": "2026-06-09T11:01:33+00:00"
     },
     {
       "name": "paragonie/random_compat",


### PR DESCRIPTION
## v0.2.23 → v0.2.24 (20 commitů)

**Fáze G + Inkrement 2a+2b — bulk mail subsystém:**
- Bulk akce seznamu přihlášek: výběr (checkboxy/select-all), export vybraných (CSV/PDF, cap 1000), soft-delete (cap 100), přesun → reassign wizard preselect
- Bulk e-mail outbox (`ParticipantMailBulk`): compose/preview/queue/status UI + drain po dávkách (JS auto-drain + cron) s **per-bulk advisory lockem** (GET_LOCK — souběžný drain dvou tabů/cronu už nepošle slice dvakrát)
- Jednotný MJML preview service + živý náhled v editoru šablon (#139): vzorový příjemce, desktop/mobil
- Trusted Twig tělo bulku (proměnné + podmínkové bloky per příjemce) + queue-validace + raw fallback + `template_slug` (uložené kampaně)
- Composer authoring: panel proměnných/bloků, snippety (`{% include %}`), template picker, create action, **seznam příjemců + náhled pro konkrétního příjemce**
- Změnový e-mail `registration-changed` (junction-diff) místo přeposílání summary na PUT
- Historie přihlášky — read-only timeline na detailu účastníka
- Automail skupiny: **volitelný filtr příjemců** (výrazový jazyk seznamu, fail-closed) + id-kurzor v drainu (stall fix)
- Automail engine hardening (datumové okno, SQL dedup+limit, per-recipient izolace, POST+CSRF)

**Fixy:**
- 🔴 check-in stránka `/web_admin/prijezd/{id}` 500 (Variable f does not exist — živé na prodi, rozbíjelo i redirect po Obnovit)
- 👥 odkaz na seznam po invalid filtr submitu
- `composer.json`: core constraint `^0.2.16` (KIND_* konstanty) + lock na reálný v0.2.16

**Ověření:** PHPStan max 0 · schema:validate green · funkční smoke 7/7 (72 ass.) · E2E proby (registrace A–Z, automail filtr+kurzor, drain konkurence, Mailpit) · code review (2 agenti) · kompletní vizuální proklik matice use cases (`docs/OSWIS_1_USE_CASES_TEST_MATRIX_2026-06-10.md`)

Tagged **v0.2.24** z této větve (zavedený flow). App-side migrace: `Version20260608180030`, `Version20260609105148` (kind backfill), `Version20260609140159`, `Version20260610090000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)