### PR TITLE
release: v0.2.27 — ruční spárování platby posílá potvrzení (kritický prod fix)

### DIFF
--- a/Controller/WebAdmin/WebAdminPaymentController.php
+++ b/Controller/WebAdmin/WebAdminPaymentController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Exception;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantPayment;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ParticipantPaymentEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantPaymentRepository;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantMailService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\PaymentMatchingService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,6 +23,7 @@ class WebAdminPaymentController extends AbstractController
         private readonly EntityManagerInterface $em,
         private readonly ParticipantPaymentRepository $paymentRepo,
         private readonly PaymentMatchingService $matchingService,
+        private readonly ParticipantMailService $participantMailService,
     ) {
     }
 
@@ -81,6 +84,9 @@ class WebAdminPaymentController extends AbstractController
             $participantId,
             $participant->getName() ?? '(bez jména)',
         ));
+        // Ruční spárování musí potvrdit platbu e-mailem stejně jako automatické při importu
+        // (sendPaymentConfirmation razítkuje confirmedByMailAt, takže se nikdy nepošle 2×).
+        $this->sendConfirmationGuarded($payment);
 
         return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_payment_edit', ['id' => $id]);
     }
@@ -88,11 +94,52 @@ class WebAdminPaymentController extends AbstractController
     public function unmatch(int $id): RedirectResponse
     {
         $payment = $this->em->find(ParticipantPayment::class, $id) ?? throw $this->createNotFoundException();
-        $payment->setParticipant(null);
+        // setParticipant(null) na persistované platbě záměrně hází NotImplementedException
+        // (ochrana API zápisů) — admin odpojení jde přes sankcionovanou detachParticipant().
+        $payment->detachParticipant();
+        // Razítko potvrzení patří ke spárování s konkrétním účastníkem — po odpojení se musí
+        // resetovat, jinak by správný účastník po přepárování (A→B) potvrzení nikdy nedostal.
+        $payment->setConfirmedByMailAt(null);
         $this->em->flush();
         $this->addFlash('success', "Účastník odpojen od platby #$id.");
 
         return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_payment_match', ['id' => $id]);
+    }
+
+    /** Ruční (do)odeslání potvrzení platby — pro platby přiřazené dříve, než assign() posílal mail. */
+    public function sendConfirmation(int $id, Request $request): RedirectResponse
+    {
+        $payment = $this->em->find(ParticipantPayment::class, $id) ?? throw $this->createNotFoundException();
+        if (!$this->isCsrfTokenValid('payment_send_confirmation_'.$id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        if (null === $payment->getParticipant()) {
+            $this->addFlash('warning', "Platba #$id nemá přiřazeného účastníka — potvrzení nelze odeslat.");
+        } elseif ($payment->isConfirmedByMail()) {
+            $this->addFlash('warning', "Potvrzení platby #$id už bylo odesláno ".$payment->getConfirmedByMailAt()?->format('j. n. Y H:i').'.');
+        } else {
+            $this->sendConfirmationGuarded($payment);
+        }
+
+        return $this->redirectToRoute('oswis_org_oswis_calendar_web_admin_payment_edit', ['id' => $id]);
+    }
+
+    /** Pošle potvrzení platby (pokud ještě nebylo) a převede výsledek na flash zprávu. */
+    private function sendConfirmationGuarded(ParticipantPayment $payment): void
+    {
+        if ($payment->isConfirmedByMail()) {
+            return;
+        }
+        try {
+            $this->participantMailService->sendPaymentConfirmation($payment);
+            $this->addFlash('success', sprintf('Potvrzení platby #%d odesláno e-mailem.', (int) $payment->getId()));
+        } catch (Exception $exception) {
+            $this->addFlash('danger', sprintf(
+                'Potvrzení platby #%d se NEPODAŘILO odeslat: %s',
+                (int) $payment->getId(),
+                $exception->getMessage(),
+            ));
+        }
     }
 
     /**

--- a/Entity/Participant/Participant.php
+++ b/Entity/Participant/Participant.php
@@ -1092,14 +1092,16 @@ class Participant implements ParticipantInterface
     }
 
     /**
-     * @param ParticipantPayment|null $participantPayment
-     *
-     * @throws NotImplementedException
+     * Removes the payment from the inverse-side collection. Historically an unimplemented
+     * stub that always threw — which silently broke the whole admin re-matching flow
+     * (unmatch/odpojit i přímé přepárování A→B přes setParticipant jdou tudy). FK žije na
+     * owning straně (ParticipantPayment::$participant) a mapping nemá orphanRemoval,
+     * takže tohle platbu jen odpojí — řádek nikdy nesmaže.
      */
     public function removePayment(?ParticipantPayment $participantPayment): void
     {
         if (null !== $participantPayment) {
-            throw new NotImplementedException('odebrání platby', 'u přihlášek');
+            $this->getPayments()->removeElement($participantPayment);
         }
     }
 

--- a/Entity/Participant/ParticipantPayment.php
+++ b/Entity/Participant/ParticipantPayment.php
@@ -198,6 +198,17 @@ class ParticipantPayment implements BasicInterface, TypeInterface, MyDateTimeInt
         $participant?->addPayment($this);
     }
 
+    /**
+     * Admin-sanctioned detach (manual re-matching in the web admin). The generic
+     * {@see setParticipant()} deliberately forbids null on a persisted payment (protects the
+     * API write path), but the curated admin "Odpojit" flow must be able to undo a wrong match.
+     */
+    public function detachParticipant(): void
+    {
+        $this->participant?->removePayment($this);
+        $this->participant = null;
+    }
+
     public function getImport(): ?ParticipantPaymentsImport
     {
         return $this->import;

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -184,6 +184,13 @@ oswis_org_oswis_calendar_web_admin_payment_unmatch:
     id: '\d+'
   methods: [POST]
 
+oswis_org_oswis_calendar_web_admin_payment_send_confirmation:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminPaymentController::sendConfirmation
+  path: "/web_admin/platby/{id}/poslat-potvrzeni"
+  requirements:
+    id: '\d+'
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_participant_payments_import:
   controller: oswis_org_oswis_calendar.web_admin.participant_payments_import_controller::import
   path: "/web_admin/prihlasky/import-plateb"

--- a/Resources/views/web_admin/payments/edit.html.twig
+++ b/Resources/views/web_admin/payments/edit.html.twig
@@ -25,6 +25,22 @@
             {% endif %}
         </p>
 
+        <p>
+            <strong>Potvrzení e-mailem:</strong>
+            {% if payment.confirmedByMail %}
+                ✅ odesláno {{ payment.confirmedByMailAt|date('j. n. Y H:i') }}
+            {% elseif payment.participant %}
+                ⚠️ neodesláno
+                <form method="post" style="display:inline;"
+                      action="{{ path('oswis_org_oswis_calendar_web_admin_payment_send_confirmation', { id: payment.id }) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('payment_send_confirmation_' ~ payment.id) }}">
+                    <button type="submit" class="btn btn-sm btn-warning">✉ Poslat potvrzení účastníkovi</button>
+                </form>
+            {% else %}
+                — (nejdřív spáruj platbu)
+            {% endif %}
+        </p>
+
         {{ form_start(form) }}
         {{ form_widget(form) }}
         <button type="submit" class="btn btn-primary">Uložit změny</button>


### PR DESCRIPTION
Ručně spárovaná platba neposlala mail 'Přijetí platby' (jen importní cesta ho posílala) — hlášeno z prod, postiženy platby #4924/#4929. Navíc E2E test odhalil, že 'Odpojit' a přepárování byly VŽDY rozbité (Participant::removePayment = stub házející NotImplementedException → 500).

assign() teď posílá potvrzení (guard proti dvojímu odeslání) · unmatch() resetuje razítko · nové tlačítko '✉ Poslat potvrzení' pro doodeslání · removePayment implementováno · detachParticipant() sankcionovaná admin cesta.

PHPStan max 0 · linty OK · smoke 8/8 · 3 scénáře E2E na klonu (spárovat→mail, odpojit→přepárovat→mail znovu, tlačítko→mail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)