### PR TITLE
Přesun účastníka z administrace + privacy interních poznámek

### DIFF
--- a/Controller/WebAdmin/WebAdminBulkReassignController.php
+++ b/Controller/WebAdmin/WebAdminBulkReassignController.php
@@ -195,6 +195,14 @@ final class WebAdminBulkReassignController extends AbstractController
         bool $preselectMode = false,
         array $preselectedIds = [],
     ): Response {
+        $distinctEvents = [];
+        foreach ($participants as $listed) {
+            $listedEvent = $listed->getEvent();
+            if (null !== $listedEvent) {
+                $distinctEvents[(string) $listedEvent->getId()] = true;
+            }
+        }
+
         return $this->render('@OswisOrgOswisCalendar/web_admin/bulk_reassign.html.twig', [
             'events'          => $events,
             'categories'      => $categories,
@@ -207,6 +215,7 @@ final class WebAdminBulkReassignController extends AbstractController
             'hardCap'         => self::HARD_CAP,
             'pageTitle'       => 'Hromadný přesun přihlášek',
             'page_title'      => 'Hromadný přesun přihlášek :: ADMIN',
+            'distinctEventCount' => count($distinctEvents),
         ]);
     }
 

--- a/Controller/WebAdmin/WebAdminBulkReassignController.php
+++ b/Controller/WebAdmin/WebAdminBulkReassignController.php
@@ -119,14 +119,22 @@ final class WebAdminBulkReassignController extends AbstractController
                     $failed[] = "#$id (nenalezen)";
                     continue;
                 }
-                // Scope guard: only allow moving participants that actually belong
-                // to the sourceEvent the admin filtered on. Prevents DevTools form
-                // injection of arbitrary participant IDs from unrelated events.
+                // Konzistenční kontrola pro režim filtru podle akce: když admin filtroval podle
+                // zdrojové akce, odmítni ID, která do ní nepatří (chytá zastaralý/upravený
+                // formulář). NENÍ to bezpečnostní kontrola — ROLE_ADMIN smí legitimně přesunout
+                // kohokoli; v preselect režimu ($sourceEvent === null) se záměrně přeskakuje,
+                // protože přesun napříč akcemi je smyslem té vstupní cesty (jednotný seznam).
                 if ($sourceEvent && $p->getEvent() !== $sourceEvent) {
                     $failed[] = sprintf('#%d (není ve zdrojové akci %s)', $id, $sourceEvent->getShortName() ?? $sourceEvent->getName() ?? '?');
                     continue;
                 }
                 $oldOffer = $p->getOffer();
+                // Přeskoč no-op přesun (už je na cílové nabídce) — jinak by setOffer zbytečně
+                // přepsal registraci a applyPostMoveSideEffects poslal mail + přepočítal kapacitu.
+                if ($oldOffer === $targetOffer) {
+                    $failed[] = sprintf('#%d (už je na cílové přihlášce)', $id);
+                    continue;
+                }
                 try {
                     $p->setOffer($targetOffer);
                     $this->em->persist($p);

--- a/Controller/WebAdmin/WebAdminBulkReassignController.php
+++ b/Controller/WebAdmin/WebAdminBulkReassignController.php
@@ -111,6 +111,8 @@ final class WebAdminBulkReassignController extends AbstractController
 
             $moved = [];
             $failed = [];
+            /** @var list<array{participant: Participant, oldOffer: ?RegistrationOffer}> $movedSideEffects */
+            $movedSideEffects = [];
             foreach ($ids as $id) {
                 $p = $this->em->find(Participant::class, $id);
                 if (!$p instanceof Participant) {
@@ -124,15 +126,24 @@ final class WebAdminBulkReassignController extends AbstractController
                     $failed[] = sprintf('#%d (není ve zdrojové akci %s)', $id, $sourceEvent->getShortName() ?? $sourceEvent->getName() ?? '?');
                     continue;
                 }
+                $oldOffer = $p->getOffer();
                 try {
                     $p->setOffer($targetOffer);
                     $this->em->persist($p);
                     $moved[] = sprintf('#%d %s', $id, $p->getContact()?->getName() ?? '?');
+                    $movedSideEffects[] = ['participant' => $p, 'oldOffer' => $oldOffer];
                 } catch (\Throwable $e) {
                     $failed[] = sprintf('#%d (%s)', $id, $e->getMessage());
                 }
             }
             $this->em->flush();
+
+            // Po commitu: oznámení o změně přihlášky + přepočet obsazenosti zdrojové i cílové
+            // nabídky. Až po flush — diff změn čte verzované záznamy zapsané teprve flushem.
+            // applyPostMoveSideEffects chyby jen loguje, takže neúspěšný mail neshodí přesun.
+            foreach ($movedSideEffects as $sideEffect) {
+                $this->participantService->applyPostMoveSideEffects($sideEffect['participant'], $sideEffect['oldOffer']);
+            }
 
             if (count($moved) > 0) {
                 $this->addFlash('success', sprintf(

--- a/Entity/Participant/Participant.php
+++ b/Entity/Participant/Participant.php
@@ -972,6 +972,36 @@ class Participant implements ParticipantInterface
     }
 
     /**
+     * Jako generateQrPng, ale na ZBÝVAJÍCÍ částky (po odečtení už zaplaceného). Když nezbývá
+     * nic k platbě (nebo je přeplaceno), vrátí null → QR se nevygeneruje. Používá se ve změnovém
+     * mailu, aby účastník, který už zálohu zaplatil, nedostal QR svádějící k duplicitní platbě.
+     */
+    public function generateRemainingQrPng(bool $deposit = true, bool $rest = true, string $qrComment = ''): ?string
+    {
+        if (null === ($event = $this->getEvent()) || null === ($bankAccount = $event->getBankAccount(true))) {
+            return null;
+        }
+        $value = null;
+        if ($deposit && $rest) {
+            $qrComment = (empty($qrComment) ? '' : "$qrComment, ").'zbývá celkem';
+            $value = $this->getRemainingPrice();
+        }
+        if ($deposit && !$rest) {
+            $qrComment = (empty($qrComment) ? '' : "$qrComment, ").'zbývající záloha';
+            $value = $this->getRemainingDeposit();
+        }
+        if (!$deposit && $rest) {
+            $qrComment = (empty($qrComment) ? '' : "$qrComment, ").'zbývající doplatek';
+            $value = $this->getRemainingPriceRest();
+        }
+        if (null === $value || $value <= 0) {
+            return null;
+        }
+
+        return $bankAccount->getQrImage($value, $this->getVariableSymbol(), $qrComment);
+    }
+
+    /**
      * Get variable symbol of this eventParticipant.
      */
     public function getVariableSymbol(): ?string
@@ -1093,6 +1123,19 @@ class Participant implements ParticipantInterface
     public function getRemainingPrice(): int
     {
         return $this->getPrice() - $this->getPaidPrice();
+    }
+
+    /**
+     * Zbývající DOPLATEK = část doplatku (cena nad rámec zálohy), která ještě není pokrytá
+     * platbami: zbývající celková částka mínus zbývající záloha. Nikdy záporné.
+     *
+     * Pozn.: záměrně samostatná, jednoznačně pojmenovaná metoda — starší {@see getRemainingRest()}
+     * vrací zbývající CELEK (price − paid), na který se spoléhá payment mail a infomaily,
+     * takže ho nepřepisujeme.
+     */
+    public function getRemainingPriceRest(): int
+    {
+        return max($this->getRemainingPrice() - $this->getRemainingDeposit(), 0);
     }
 
     /**

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -421,6 +421,23 @@ services:
       $decorated: '@.inner'
       $attendanceRepository: '@OswisOrg\OswisCalendarBundle\Repository\Participant\SubEventAttendanceRepository'
 
+  ## Privacy: strip internal-only fields (payment internalNote, non-public note text) for
+  ## non-managers. Registered on BOTH item normalizers (json-ld + plain json) — the Ionic
+  ## client requests either, so covering one would leak via the other. decoration_priority
+  ## puts it outside EventCapacityNormalizer (order is immaterial — disjoint fields).
+  OswisOrg\OswisCalendarBundle\Serializer\ParticipantPrivacyNormalizer:
+    decorates: 'api_platform.jsonld.normalizer.item'
+    decoration_priority: 10
+    arguments:
+      $decorated: '@.inner'
+
+  oswis_calendar.participant_privacy_normalizer.json:
+    class: OswisOrg\OswisCalendarBundle\Serializer\ParticipantPrivacyNormalizer
+    decorates: 'api_platform.serializer.normalizer.item'
+    decoration_priority: 10
+    arguments:
+      $decorated: '@.inner'
+
   OswisOrg\OswisCalendarBundle\Repository\Registration\RegistrationFlagRepository:
     class: OswisOrg\OswisCalendarBundle\Repository\Registration\RegistrationFlagRepository
     autowire: true

--- a/Resources/views/e-mail/pages/participant-registration-changed.html.twig
+++ b/Resources/views/e-mail/pages/participant-registration-changed.html.twig
@@ -37,7 +37,7 @@
     <div style="border-top:1px solid #dddddd; margin:18px 0;"></div>
     <p>Pro pořádek {{ f ? 'Vám' : 'ti' }} posíláme <strong>aktuální stav celé přihlášky</strong>:</p>
     {% include '@OswisOrgOswisCalendar/other/summary/participant-summary.html.twig' %}
-    {% include '@OswisOrgOswisCalendar/other/qr-payment/event-participant-qr-payment.html.twig' %}
+    {% include '@OswisOrgOswisCalendar/other/qr-payment/event-participant-qr-payment.html.twig' with {'depositLabel': 'Zbývající záloha', 'restLabel': 'Zbývající doplatek'} %}
 {% endblock %}
 
 {% block content_footer_inner %}

--- a/Resources/views/e-mail/pages/participant-registration-changed.html.twig
+++ b/Resources/views/e-mail/pages/participant-registration-changed.html.twig
@@ -1,13 +1,12 @@
 {% extends '@OswisOrgOswisCore/e-mail/pages/message.html.twig' %}
 
-{# On-update change notice. Variables (set in PHP `$data`, see ParticipantMailService::sendRegistrationChanged):
-     - participant / appUser / contact / salutationName: as in every participant mail
-     - changes: {
-         flags: { '<category>': { added: [...], removed: [...] } },
-         registrationsAdded: [...], registrationsRemoved: [...], contactUpdated: bool
-       } — the diff since the last confirmation (ParticipantChangeService::computeChanges)
-   f / a / salName come from the base message.html.twig.
-#}
+{# On-update change notice + úplné aktuální shrnutí přihlášky + QR na ZBÝVAJÍCÍ částky.
+   Proměnné (set v PHP `$data`, viz ParticipantMailService::sendRegistrationChanged):
+     - participant / appUser / contact / salutationName: jako u každého participant mailu
+     - changes: { flags: { '<cat>': { added, removed } }, registrationsAdded, registrationsRemoved, contactUpdated }
+     - depositQr / restQr: CID embednutých QR na zbývající zálohu / doplatek (nemusí být)
+     - depositAmount / restAmount: zbývající částky pro popisky QR
+   f / a / salName přicházejí z base message.html.twig. #}
 
 {% block content_inner %}
     <p>
@@ -34,9 +33,13 @@
         {% endif %}
     </ul>
     <p>Pokud tyto změny neprovedl{{ a }} {{ f ? 'Vy' : 'ty' }}, dej{{ f ? 'te' : '' }} nám prosím vědět odpovědí na tento e-mail.</p>
+
+    <div style="border-top:1px solid #dddddd; margin:18px 0;"></div>
+    <p>Pro pořádek {{ f ? 'Vám' : 'ti' }} posíláme <strong>aktuální stav celé přihlášky</strong>:</p>
+    {% include '@OswisOrgOswisCalendar/other/summary/participant-summary.html.twig' %}
+    {% include '@OswisOrgOswisCalendar/other/qr-payment/event-participant-qr-payment.html.twig' %}
 {% endblock %}
 
 {% block content_footer_inner %}
-    Aktuální stav celé přihlášky najdeš{{ f ? 'te' : '' }} ve svém účtu.
     V případě nejasností nás neváhej{{ f ? 'te' : '' }} kontaktovat odpovědí na tento e-mail.
 {% endblock %}

--- a/Resources/views/e-mail/pages/participant-registration-changed.html.twig
+++ b/Resources/views/e-mail/pages/participant-registration-changed.html.twig
@@ -32,7 +32,8 @@
             <li>Byly aktualizovány tvé kontaktní údaje.</li>
         {% endif %}
     </ul>
-    <p>Pokud tyto změny neprovedl{{ a }} {{ f ? 'Vy' : 'ty' }}, dej{{ f ? 'te' : '' }} nám prosím vědět odpovědí na tento e-mail.</p>
+    {# Disclaimer pro špatného příjemce — záměrně VŽDY vykání (může dorazit komukoliv). #}
+    <p>Pokud jste tyto změny neprovedl{{ a }} Vy, dejte nám prosím vědět odpovědí na tento e-mail.</p>
 
     <div style="border-top:1px solid #dddddd; margin:18px 0;"></div>
     <p>Pro pořádek {{ f ? 'Vám' : 'ti' }} posíláme <strong>aktuální stav celé přihlášky</strong>:</p>

--- a/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
@@ -66,7 +66,7 @@
             {% endfor %}
             {% for note in participant.notes|filter(note => note.textValue|default|length > 0) %}
                 <li style="list-style-type: '📝'; {{ note.deletedAt|default ? 'text-decoration:line-through;' : '' }}; color: darkorange;">
-                    <span class="small"><strong>{{ note.textValue }}</strong>{% if note.createdBy.shortName|default or note.createdBy.name|default %} <small>({{ note.createdBy.shortName|default(note.createdBy.name|default) }})</small>{% endif %}</span>
+                    <span class="small">{% if not note.publicNote|default(false) %}<strong style="color:#b00000;">[INTERNÍ]</strong> {% endif %}<strong>{{ note.textValue }}</strong>{% if note.createdBy.shortName|default or note.createdBy.name|default %} <small>({{ note.createdBy.shortName|default(note.createdBy.name|default) }})</small>{% endif %}</span>
                 </li>
             {% endfor %}
         </ul>

--- a/Resources/views/other/qr-payment/event-participant-qr-payment.html.twig
+++ b/Resources/views/other/qr-payment/event-participant-qr-payment.html.twig
@@ -13,7 +13,7 @@
                         <h4 style="color: #006FAD; margin: 0 0 6px;">Záloha</h4>
                         <img src="{{ depositQr }}" alt="Záloha - QR Platba" title="Záloha - QR Platba" style="max-width: 100%; height: auto;">
                         {% if participant.depositValue|default %}
-                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ participant.depositValue }},-&nbsp;Kč</div>
+                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ depositAmount is defined ? depositAmount : participant.depositValue }},-&nbsp;Kč</div>
                         {% endif %}
                     </td>
                 {% endif %}
@@ -22,7 +22,7 @@
                         <h4 style="color: #006FAD; margin: 0 0 6px;">Doplatek</h4>
                         <img src="{{ restQr }}" alt="Doplatek - QR Platba" title="Doplatek - QR Platba" style="max-width: 100%; height: auto;">
                         {% if participant.priceRest|default %}
-                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ participant.priceRest }},-&nbsp;Kč</div>
+                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ restAmount is defined ? restAmount : participant.priceRest }},-&nbsp;Kč</div>
                         {% endif %}
                     </td>
                 {% endif %}

--- a/Resources/views/other/qr-payment/event-participant-qr-payment.html.twig
+++ b/Resources/views/other/qr-payment/event-participant-qr-payment.html.twig
@@ -3,6 +3,9 @@
    convert, so tags leaked through as unknown elements and the QR block visually
    collapsed. Each <img> references a CID attachment embedded by
    ParticipantMailService::embedQrPayments. #}
+{# Self-default `f` jako participant-summary.html.twig — partial vkládají formálně i neformálně
+   adresované maily; `is defined` (ne |default), ať legitimní f=false (tykání) přežije. #}
+{% set f = f is defined ? f : (participant.formal is defined ? participant.formal : true) %}
 {% if depositQr|default or restQr|default %}
     <div style="border: 3px solid #006FAD; padding: 12px; margin-top: 18px;">
         <h3 style="color: #006FAD; text-align: center; margin: 0 0 8px;">QR&nbsp;PLATBA</h3>
@@ -10,18 +13,22 @@
             <tr>
                 {% if depositQr|default %}
                     <td align="center" style="vertical-align: top; padding: 0 8px; width: 50%;">
-                        <h4 style="color: #006FAD; margin: 0 0 6px;">Záloha</h4>
-                        <img src="{{ depositQr }}" alt="Záloha - QR Platba" title="Záloha - QR Platba" style="max-width: 100%; height: auto;">
-                        {% if participant.depositValue|default %}
+                        <h4 style="color: #006FAD; margin: 0 0 6px;">{{ depositLabel|default('Záloha') }}</h4>
+                        <img src="{{ depositQr }}" alt="{{ depositLabel|default('Záloha') }} - QR Platba" title="{{ depositLabel|default('Záloha') }} - QR Platba" style="max-width: 100%; height: auto;">
+                        {% if depositAmount is defined and depositAmount < participant.depositValue|default(depositAmount) %}
+                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ depositAmount }} z {{ participant.depositValue }},-&nbsp;Kč</div>
+                        {% elseif participant.depositValue|default %}
                             <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ depositAmount is defined ? depositAmount : participant.depositValue }},-&nbsp;Kč</div>
                         {% endif %}
                     </td>
                 {% endif %}
                 {% if restQr|default %}
                     <td align="center" style="vertical-align: top; padding: 0 8px; width: 50%;">
-                        <h4 style="color: #006FAD; margin: 0 0 6px;">Doplatek</h4>
-                        <img src="{{ restQr }}" alt="Doplatek - QR Platba" title="Doplatek - QR Platba" style="max-width: 100%; height: auto;">
-                        {% if participant.priceRest|default %}
+                        <h4 style="color: #006FAD; margin: 0 0 6px;">{{ restLabel|default('Doplatek') }}</h4>
+                        <img src="{{ restQr }}" alt="{{ restLabel|default('Doplatek') }} - QR Platba" title="{{ restLabel|default('Doplatek') }} - QR Platba" style="max-width: 100%; height: auto;">
+                        {% if restAmount is defined and restAmount < participant.priceRest|default(restAmount) %}
+                            <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ restAmount }} z {{ participant.priceRest }},-&nbsp;Kč</div>
+                        {% elseif participant.priceRest|default %}
                             <div style="color: #606060; font-size: 0.9em; margin-top: 4px;">{{ restAmount is defined ? restAmount : participant.priceRest }},-&nbsp;Kč</div>
                         {% endif %}
                     </td>
@@ -29,9 +36,9 @@
             </tr>
         </table>
         <p style="text-align: center; color: #606060; font-size: 0.85em; margin: 10px 0 0;">
-            Pro zaslání zálohy i&nbsp;doplatku můžeš použít
+            Pro zaslání zálohy i&nbsp;doplatku {{ f ? 'můžete' : 'můžeš' }} použít
             <b><a href="http://qr-platba.cz/pro-uzivatele/" title="Co je QR platba?" target="_blank">QR&nbsp;platbu</a></b>.
-            <br>Naskenuj kód do&nbsp;aplikace tvé&nbsp;banky a&nbsp;všechny údaje se ti předvyplní.
+            <br>Naskenuj{{ f ? 'te' : '' }} kód do&nbsp;aplikace {{ f ? 'Vaší' : 'tvé' }}&nbsp;banky a&nbsp;všechny údaje se {{ f ? 'Vám' : 'ti' }} předvyplní.
         </p>
     </div>
 {% endif %}

--- a/Resources/views/other/summary/participant-summary.html.twig
+++ b/Resources/views/other/summary/participant-summary.html.twig
@@ -185,11 +185,14 @@
     </ul>
 {% endif %}
 
-{% if participant.notes|filter(note => note.textValue|default|length > 0)|length > 0 %}
+{# Účastník vidí jen veřejné poznámky; organizátor (isInternal=true, předáno z web_adminu)
+   vidí i interní, zřetelně označené „[INTERNÍ]". `note.publicNote` je default false. #}
+{% set visibleNotes = participant.notes|filter(note => note.textValue|default|length > 0 and (isInternal or note.publicNote)) %}
+{% if visibleNotes|length > 0 %}
     <h3>Poznámky</h3>
     <ul>
-        {% for note in participant.notes|filter(note => note.textValue|default|length > 0) %}
-            <li><p><small>{{ note.textValue }}</small></p></li>
+        {% for note in visibleNotes %}
+            <li><p><small>{% if not note.publicNote %}<strong style="color:#b00000;">[INTERNÍ]</strong> {% endif %}{{ note.textValue }}</small></p></li>
         {% endfor %}
     </ul>
 {% endif %}

--- a/Resources/views/web_admin/bulk_reassign.html.twig
+++ b/Resources/views/web_admin/bulk_reassign.html.twig
@@ -48,6 +48,12 @@
                 Předvybráno <strong>{{ preselectedIds|default([])|length }}</strong> přihlášek ze seznamu.
                 Vyber cílovou přihlášku a potvrď přesun.
             </div>
+            {% if distinctEventCount|default(0) > 1 %}
+                <div class="alert alert-warning py-2">
+                    ⚠️ Výběr zahrnuje účastníky z <strong>{{ distinctEventCount }}</strong> různých akcí —
+                    všichni se přesunou na vybranou cílovou přihlášku. Zkontroluj, že je to záměr.
+                </div>
+            {% endif %}
         {% endif %}
         {% if sourceEvent or preselectMode|default(false) %}
             <form method="post"

--- a/Resources/views/web_admin/participant.html.twig
+++ b/Resources/views/web_admin/participant.html.twig
@@ -88,7 +88,7 @@
         {% if not isFullDetail %}
             {# Legacy arrival / check-in screen still relies on the full e-mail
                summary include — keep it here for that route only. #}
-            {% include '@OswisOrgOswisCalendar/other/summary/participant-summary.html.twig' %}
+            {% include '@OswisOrgOswisCalendar/other/summary/participant-summary.html.twig' with {'isInternal': true} %}
         {% else %}
             {# ----- Admin-friendly full detail layout ----- #}
 

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -109,7 +109,7 @@
                     <div class="{{ participantRange.active|default ? '' : 'strike' }}">{{ participantRange.event.shortName|default }}{% if participantRange.offer.shortName|default %} · {{ participantRange.offer.shortName }}{% endif %}</div>
                 {% endfor %}
                 {% for note in participant.notes|filter(note => note.textValue|default|length > 0) %}
-                    <div class="note {{ note.deletedAt|default ? 'strike' : '' }}">{{ note.textValue }}{% if note.createdBy.shortName|default or note.createdBy.name|default %} <span class="muted">({{ note.createdBy.shortName|default(note.createdBy.name|default) }})</span>{% endif %}</div>
+                    <div class="note {{ note.deletedAt|default ? 'strike' : '' }}">{% if not note.publicNote|default(false) %}<strong style="color:#b00000;">[INTERNÍ]</strong> {% endif %}{{ note.textValue }}{% if note.createdBy.shortName|default or note.createdBy.name|default %} <span class="muted">({{ note.createdBy.shortName|default(note.createdBy.name|default) }})</span>{% endif %}</div>
                 {% endfor %}
             </td>
             <td>

--- a/Serializer/ParticipantPrivacyNormalizer.php
+++ b/Serializer/ParticipantPrivacyNormalizer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Serializer;
+
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantNote;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Strips internal-only fields from API output for non-manager viewers.
+ *
+ * A logged-in participant (ROLE_CUSTOMER) reaches only their OWN participant record
+ * (row-scoped by {@see \OswisOrg\OswisCalendarBundle\ApiPlatform\ParticipantContainsUserExtension}),
+ * but the embedded participant graph still serialized fields meant strictly for organisers:
+ *   - any `internalNote` (the OSWIS NameableTrait convention for an organiser-only note) —
+ *     e.g. the payment's raw bank-statement import line (counterparty account, payer name,
+ *     phone) used for matching, a flag's internal note, a contact-detail internal note;
+ *   - {@see ParticipantNote}::textValue of a NON-public note (publicNote = false).
+ *
+ * Managers (ROLE_MANAGER, incl. ROLE_ADMIN via hierarchy) keep everything — the web/Ionic
+ * admin relies on it. Public payment notes (`note`) and public participant notes stay visible
+ * to the participant. See feedback_internal_notes_and_disclaimer.
+ *
+ * Registered as a decorator on BOTH item normalizers (json + json-ld) because the Ionic
+ * client requests either format — covering only one would leak via the other. Mirrors the
+ * existing {@see EventCapacityNormalizer} pattern, including the SerializerAwareInterface
+ * forwarding the inner AbstractItemNormalizer requires.
+ */
+final class ParticipantPrivacyNormalizer implements NormalizerInterface, SerializerAwareInterface
+{
+    public function __construct(
+        private readonly NormalizerInterface $decorated,
+        private readonly Security $security,
+    ) {
+    }
+
+    public function setSerializer(SerializerInterface $serializer): void
+    {
+        if ($this->decorated instanceof SerializerAwareInterface) {
+            $this->decorated->setSerializer($serializer);
+        }
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $data = $this->decorated->normalize($object, $format, $context);
+
+        // Managers see everything; only strip for non-managers (participants).
+        if (!is_array($data) || $this->security->isGranted('ROLE_MANAGER')) {
+            return $data;
+        }
+
+        // No `internalNote` (NameableTrait convention) ever reaches a participant — on any
+        // entity in the graph (payment, flag, contact detail, …). No-op when absent.
+        unset($data['internalNote']);
+
+        // A non-public participant note's text is internal too (its publicNote flag stays visible).
+        if ($object instanceof ParticipantNote && !$object->isPublicNote()) {
+            unset($data['textValue']);
+        }
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $this->decorated->supportsNormalization($data, $format, $context);
+    }
+
+    /**
+     * @return array<string, bool|null>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return $this->decorated->getSupportedTypes($format);
+    }
+}

--- a/Service/Participant/ParticipantMailService.php
+++ b/Service/Participant/ParticipantMailService.php
@@ -116,6 +116,7 @@ class ParticipantMailService
             try {
                 $participantMail = new ParticipantMail($participant, $appUser, $title, ParticipantMail::TYPE_REGISTRATION_CHANGED);
                 $participantMail->setPastMails($this->participantMailRepository->findByParticipant($participant));
+                $templatedEmail = $participantMail->getTemplatedEmail();
                 $data = [
                     'participant'    => $participant,
                     'appUser'        => $appUser,
@@ -123,7 +124,10 @@ class ParticipantMailService
                     'salutationName' => $contact instanceof Person ? $contact->getSalutationName() : $contact?->getName(),
                     'changes'        => $changes,
                     'type'           => ParticipantMail::TYPE_REGISTRATION_CHANGED,
+                    'depositAmount'  => $participant->getRemainingDeposit(),
+                    'restAmount'     => $participant->getRemainingPriceRest(),
                 ];
+                $data = $this->embedQrPayments($templatedEmail, $participant, $data, true);
                 $this->em->persist($participantMail);
                 $this->mailService->sendEMail($participantMail, self::REGISTRATION_CHANGED_TEMPLATE, $data);
                 $this->em->flush();
@@ -400,7 +404,7 @@ class ParticipantMailService
         return 'oswis.seznamovakup.cz';
     }
 
-    public function embedQrPayments(TemplatedEmail $templatedEmail, Participant $participant, array $mailData): array
+    public function embedQrPayments(TemplatedEmail $templatedEmail, Participant $participant, array $mailData, bool $remainingOnly = false): array
     {
         $participantId = $participant->getId();
         $participantContactSlug = $participant->getContact()?->getSlug();
@@ -412,7 +416,10 @@ class ParticipantMailService
                 'restQr' => ['deposit' => false, 'rest' => true],
             ] as $key => $opts
         ) {
-            if ($qrPng = $participant->generateQrPng($opts['deposit'], $opts['rest'], $qrComment)) {
+            $qrPng = $remainingOnly
+                ? $participant->generateRemainingQrPng($opts['deposit'], $opts['rest'], $qrComment)
+                : $participant->generateQrPng($opts['deposit'], $opts['rest'], $qrComment);
+            if ($qrPng) {
                 $templatedEmail->embed($qrPng, $key, 'image/png');
                 $mailData[$key] = "cid:$key";
             }

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -65,6 +65,44 @@ class ParticipantService
     }
 
     /**
+     * Po přesunu účastníka na jinou nabídku (`setOffer`) sjednotí "po-zápisovou" logiku,
+     * kterou jinak dělá jen ParticipantSubscriber (ten běží pouze na API requestech): pošle
+     * oznámení o změně přihlášky a přepočítá obsazenost příznaků i obou dotčených nabídek
+     * (zdrojové i cílové), aby kapacita obou ročníků zůstala správná.
+     *
+     * Volat AŽ PO `em->flush()` přesunu — diff změn (ParticipantChangeService) čte verzované
+     * záznamy, které vzniknou teprve zápisem. Chyby jen loguje, nikdy nevyhazuje.
+     */
+    public function applyPostMoveSideEffects(Participant $participant, ?RegistrationOffer $oldOffer = null): void
+    {
+        try {
+            $this->participantMailService->notifyParticipantChanged($participant);
+        } catch (\Throwable $e) {
+            $this->logger->error(sprintf(
+                'applyPostMoveSideEffects: oznámení o změně selhalo pro účastníka #%d: %s',
+                $participant->getId() ?? 0,
+                $e->getMessage(),
+            ));
+        }
+        try {
+            $this->flagRangeService->updateUsages($participant);
+            $newOffer = $participant->getOffer();
+            if (null !== $newOffer) {
+                $this->registrationOfferService->updateUsage($newOffer);
+            }
+            if (null !== $oldOffer && $oldOffer !== $newOffer) {
+                $this->registrationOfferService->updateUsage($oldOffer);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error(sprintf(
+                'applyPostMoveSideEffects: přepočet obsazenosti selhal pro účastníka #%d: %s',
+                $participant->getId() ?? 0,
+                $e->getMessage(),
+            ));
+        }
+    }
+
+    /**
      * @param Participant|null $participant
      *
      * @return Participant


### PR DESCRIPTION
## Summary
- **Přesun účastníka mezi ročníky z administrace** funguje korektně: sdílená `applyPostMoveSideEffects` po přesunu pošle „Změna v přihlášce" se shrnutím přihlášky + QR na **zbývající** částky (formát „X z Y"), přepočte obsazenost zdroje i cíle; admin nástroj přeskočí no-op přesun a varuje při výběru z více akcí.
- **Privacy interních poznámek:** `ParticipantPrivacyNormalizer` ne-managerovi přes API strhne `internalNote` (surový bankovní výpis, 4837 plateb / 2875 účastníků) + text neveřejných poznámek; manager/admin má vše. Staff výpisy (PDF/list) značí neveřejné poznámky `[INTERNÍ]`.
- Disclaimer ve změnovém mailu vždy vykáním; QR partial parametrický + f-aware tón.

## Test plan
- PHPStan level max: 0 chyb
- App functional smoke (klon DB + Mailpit): 13 testů / 140 assertions OK — vč. API privacy testu (majitel bez internalNote, manager s ním, json + json-ld) a smoke přesunu (mail + shrnutí + QR)
- `doctrine:schema:validate` in sync, twig lint OK
- Reálné ověření v Mailpitu (Berenika → „Změna v přihlášce", QR „Zbývající doplatek 3195 z 3900", vykání)

🤖 Generated with [Claude Code](https://claude.com/claude-code)