### PR TITLE
release: v0.2.28 — fix PUT /api/participants (400 po provedeném zápisu, I3)

### DIFF
--- a/Entity/Participant/Participant.php
+++ b/Entity/Participant/Participant.php
@@ -98,6 +98,10 @@ use Symfony\Component\Serializer\Attribute\MaxDepth;
         ),
         new Put(
             denormalizationContext: ['groups' => ['entity_put', 'calendar_participant_put'], 'enable_max_depth' => true],
+            // Bez explicitních groups se odpověď serializovala přes CELÝ negroupovaný graf
+            // entit (vč. write-only atributů z konstruktorů) a padala na 400 — PUT tak byl
+            // od nepaměti nepoužitelný. Odpověď = stejný tvar jako funkční item GET.
+            normalizationContext: ['groups' => ['entity_get', 'calendar_participant_get'], 'enable_max_depth' => true],
             security: "is_granted('ROLE_MANAGER')"
         ),
     ],

--- a/Entity/Registration/RegistrationFlagGroupOffer.php
+++ b/Entity/Registration/RegistrationFlagGroupOffer.php
@@ -159,7 +159,13 @@ class RegistrationFlagGroupOffer implements NameableInterface
         }
     }
 
-    public function isCategory(?RegistrationFlagCategory $category = null): bool
+    /**
+     * POZOR na pojmenování: dřívější `isCategory()` udělalo z metody "getter" serializeru —
+     * PropertyInfo odvodí atribut `category` z parametru konstruktoru (to-one relace
+     * RegistrationFlagCategory) a PropertyAccess čte prefixy is/get/has; bool návrat pak shodil
+     * KAŽDOU negroupovanou serializaci grafu (PUT /api/participants → 400). Proto isOfCategory.
+     */
+    public function isOfCategory(?RegistrationFlagCategory $category = null): bool
     {
         return null === $category || ($this->getFlagCategory() && $this->getFlagCategory() === $category);
     }

--- a/Entity/Registration/RegistrationOffer.php
+++ b/Entity/Registration/RegistrationOffer.php
@@ -325,7 +325,7 @@ class RegistrationOffer implements NameableInterface
             $flagGroupRanges = $flagGroupRanges->filter(static fn (RegistrationFlagGroupOffer $range) => $range->isPublicOnWeb());
         }
         if (null !== $flagCategory) {
-            $flagGroupRanges = $flagGroupRanges->filter(static fn (RegistrationFlagGroupOffer $range) => $range->isCategory($flagCategory));
+            $flagGroupRanges = $flagGroupRanges->filter(static fn (RegistrationFlagGroupOffer $range) => $range->isOfCategory($flagCategory));
         }
         if (null !== $flagType) {
             $flagGroupRanges = $flagGroupRanges->filter(static fn (RegistrationFlagGroupOffer $range) => $range->isType($flagType));


### PR DESCRIPTION
PUT na přihlášku vracel 400 pro JAKÝKOLI payload — přičemž zápis už proběhl (klient viděl chybu, data se měnila). Dva kořeny: chybějící normalizationContext na Put (odpověď šla přes negroupovaný graf) + `isCategory(): bool` na RegistrationFlagGroupOffer fungující jako falešný getter atributu 'category' odvozeného z parametru konstruktoru. Odblokovává Ionic editace přihlášek + změnový e-mail registration-changed (Ink.2b krok 5).

PUT → 200 ověřeno na klonu (zápis aplikován, change-mail pipeline žije) · PHPStan max 0 · nový PUT smoke v app suite (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)