### PR TITLE
Admin flag editing (web admin + API/Ionic), incl. missing categories

### DIFF
--- a/Controller/Api/ParticipantFlagApiController.php
+++ b/Controller/Api/ParticipantFlagApiController.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Controller\Api;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagGroupOffer;
+use OswisOrg\OswisCalendarBundle\Exception\FlagCapacityExceededException;
+use OswisOrg\OswisCalendarBundle\Exception\FlagOutOfRangeException;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFlagUpdateService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * JWT-secured flag editing for the Ionic admin.
+ *
+ *  - GET  /api/participants/{id}/available-flags — every flag category selectable for the
+ *    participant (recursive, incl. admin-only/non-public ones the participant has no group for
+ *    yet), each offer marked selected/full. Lets the mobile admin show ALL categories, not just
+ *    the ones already on the participant.
+ *  - POST /api/participants/{id}/flags — set one category's flags in a single call.
+ *
+ * Both delegate to {@see ParticipantFlagUpdateService} — the SAME trusted core the web admin uses,
+ * so the mobile and web paths can't diverge. This replaces the old PUT /participant_flag_groups
+ * flow, which could neither add a flag (the client sent a flagOffer without its @id IRI, so the API
+ * couldn't resolve it) nor add a category the participant had no group for.
+ */
+#[IsGranted('ROLE_MANAGER')]
+final class ParticipantFlagApiController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ParticipantFlagUpdateService $flagUpdateService,
+    ) {
+    }
+
+    public function available(int $participantId): JsonResponse
+    {
+        $participant = $this->em->find(Participant::class, $participantId);
+        if (!$participant instanceof Participant || $participant->isDeleted()) {
+            return new JsonResponse(['error' => 'not_found', 'message' => 'Účastník nenalezen.'], Response::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse(['categories' => $this->serializeModel($participant)]);
+    }
+
+    public function set(Request $request, int $participantId): JsonResponse
+    {
+        $participant = $this->em->find(Participant::class, $participantId);
+        if (!$participant instanceof Participant || $participant->isDeleted()) {
+            return new JsonResponse(['error' => 'not_found', 'message' => 'Účastník nenalezen.'], Response::HTTP_NOT_FOUND);
+        }
+
+        try {
+            /** @var array<string, mixed> $payload */
+            $payload = json_decode($request->getContent() ?: '[]', true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return new JsonResponse(['error' => 'bad_json', 'message' => 'Neplatné tělo požadavku.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $rawGroupOfferId = $payload['flagGroupOffer'] ?? null;
+        $groupOfferId = is_numeric($rawGroupOfferId) ? (int) $rawGroupOfferId : 0;
+        $groupOffer = $groupOfferId > 0 ? $this->em->find(RegistrationFlagGroupOffer::class, $groupOfferId) : null;
+        if (!$groupOffer instanceof RegistrationFlagGroupOffer) {
+            return new JsonResponse(['error' => 'bad_category', 'message' => 'Neznámá kategorie příznaků.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $flagOfferIds = [];
+        foreach ((array) ($payload['flagOffers'] ?? []) as $rawId) {
+            if (is_numeric($rawId)) {
+                $flagOfferIds[] = (int) $rawId;
+            }
+        }
+        $admin = (bool) ($payload['admin'] ?? false);
+
+        try {
+            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin);
+        } catch (FlagCapacityExceededException $e) {
+            return new JsonResponse(['error' => 'capacity', 'message' => $e->getMessage()], Response::HTTP_CONFLICT);
+        } catch (FlagOutOfRangeException $e) {
+            return new JsonResponse(['error' => 'range', 'message' => $e->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'failed', 'message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
+        }
+
+        return new JsonResponse(['categories' => $this->serializeModel($participant)]);
+    }
+
+    /**
+     * Flatten {@see ParticipantFlagUpdateService::getFlagSelectionModel()} into JSON-safe scalars.
+     *
+     * @return list<array{flagGroupOffer: int|null, category: string, min: int, max: int|null, hasGroup: bool, flagOffers: list<array{id: int|null, name: string|null, price: int, selected: bool, remaining: int|null, full: bool}>}>
+     */
+    private function serializeModel(Participant $participant): array
+    {
+        $out = [];
+        foreach ($this->flagUpdateService->getFlagSelectionModel($participant) as $cat) {
+            $offers = [];
+            foreach ($cat['flagOffers'] as $flagOffer) {
+                $offer = $flagOffer['offer'];
+                $offers[] = [
+                    'id'        => $offer->getId(),
+                    'name'      => $offer->getFlag()?->getName() ?? $offer->getName(),
+                    'price'     => $offer->getPrice(),
+                    'selected'  => $flagOffer['selected'],
+                    'remaining' => $flagOffer['remaining'],
+                    'full'      => $flagOffer['full'],
+                ];
+            }
+            $out[] = [
+                'flagGroupOffer' => $cat['groupOffer']->getId(),
+                'category'       => $cat['categoryName'],
+                'min'            => $cat['min'],
+                'max'            => $cat['max'],
+                'hasGroup'       => $cat['hasGroup'],
+                'flagOffers'     => $offers,
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -5,6 +5,7 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
 use OswisOrg\OswisCalendarBundle\Exception\FlagCapacityExceededException;
+use OswisOrg\OswisCalendarBundle\Exception\FlagOutOfRangeException;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Communication\CommunicationTimelineService;
 use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagGroupOffer;
@@ -122,6 +123,8 @@ final class WebAdminParticipantsController extends AbstractController
                 'Kapacita překročena: %s. Zaškrtni „povolit překročení kapacity" pro vynucení.',
                 $e->getMessage(),
             ));
+        } catch (FlagOutOfRangeException $e) {
+            $this->addFlash('error', sprintf('Mimo povolený počet příznaků: %s', $e->getMessage()));
         } catch (\Throwable $e) {
             $this->addFlash('error', sprintf('Příznaky neuloženy: %s', $e->getMessage()));
         }

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -2,10 +2,14 @@
 
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Entity\ParticipantMail\ParticipantMail;
+use OswisOrg\OswisCalendarBundle\Exception\FlagCapacityExceededException;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Communication\CommunicationTimelineService;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagGroupOffer;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantChangeService;
+use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFlagUpdateService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantMailService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantService;
 use OswisOrg\OswisAddressBookBundle\Entity\AbstractClass\AbstractContact;
@@ -26,6 +30,7 @@ final class WebAdminParticipantsController extends AbstractController
         private readonly CommunicationTimelineService $timelineService,
         private readonly ParticipantMailService $participantMailService,
         private readonly ParticipantChangeService $changeService,
+        private readonly ParticipantFlagUpdateService $flagUpdateService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -61,6 +66,74 @@ final class WebAdminParticipantsController extends AbstractController
         return new RedirectResponse($this->generateUrl(
             'oswis_org_oswis_calendar_web_admin_participant_detail',
             ['participantId' => $participantId, '_fragment' => 'komunikace'],
+        ));
+    }
+
+    /**
+     * Add/remove a participant's registration flags for ONE category from the admin detail page.
+     *
+     * Works even when the participant has no flag group for that category yet — the group is
+     * materialised on demand (admin-only categories like Sleva / Zkrácený pobyt / Poznámky k platbě
+     * never auto-create at registration because setFlagGroupsByOffer filters onlyPublic=true). The
+     * heavy lifting (validation, capacity, soft-delete, activation, usage recompute) lives in
+     * {@see ParticipantFlagUpdateService::setFlags()}. Silent — sends no e-mail. With the
+     * `admin_override` checkbox the capacity ceiling is bypassed ($admin=true).
+     *
+     * Uses a lightweight em->find() + flush (the proven bulk-reassign persist path), not the full
+     * detail-graph hydration, to avoid the L2-cache/getName() memory blow-up on large graphs.
+     */
+    #[IsGranted('ROLE_MANAGER')]
+    public function editFlags(Request $request, int $participantId): Response
+    {
+        if (!$this->isCsrfTokenValid('participant_edit_flags_'.$participantId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $participant = $this->em->find(Participant::class, $participantId);
+        if (!$participant instanceof Participant || $participant->isDeleted()) {
+            throw $this->createNotFoundException('Účastník nenalezen.');
+        }
+
+        $groupOfferId = (int) $request->request->get('flagGroupOfferId');
+        $groupOffer = $groupOfferId > 0 ? $this->em->find(RegistrationFlagGroupOffer::class, $groupOfferId) : null;
+        if (!$groupOffer instanceof RegistrationFlagGroupOffer) {
+            $this->addFlash('error', 'Neznámá kategorie příznaků.');
+
+            return $this->redirectToParticipantFlags($participantId);
+        }
+
+        $flagOfferIds = [];
+        foreach ((array) $request->request->all('flagOfferIds') as $rawId) {
+            if (is_numeric($rawId)) {
+                $flagOfferIds[] = (int) $rawId;
+            }
+        }
+        $admin = (bool) $request->request->get('admin_override', false);
+
+        try {
+            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin);
+            $this->addFlash('success', sprintf(
+                'Příznaky kategorie „%s" u účastníka #%d uloženy%s.',
+                $groupOffer->getFlagCategory()?->getName() ?? '?',
+                $participantId,
+                $admin ? ' (povoleno překročení kapacity)' : '',
+            ));
+        } catch (FlagCapacityExceededException $e) {
+            $this->addFlash('error', sprintf(
+                'Kapacita překročena: %s. Zaškrtni „povolit překročení kapacity" pro vynucení.',
+                $e->getMessage(),
+            ));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', sprintf('Příznaky neuloženy: %s', $e->getMessage()));
+        }
+
+        return $this->redirectToParticipantFlags($participantId);
+    }
+
+    private function redirectToParticipantFlags(int $participantId): RedirectResponse
+    {
+        return new RedirectResponse($this->generateUrl(
+            'oswis_org_oswis_calendar_web_admin_participant_detail',
+            ['participantId' => $participantId, '_fragment' => 'priznaky'],
         ));
     }
 
@@ -106,10 +179,19 @@ final class WebAdminParticipantsController extends AbstractController
             }
         }
 
+        // Flag editor model: every category reachable for this participant (incl. admin-only ones
+        // the participant has no group for yet). Best-effort — must not break the detail page.
+        $flagSelectionModel = [];
+        try {
+            $flagSelectionModel = $this->flagUpdateService->getFlagSelectionModel($participant);
+        } catch (\Throwable) {
+        }
+
         return $this->render('@OswisOrgOswisCalendar/web_admin/participant.html.twig', [
             'participant'        => $participant,
             'entries'            => $entries,
             'history'            => $history,
+            'flagSelectionModel' => $flagSelectionModel,
             'isAdmin'            => true,
             'showFullDetail'     => true,
             'participantId'      => $participantId,

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -3,6 +3,20 @@ oswis_org_oswis_calendar_api_participants_export:
   path: "/api/exports/participants"
   methods: [GET]
 
+oswis_org_oswis_calendar_api_participant_available_flags:
+  controller: OswisOrg\OswisCalendarBundle\Controller\Api\ParticipantFlagApiController::available
+  path: "/api/participants/{participantId}/available-flags"
+  requirements:
+    participantId: '\d+'
+  methods: [GET]
+
+oswis_org_oswis_calendar_api_participant_set_flags:
+  controller: OswisOrg\OswisCalendarBundle\Controller\Api\ParticipantFlagApiController::set
+  path: "/api/participants/{participantId}/flags"
+  requirements:
+    participantId: '\d+'
+  methods: [POST]
+
 oswis_org_oswis_calendar_participant_resend_activation_email:
   controller: oswis_org_oswis_calendar.participant.participant_controller::resendActivationEmail
   path: "/akce/prihlaska/email-overeni/{participantId}"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -265,6 +265,13 @@ oswis_org_oswis_calendar_web_admin_participant_set_gender:
     participantId: '\d+'
   methods: [POST]
 
+oswis_org_oswis_calendar_web_admin_participant_edit_flags:
+  controller: oswis_org_oswis_calendar.web_admin.participants_controller::editFlags
+  path: "/web_admin/ucastnici/{participantId}/priznaky"
+  requirements:
+    participantId: '\d+'
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_participant_resend_mail:
   controller: oswis_org_oswis_calendar.web_admin.participants_controller::resendMail
   path: "/web_admin/ucastnici/{participantId}/znovu-poslat-mail/{mailId}"

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -22,6 +22,12 @@ services:
     public: true
     tags: [ 'controller.service_arguments' ]
 
+  ## API flag-editing controller (JWT, ROLE_MANAGER) — Ionic admin
+  OswisOrg\OswisCalendarBundle\Controller\Api\ParticipantFlagApiController:
+    autowire: true
+    public: true
+    tags: [ 'controller.service_arguments' ]
+
   ###
   ### CONTROLLERS
   ###

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -352,6 +352,10 @@ services:
     autowire: true
     public: true
 
+  OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantFlagUpdateService:
+    autowire: true
+    public: true
+
   oswis_org_oswis_calendar.participant.participant_category_service:
     class: OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantCategoryService
     autowire: true

--- a/Resources/views/web_admin/participant.html.twig
+++ b/Resources/views/web_admin/participant.html.twig
@@ -266,15 +266,64 @@
                 </div>
             </div>
 
-            {# Příznaky (flag groups) #}
-            {% set flagGroupRows = participant.flagGroups|default([]) %}
-            {% if flagGroupRows|length > 0 %}
-                <div class="card" style="margin-bottom: 1rem;">
-                    <div class="card-body">
-                        <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Příznaky</h5>
+            {# Příznaky (flag groups) — editovatelné, vč. kategorií, které účastník zatím nemá #}
+            <div class="card" style="margin-bottom: 1rem;" id="priznaky">
+                <div class="card-body">
+                    <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Příznaky</h5>
+                    {% if isAdmin|default(false) and flagSelectionModel|default([])|length > 0 %}
+                        <p class="text-muted" style="font-size: .85em; margin-bottom: .75rem;">
+                            Každá kategorie se ukládá zvlášť. Lze přidat i kategorii, kterou účastník zatím nemá
+                            (např. Sleva, Zkrácený pobyt). „Povolit překročení kapacity" obejde naplněnou nabídku.
+                        </p>
+                        {% for cat in flagSelectionModel %}
+                            {% set single = cat.max == 1 %}
+                            <form method="post"
+                                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_edit_flags', { participantId: participant.id }) }}"
+                                  style="border-top: 1px solid #f0f0f0; padding: .5rem 0;">
+                                <input type="hidden" name="_token" value="{{ csrf_token('participant_edit_flags_' ~ participant.id) }}">
+                                <input type="hidden" name="flagGroupOfferId" value="{{ cat.groupOffer.id }}">
+                                <div style="display: flex; flex-wrap: wrap; align-items: center; gap: .5rem;">
+                                    <strong style="min-width: 11rem;">
+                                        {{ cat.categoryName }}
+                                        {% if not cat.hasGroup %}<span class="badge bg-secondary" style="font-weight: normal;">zatím nepřidáno</span>{% endif %}
+                                        <br><small class="text-muted">
+                                            {% if single %}vyber právě 1{% else %}min {{ cat.min }}{% if cat.max is not null %}, max {{ cat.max }}{% endif %}{% endif %}
+                                        </small>
+                                    </strong>
+                                    <div style="flex: 1; min-width: 16rem;">
+                                        {% if single and cat.min == 0 %}
+                                            <label style="margin-right: .75rem; white-space: nowrap;">
+                                                <input type="radio" name="flagOfferIds[]" value=""
+                                                       {{ cat.flagOffers|filter(fo => fo.selected)|length == 0 ? 'checked' : '' }}>
+                                                <span class="text-muted">— žádný —</span>
+                                            </label>
+                                        {% endif %}
+                                        {% for fo in cat.flagOffers %}
+                                            <label style="margin-right: .75rem; white-space: nowrap; {{ fo.full ? 'opacity:.5;' : '' }}">
+                                                <input type="{{ single ? 'radio' : 'checkbox' }}" name="flagOfferIds[]"
+                                                       value="{{ fo.offer.id }}"
+                                                       {{ fo.selected ? 'checked' : '' }}
+                                                       {{ fo.full ? 'disabled' : '' }}>
+                                                {{ fo.offer.flag.name|default(fo.offer.name|default('příznak')) }}
+                                                {% if fo.offer.price|default(0) != 0 %}<span class="text-muted">({{ fo.offer.price > 0 ? '+' : '' }}{{ fo.offer.price }} Kč)</span>{% endif %}
+                                                {% if fo.remaining is not null %}<span class="text-muted" style="font-size: .8em;">[zbývá {{ fo.remaining }}]</span>{% endif %}
+                                            </label>
+                                        {% else %}
+                                            <em class="text-secondary">žádné nabídky</em>
+                                        {% endfor %}
+                                    </div>
+                                    <label style="white-space: nowrap; font-size: .8em;" title="Obejít naplněnou kapacitu">
+                                        <input type="checkbox" name="admin_override" value="1"> překročit kapacitu
+                                    </label>
+                                    <button type="submit" class="btn btn-sm btn-primary">Uložit</button>
+                                </div>
+                            </form>
+                        {% endfor %}
+                    {% else %}
+                        {# Read-only fallback (ne-admin, nebo žádné dostupné kategorie) #}
                         <table class="table table-sm" style="margin-bottom: 0;">
                             <tbody>
-                                {% for flagGroup in flagGroupRows %}
+                                {% for flagGroup in participant.flagGroups|default([]) %}
                                     <tr>
                                         <th style="width: 12rem; white-space: nowrap;">
                                             {{ flagGroup.flagGroupRange.flagCategory.name|default(flagGroup.name|default('Skupina')) }}
@@ -292,12 +341,14 @@
                                             {% endfor %}
                                         </td>
                                     </tr>
+                                {% else %}
+                                    <tr><td><em class="text-secondary">Žádné příznaky.</em></td></tr>
                                 {% endfor %}
                             </tbody>
                         </table>
-                    </div>
+                    {% endif %}
                 </div>
-            {% endif %}
+            </div>
 
             {# Poznámky — interní/veřejné poznámky k účastníkovi #}
             <div class="card" style="margin-bottom: 1rem;" id="poznamky">

--- a/Service/Participant/ParticipantFlagUpdateService.php
+++ b/Service/Participant/ParticipantFlagUpdateService.php
@@ -104,11 +104,19 @@ final class ParticipantFlagUpdateService
             throw new \InvalidArgumentException('Tato kategorie příznaků není pro přihlášku účastníka dostupná.');
         }
 
-        $group = $this->findGroup($participant, $groupOffer);
-        if (!$group instanceof ParticipantFlagGroup) {
+        // Find any group bound to this offer, including a soft-deleted one (a category removed
+        // earlier leaves a soft-deleted group; addFlagGroupOffer would then refuse to create a new
+        // one — its existence check counts soft-deleted groups too — so we must restore that group
+        // rather than fail).
+        $group = $this->findGroup($participant, $groupOffer, includeDeleted: true);
+        if ($group instanceof ParticipantFlagGroup) {
+            if ($group->isDeleted()) {
+                $group->setDeletedAt(null);
+            }
+        } else {
             // Idempotent — creates an empty group bound to this offer (binding is immutable afterwards).
             $participant->addFlagGroupOffer($groupOffer);
-            $group = $this->findGroup($participant, $groupOffer);
+            $group = $this->findGroup($participant, $groupOffer, includeDeleted: true);
         }
         if (!$group instanceof ParticipantFlagGroup) {
             throw new \InvalidArgumentException('Skupinu příznaků se nepodařilo vytvořit.');
@@ -224,9 +232,12 @@ final class ParticipantFlagUpdateService
         return $model;
     }
 
-    private function findGroup(Participant $participant, RegistrationFlagGroupOffer $groupOffer): ?ParticipantFlagGroup
-    {
-        foreach ($participant->getFlagGroups(null, null, true) as $group) {
+    private function findGroup(
+        Participant $participant,
+        RegistrationFlagGroupOffer $groupOffer,
+        bool $includeDeleted = false,
+    ): ?ParticipantFlagGroup {
+        foreach ($participant->getFlagGroups(null, null, !$includeDeleted) as $group) {
             if ($group->getFlagGroupOffer()?->getId() === $groupOffer->getId()) {
                 return $group;
             }

--- a/Service/Participant/ParticipantFlagUpdateService.php
+++ b/Service/Participant/ParticipantFlagUpdateService.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Service\Participant;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlag;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantFlagGroup;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagGroupOffer;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagOffer;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationOffer;
+use OswisOrg\OswisCalendarBundle\Exception\FlagCapacityExceededException;
+use OswisOrg\OswisCalendarBundle\Exception\FlagOutOfRangeException;
+use OswisOrg\OswisCalendarBundle\Service\Registration\RegistrationFlagOfferService;
+use OswisOrg\OswisCoreBundle\Exceptions\NotImplementedException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Admin-side editing of a participant's registration flags (příznaky) — the piece the public
+ * registration form never offered.
+ *
+ * Two capabilities the existing flows lack:
+ *  1. Editing a flag category EVEN WHEN the participant has no {@see ParticipantFlagGroup} for it
+ *     yet. At registration time only PUBLIC group offers get a group ({@see Participant::setFlagGroupsByOffer()}
+ *     filters onlyPublic=true), so admin-only categories (Sleva, Zkrácený pobyt, Poznámky k platbě)
+ *     never materialise. Here we create the group on demand via the idempotent
+ *     {@see Participant::addFlagGroupOffer()}.
+ *  2. A single trusted entry point shared by the web admin controller and the API state processor,
+ *     so the capacity/min-max/soft-delete logic in {@see ParticipantFlagGroup::setParticipantFlags()}
+ *     cannot drift between the two clients.
+ *
+ * What it deliberately does NOT do: send any e-mail (admin micro-edits stay silent), and it never
+ * lets an admin attach a group offer that is not reachable from the participant's own registration
+ * offer (the recursive availability set is the security boundary).
+ */
+final class ParticipantFlagUpdateService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly RegistrationFlagOfferService $flagOfferService,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * All flag-group offers reachable for this participant's registration offer — recursively
+     * through requiredRegRange (a turnus offer pulls its parent registration's categories), and
+     * including non-public (admin-only) offers when $includeNonPublic is true.
+     *
+     * Deduplicated by id (the recursive walk can surface the same offer twice) with a stable order.
+     *
+     * @return list<RegistrationFlagGroupOffer>
+     */
+    public function getAvailableGroupOffers(Participant $participant, bool $includeNonPublic = true): array
+    {
+        $offer = $participant->getOffer();
+        if (!$offer instanceof RegistrationOffer) {
+            return [];
+        }
+        $byId = [];
+        foreach ($offer->getFlagGroupRanges(null, null, !$includeNonPublic, true) as $groupOffer) {
+            $groupOfferId = $groupOffer->getId();
+            if (null !== $groupOfferId) {
+                $byId[$groupOfferId] = $groupOffer;
+            }
+        }
+
+        return array_values($byId);
+    }
+
+    /**
+     * Set the participant's flags for ONE category (group offer) to exactly the given selection,
+     * materialising the participant flag group if it does not exist yet.
+     *
+     * Reuses {@see ParticipantFlagGroup::setParticipantFlags()} for validation: it enforces the
+     * group's min/max, each flag offer's min/max and remaining capacity ($admin=true bypasses the
+     * capacity ceiling), soft-deletes removed flags and activates added ones. Persisted in two
+     * flushes — the second one recomputes the cached usage counts, which read committed rows and so
+     * must run after the first flush.
+     *
+     * @param list<int> $selectedFlagOfferIds ids of the RegistrationFlagOffers that should remain/become active
+     *
+     * @throws FlagCapacityExceededException when adding would exceed a flag offer's capacity (only when $admin=false)
+     * @throws FlagOutOfRangeException       when the resulting count breaks a min/max constraint
+     * @throws NotImplementedException       propagated from the entity layer (should not happen here)
+     * @throws \InvalidArgumentException     when the group offer is not reachable for this participant
+     */
+    public function setFlags(
+        Participant $participant,
+        RegistrationFlagGroupOffer $groupOffer,
+        array $selectedFlagOfferIds,
+        bool $admin = false,
+    ): void {
+        // Security boundary: the group offer must belong to this participant's (recursive) offer set.
+        $availableIds = array_map(
+            static fn (RegistrationFlagGroupOffer $go): ?int => $go->getId(),
+            $this->getAvailableGroupOffers($participant, true),
+        );
+        if (null === $groupOffer->getId() || !in_array($groupOffer->getId(), $availableIds, true)) {
+            throw new \InvalidArgumentException('Tato kategorie příznaků není pro přihlášku účastníka dostupná.');
+        }
+
+        $group = $this->findGroup($participant, $groupOffer);
+        if (!$group instanceof ParticipantFlagGroup) {
+            // Idempotent — creates an empty group bound to this offer (binding is immutable afterwards).
+            $participant->addFlagGroupOffer($groupOffer);
+            $group = $this->findGroup($participant, $groupOffer);
+        }
+        if (!$group instanceof ParticipantFlagGroup) {
+            throw new \InvalidArgumentException('Skupinu příznaků se nepodařilo vytvořit.');
+        }
+
+        // Resolve the requested ids against the offers actually available in this group (incl. non-public).
+        $selectedOffers = [];
+        foreach ($group->getAvailableFlagOffers(false) as $flagOffer) {
+            if ($flagOffer instanceof RegistrationFlagOffer
+                && null !== $flagOffer->getId()
+                && in_array($flagOffer->getId(), $selectedFlagOfferIds, true)) {
+                $selectedOffers[$flagOffer->getId()] = $flagOffer;
+            }
+        }
+
+        // Build the new collection: keep existing active flags whose offer stays selected (preserves
+        // their identity so setParticipantFlags() treats them as unchanged), create new ones for the rest.
+        $existingByOfferId = [];
+        foreach ($group->getParticipantFlags(true) as $existingFlag) {
+            $offerId = $existingFlag->getFlagOffer()?->getId();
+            if (null !== $offerId) {
+                $existingByOfferId[$offerId] = $existingFlag;
+            }
+        }
+        /** @var Collection<int, ParticipantFlag> $newFlags */
+        $newFlags = new ArrayCollection();
+        foreach ($selectedOffers as $offerId => $flagOffer) {
+            if (isset($existingByOfferId[$offerId])) {
+                $newFlags->add($existingByOfferId[$offerId]);
+                continue;
+            }
+            // Mirror the registration form (FlagGroupOfParticipantType): a freshly constructed
+            // ParticipantFlag with its group set self-registers into the group's collection, so
+            // setParticipantFlags() then sees it as already-present and skips its activate() loop.
+            // Activate explicitly — exactly as the registration path does — so the flag is active.
+            $newFlag = new ParticipantFlag($flagOffer, $group);
+            $newFlag->activate();
+            $newFlags->add($newFlag);
+        }
+
+        // Validates + applies (soft-deletes removed, activates added). Throws on capacity/min-max.
+        $group->setParticipantFlags($newFlags, $admin);
+
+        $this->em->persist($participant);
+        $this->em->flush();
+
+        // Recompute cached usage AFTER the flush — countParticipantFlags() counts committed rows, so a
+        // pre-flush count would be stale. Mirrors the recompute endpoint (ParticipantController::updateParticipants).
+        $participant->updateCachedColumns();
+        $this->flagOfferService->updateUsages($participant);
+        $this->em->flush();
+
+        $this->logger->info(sprintf(
+            'FLAG EDIT: participant #%d category #%d set to [%s] (admin=%s).',
+            $participant->getId() ?? 0,
+            $groupOffer->getId(),
+            implode(',', array_keys($selectedOffers)),
+            $admin ? 'true' : 'false',
+        ));
+    }
+
+    /**
+     * Presentation model for the admin flag editor: every flag category reachable for the
+     * participant (recursive, incl. non-public), with each flag offer marked selected/full and the
+     * group's min/max — so the template can render one edit form per category, including categories
+     * the participant has no group for yet ('hasGroup' = false).
+     *
+     * @return list<array{
+     *     groupOffer: RegistrationFlagGroupOffer,
+     *     categoryName: string,
+     *     min: int,
+     *     max: int|null,
+     *     hasGroup: bool,
+     *     flagOffers: list<array{offer: RegistrationFlagOffer, selected: bool, remaining: int|null, full: bool}>
+     * }>
+     */
+    public function getFlagSelectionModel(Participant $participant): array
+    {
+        $model = [];
+        foreach ($this->getAvailableGroupOffers($participant, true) as $groupOffer) {
+            $group = $this->findGroup($participant, $groupOffer);
+            $activeOfferIds = [];
+            if ($group instanceof ParticipantFlagGroup) {
+                foreach ($group->getParticipantFlags(true) as $participantFlag) {
+                    $activeOfferId = $participantFlag->getFlagOffer()?->getId();
+                    if (null !== $activeOfferId) {
+                        $activeOfferIds[$activeOfferId] = true;
+                    }
+                }
+            }
+            $flagOffers = [];
+            foreach ($groupOffer->getFlagOffers(false) as $offer) {
+                $selected = null !== $offer->getId() && isset($activeOfferIds[$offer->getId()]);
+                $remaining = $offer->getRemainingCapacity();
+                $flagOffers[] = [
+                    'offer'     => $offer,
+                    'selected'  => $selected,
+                    'remaining' => $remaining,
+                    // "full" only blocks NEW selections — an already-selected flag is never disabled.
+                    'full'      => !$selected && null !== $remaining && $remaining < 1,
+                ];
+            }
+            $model[] = [
+                'groupOffer'   => $groupOffer,
+                'categoryName' => $groupOffer->getFlagCategory()?->getName() ?? 'Ostatní',
+                'min'          => $groupOffer->getMin(),
+                'max'          => $groupOffer->getMax(),
+                'hasGroup'     => $group instanceof ParticipantFlagGroup,
+                'flagOffers'   => $flagOffers,
+            ];
+        }
+
+        return $model;
+    }
+
+    private function findGroup(Participant $participant, RegistrationFlagGroupOffer $groupOffer): ?ParticipantFlagGroup
+    {
+        foreach ($participant->getFlagGroups(null, null, true) as $group) {
+            if ($group->getFlagGroupOffer()?->getId() === $groupOffer->getId()) {
+                return $group;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Service/Participant/ParticipantFlagUpdateService.php
+++ b/Service/Participant/ParticipantFlagUpdateService.php
@@ -164,9 +164,13 @@ final class ParticipantFlagUpdateService
         $this->em->flush();
 
         // Recompute cached usage AFTER the flush — countParticipantFlags() counts committed rows, so a
-        // pre-flush count would be stale. Mirrors the recompute endpoint (ParticipantController::updateParticipants).
+        // pre-flush count would be stale. Recompute EVERY offer in the edited category (not just the
+        // ones the participant still holds): a REMOVED offer is no longer in the participant's flag set,
+        // so updateUsages($participant) would never touch it and its cached usage would stay inflated.
         $participant->updateCachedColumns();
-        $this->flagOfferService->updateUsages($participant);
+        foreach ($groupOffer->getFlagOffers(false) as $offer) {
+            $this->flagOfferService->updateUsage($offer);
+        }
         $this->em->flush();
 
         $this->logger->info(sprintf(


### PR DESCRIPTION
Adds admin editing of a participant's registration flags across web admin + API (consumed by Ionic), including **materialising flag categories the participant has no group for yet** (admin-only Sleva / Zkrácený pobyt / Poznámky k platbě, which never auto-create at registration).

- `ParticipantFlagUpdateService` — shared trusted core (find/restore/materialise group → setParticipantFlags(admin) → recompute usage). Silent (no e-mail).
- Web admin: `editFlags` action + editable Příznaky section on participant detail.
- API: `GET /api/participants/{id}/available-flags` + `POST /api/participants/{id}/flags` (ROLE_MANAGER), replacing the fragile PUT /participant_flag_groups.
- Ionic: `changeFlags` → endpoints + shows missing categories + admin capacity-override toggle.

3 bugs found by live testing + fixed (activation, soft-deleted-group restore, removed-offer usage recompute). Verified: web admin browser E2E, API curl E2E (admin JWT), Ionic live browser E2E, PHPStan max=0, schema in sync, independent code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)