### PR TITLE
perf(api): kolekce /api/participants bez embedovaného katalogu (104→17 kB/účastník)

### DIFF
--- a/Resources/config/serialization/Participant/Participant.yaml
+++ b/Resources/config/serialization/Participant/Participant.yaml
@@ -54,13 +54,14 @@ OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlagGroup:
       groups:
         - 'calendar_participants_get'
         - 'calendar_participant_get'
+    # flagGroupOffer + availableFlagOffers JEN v item GET (edit formulář v admin
+    # detailu) — v KOLEKCI je nikdo nečte a embeddovaly celý katalog příznaků
+    # u každého účastníka (~60 % z ~104 kB/účastník → 504 na plné akci).
     flagGroupOffer:
       groups:
-        - 'calendar_participants_get'
         - 'calendar_participant_get'
     availableFlagOffers:
       groups:
-        - 'calendar_participants_get'
         - 'calendar_participant_get'
     min:
       groups:
@@ -138,14 +139,11 @@ OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationOffer:
         - 'calendar_participants_post'
         - 'calendar_participant_get'
         - 'calendar_participant_put'
-    flagGroupRanges:
-      groups:
-        - 'calendar_participants_get'
-        - 'calendar_participant_get'
-    requiredRegRange:
-      groups:
-        - 'calendar_participants_get'
-        - 'calendar_participant_get'
+    # flagGroupRanges + requiredRegRange v participant odpovědích nečte ŽÁDNÝ
+    # klient (Ionic bere katalog ze /api/registration_offers) — requiredRegRange
+    # embedoval rekurzivně další celý offer (34 kB/účastník). Odebráno z
+    # participant groups úplně; /api/registration_offers se to nedotýká (ten
+    # serializuje jen entities_get z core traitů, tyto groups nikdy nenesl).
 
 OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlag:
   attributes:


### PR DESCRIPTION
95 kB ze 104 kB na účastníka byl registrační katalog embedovaný u každého účastníka 3-4× (flagGroupOffer.flagOffers + availableFlagOffers + offer.flagGroupRanges + rekurzivní offer.requiredRegRange). Plný per-akce seznam (dle designu NEstránkovaný) tak dělal ~34 MB / >60 s → 504.

- flagGroupOffer + availableFlagOffers nově JEN v item GET (admin detail/edit je čte odtud — ověřeno, nedotčeno)
- flagGroupRanges + requiredRegRange odebrány z participant groups úplně (nečte žádný klient; Ionic je v TS modelech nemá, katalog bere ze /api/registration_offers)

Měření (klon, 30 položek): payload 2 985→474 kB, čas 5.0→1.2 s; projekce plné akce 340: ~34 MB/~57 s → ~5.4 MB/~13 s. Audit spotřeby polí + čísla: docs/OSWIS_1_PARTICIPANTS_API_PAYLOAD_ANALYSIS_2026-06-12.md (workspace). Plná app suite 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)