### PR TITLE
feat(participant): flag editing + 2026 dietary/transport setup + native detail UI

### DIFF
--- a/Command/Setup2026FlagsCommand.php
+++ b/Command/Setup2026FlagsCommand.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use OswisOrg\OswisCalendarBundle\Entity\NonPersistent\Capacity;
+use OswisOrg\OswisCalendarBundle\Entity\NonPersistent\FlagAmountRange;
+use OswisOrg\OswisCalendarBundle\Entity\NonPersistent\Price;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlag;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagCategory;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagGroupOffer;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationFlagOffer;
+use OswisOrg\OswisCalendarBundle\Entity\Registration\RegistrationOffer;
+use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Nameable;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Idempotentně doplní admin-only příznakové kategorie na hlavní přihlášku ročníku 2026:
+ *  - Stravovací omezení (8-volbová merge sada; "Jiné" s textovým upřesněním),
+ *  - Doprava – příjezd / odjezd (po 1 příznaku s textValem = datum a čas).
+ *
+ * Flag konfigurace se v OSWISu tvoří přes entity vrstvu (viz YearCloneService) — tento command
+ * mirroruje stejnou konstrukci. Pouštět nejdřív na klon (--apply), pak na prod jako web4.
+ */
+#[AsCommand(
+    name: 'oswis:flags:setup-2026',
+    description: 'Idempotentně naváže admin kategorie příznaků (dietní + doprava) na hlavní přihlášku ročníku.',
+)]
+final class Setup2026FlagsCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Deklarativní specifikace kategorií k zajištění. Slugy příznaků dietních režimů a dopravy
+     * odpovídají existujícím master příznakům (ověřeno v DB) — ty se NEpřejmenovávají, jen se na ně
+     * vytvoří nabídky. Nové dietní příznaky (vejce/sója/ořechy/jiné) se vytvoří.
+     *
+     * @return list<array{
+     *   categorySlug: string, groupOfferSlug: string, groupName: string, groupShortName: string,
+     *   min: int, max: int|null,
+     *   flags: list<array{slug: string, name: string, shortName: string, formValueLabel: ?string}>
+     * }>
+     */
+    private function categoriesSpec(): array
+    {
+        return [
+            [
+                'categorySlug'   => 'stravovaci-omezeni',
+                'groupOfferSlug' => 'stravovaci-omezeni-2026',
+                'groupName'      => 'Stravovací omezení',
+                'groupShortName' => 'Strava',
+                'min'            => 0,
+                'max'            => null, // multi-select
+                'flags'          => [
+                    ['slug' => 'vegetarian', 'name' => 'Vegetariánská strava', 'shortName' => 'Vegetarián', 'formValueLabel' => null],
+                    ['slug' => 'vegan', 'name' => 'Veganská strava', 'shortName' => 'Vegan', 'formValueLabel' => null],
+                    ['slug' => 'bez-lepku', 'name' => 'Lepek', 'shortName' => 'Lepek', 'formValueLabel' => null],
+                    ['slug' => 'bez-laktozy', 'name' => 'Mléko/laktóza', 'shortName' => 'Mléko/laktóza', 'formValueLabel' => null],
+                    ['slug' => 'vejce', 'name' => 'Vejce', 'shortName' => 'Vejce', 'formValueLabel' => null],
+                    ['slug' => 'soja', 'name' => 'Sója', 'shortName' => 'Sója', 'formValueLabel' => null],
+                    ['slug' => 'orechy', 'name' => 'Ořechy', 'shortName' => 'Ořechy', 'formValueLabel' => null],
+                    ['slug' => 'jine-dieta', 'name' => 'Jiné (upřesněte)', 'shortName' => 'Jiné', 'formValueLabel' => 'Upřesnění (alergie/dieta)'],
+                ],
+            ],
+            [
+                'categorySlug'   => 'doprava-prijezd',
+                'groupOfferSlug' => 'doprava-prijezd-2026',
+                'groupName'      => 'Doprava – příjezd',
+                'groupShortName' => 'Příjezd',
+                'min'            => 0,
+                'max'            => 1, // binární
+                'flags'          => [
+                    ['slug' => 'odvoz-do-kempu', 'name' => 'Odvoz z nádraží do kempu', 'shortName' => 'Odvoz z nádraží', 'formValueLabel' => 'Datum a čas příjezdu'],
+                ],
+            ],
+            [
+                'categorySlug'   => 'doprava-odjezd',
+                'groupOfferSlug' => 'doprava-odjezd-2026',
+                'groupName'      => 'Doprava – odjezd',
+                'groupShortName' => 'Odjezd',
+                'min'            => 0,
+                'max'            => 1, // binární
+                'flags'          => [
+                    ['slug' => 'odjezd-vlakem', 'name' => 'Odvoz z kempu na nádraží', 'shortName' => 'Odvoz na nádraží', 'formValueLabel' => 'Datum a čas odjezdu'],
+                ],
+            ],
+        ];
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('regOfferId', InputArgument::REQUIRED, 'ID hlavní přihlášky ročníku (calendar_reg_range.id; na klonu 120 pro 2026)');
+        $this->addOption('apply', null, InputOption::VALUE_NONE, 'Skutečně zapsat změny (bez tohoto jen dry-run).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $regOfferIdRaw = $input->getArgument('regOfferId');
+        if (!is_string($regOfferIdRaw) || !ctype_digit($regOfferIdRaw)) {
+            $io->error('Argument regOfferId musí být celé číslo (ID přihlášky).');
+
+            return Command::FAILURE;
+        }
+        $regOfferId = (int) $regOfferIdRaw;
+        $apply = true === $input->getOption('apply');
+
+        $offer = $this->em->getRepository(RegistrationOffer::class)->find($regOfferId);
+        if (!$offer instanceof RegistrationOffer) {
+            $io->error("Přihláška id={$regOfferId} neexistuje.");
+
+            return Command::FAILURE;
+        }
+
+        $io->title('Setup příznaků — přihláška: '.((string) $offer->getName()).' (id '.$regOfferId.')');
+        $io->writeln('Režim: '.($apply ? '<comment>APPLY (zápis)</comment>' : 'dry-run (jen výpis)'));
+
+        foreach ($this->categoriesSpec() as $spec) {
+            $category = $this->em->getRepository(RegistrationFlagCategory::class)->findOneBy(['slug' => $spec['categorySlug']]);
+            if (!$category instanceof RegistrationFlagCategory) {
+                $io->error("Kategorie \"{$spec['categorySlug']}\" nenalezena — přeskakuji.");
+                continue;
+            }
+            $io->section($spec['groupName']." ({$spec['categorySlug']})");
+            $flags = $this->syncMasterFlags($category, $spec['flags'], $io, $apply);
+            $this->buildGroupOffer($offer, $category, $spec, $flags, $io, $apply);
+        }
+
+        if ($apply) {
+            $this->em->flush();
+            $io->success('Zapsáno. Spusť doctrine:schema:validate a ověř editor v prohlížeči.');
+        } else {
+            $io->note('Dry-run hotov. Spusť znovu s --apply pro zápis.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Zajistí master příznaky (idempotentně): vytvoří chybějící, přejmenuje ty, jejichž název neodpovídá.
+     * Slug se vždy drží stabilní (data + filtr fasety). Vrací slug => RegistrationFlag.
+     *
+     * @param list<array{slug: string, name: string, shortName: string, formValueLabel: ?string}> $flagSpecs
+     *
+     * @return array<string, RegistrationFlag>
+     */
+    private function syncMasterFlags(RegistrationFlagCategory $category, array $flagSpecs, SymfonyStyle $io, bool $apply): array
+    {
+        $repo = $this->em->getRepository(RegistrationFlag::class);
+        $result = [];
+        foreach ($flagSpecs as $f) {
+            $flag = $repo->findOneBy(['slug' => $f['slug']]);
+            if ($flag instanceof RegistrationFlag) {
+                if ($flag->getName() !== $f['name'] || $flag->getShortName() !== $f['shortName']) {
+                    $io->writeln(sprintf('  ~ rename "%s": %s → %s', $f['slug'], (string) $flag->getName(), $f['name']));
+                    if ($apply) {
+                        $flag->setName($f['name']);
+                        $flag->setShortName($f['shortName']);
+                        $flag->setForcedSlug($f['slug']); // drž slug i po změně názvu
+                    }
+                } else {
+                    $io->writeln(sprintf('  = "%s" beze změny', $f['slug']));
+                }
+                $result[$f['slug']] = $flag;
+                continue;
+            }
+            $io->writeln(sprintf('  + nový příznak "%s" (%s)', $f['slug'], $f['name']));
+            $flag = new RegistrationFlag(new Nameable($f['name'], $f['shortName'], null, null, $f['slug']), $category);
+            if ($apply) {
+                $this->em->persist($flag);
+            }
+            $result[$f['slug']] = $flag;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Vytvoří (pokud chybí) group offer pro daný ročník + flag offers (admin-only, zdarma, bez kapacity)
+     * a naváže group offer na přihlášku. Idempotentní: existující group offer (dle slug navázaný na
+     * přihlášku) přeskočí.
+     *
+     * @param array{
+     *   categorySlug: string, groupOfferSlug: string, groupName: string, groupShortName: string,
+     *   min: int, max: int|null,
+     *   flags: list<array{slug: string, name: string, shortName: string, formValueLabel: ?string}>
+     * } $spec
+     * @param array<string, RegistrationFlag> $flags
+     */
+    private function buildGroupOffer(
+        RegistrationOffer $offer,
+        RegistrationFlagCategory $category,
+        array $spec,
+        array $flags,
+        SymfonyStyle $io,
+        bool $apply,
+    ): void {
+        foreach ($offer->getFlagGroupRanges() as $existing) {
+            if ($spec['groupOfferSlug'] === $existing->getSlug()) {
+                $io->writeln('  = group offer "'.$spec['groupOfferSlug'].'" už navázaný — přeskakuji.');
+
+                return;
+            }
+        }
+
+        $io->writeln('  + group offer "'.$spec['groupOfferSlug'].'" (admin-only)');
+        $group = new RegistrationFlagGroupOffer($category, new FlagAmountRange($spec['min'], $spec['max']), null, null);
+        $group->setName($spec['groupName']);
+        $group->setShortName($spec['groupShortName']);
+        $group->setForcedSlug($spec['groupOfferSlug']);
+        $group->setPublicOnWeb(false); // admin-set: mimo registrační formulář, editor (onlyPublic=false) ho nabídne
+
+        foreach ($spec['flags'] as $f) {
+            $flag = $flags[$f['slug']];
+            $offerSlug = $f['slug'].'-2026';
+            $io->writeln('    + flag offer "'.$offerSlug.'"');
+            $flagOffer = new RegistrationFlagOffer(
+                $flag,
+                new Capacity(null, null), // bez kapacitního stropu
+                new Price(0, 0),          // zdarma, bez zálohy
+                new FlagAmountRange(0, null),
+                null,
+            );
+            $flagOffer->setName($f['name']);
+            $flagOffer->setShortName($f['shortName']);
+            $flagOffer->setForcedSlug($offerSlug);
+            $flagOffer->setPublicOnWeb(false);
+            $flagOffer->setBaseUsage(0);
+            $flagOffer->setFullUsage(0);
+            if (null !== $f['formValueLabel']) {
+                $flagOffer->setFormValueLabel($f['formValueLabel']);
+                $flagOffer->setFormValueRegex('.{0,255}'); // povolí volný text → isFormValueAllowed()=true
+            }
+            $group->addFlagRange($flagOffer);
+            if ($apply) {
+                $this->em->persist($flagOffer);
+            }
+        }
+
+        $offer->addFlagGroupRange($group);
+        if ($apply) {
+            $this->em->persist($group);
+        }
+    }
+}

--- a/Controller/Api/ParticipantFlagApiController.php
+++ b/Controller/Api/ParticipantFlagApiController.php
@@ -76,9 +76,15 @@ final class ParticipantFlagApiController
             }
         }
         $admin = (bool) ($payload['admin'] ?? false);
+        $textValues = [];
+        foreach ((array) ($payload['textValues'] ?? []) as $rawId => $rawText) {
+            if (is_numeric($rawId)) {
+                $textValues[(int) $rawId] = is_string($rawText) ? $rawText : null;
+            }
+        }
 
         try {
-            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin);
+            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin, $textValues);
         } catch (FlagCapacityExceededException $e) {
             return new JsonResponse(['error' => 'capacity', 'message' => $e->getMessage()], Response::HTTP_CONFLICT);
         } catch (FlagOutOfRangeException $e) {
@@ -93,7 +99,7 @@ final class ParticipantFlagApiController
     /**
      * Flatten {@see ParticipantFlagUpdateService::getFlagSelectionModel()} into JSON-safe scalars.
      *
-     * @return list<array{flagGroupOffer: int|null, category: string, min: int, max: int|null, hasGroup: bool, flagOffers: list<array{id: int|null, name: string|null, price: int, selected: bool, remaining: int|null, full: bool}>}>
+     * @return list<array{flagGroupOffer: int|null, category: string, min: int, max: int|null, hasGroup: bool, flagOffers: list<array{id: int|null, name: string|null, price: int, selected: bool, remaining: int|null, full: bool, formValueAllowed: bool, formValueLabel: string|null, textValue: string|null}>}>
      */
     private function serializeModel(Participant $participant): array
     {
@@ -103,12 +109,15 @@ final class ParticipantFlagApiController
             foreach ($cat['flagOffers'] as $flagOffer) {
                 $offer = $flagOffer['offer'];
                 $offers[] = [
-                    'id'        => $offer->getId(),
-                    'name'      => $offer->getFlag()?->getName() ?? $offer->getName(),
-                    'price'     => $offer->getPrice(),
-                    'selected'  => $flagOffer['selected'],
-                    'remaining' => $flagOffer['remaining'],
-                    'full'      => $flagOffer['full'],
+                    'id'               => $offer->getId(),
+                    'name'             => $offer->getFlag()?->getName() ?? $offer->getName(),
+                    'price'            => $offer->getPrice(),
+                    'selected'         => $flagOffer['selected'],
+                    'remaining'        => $flagOffer['remaining'],
+                    'full'             => $flagOffer['full'],
+                    'formValueAllowed' => $flagOffer['formValueAllowed'],
+                    'formValueLabel'   => $flagOffer['formValueLabel'],
+                    'textValue'        => $flagOffer['textValue'],
                 ];
             }
             $out[] = [

--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -109,9 +109,15 @@ final class WebAdminParticipantsController extends AbstractController
             }
         }
         $admin = (bool) $request->request->get('admin_override', false);
+        $textValues = [];
+        foreach ((array) $request->request->all('flagTextValues') as $rawId => $rawText) {
+            if (is_numeric($rawId)) {
+                $textValues[(int) $rawId] = is_string($rawText) ? $rawText : null;
+            }
+        }
 
         try {
-            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin);
+            $this->flagUpdateService->setFlags($participant, $groupOffer, $flagOfferIds, $admin, $textValues);
             $this->addFlash('success', sprintf(
                 'Příznaky kategorie „%s" u účastníka #%d uloženy%s.',
                 $groupOffer->getFlagCategory()?->getName() ?? '?',
@@ -190,8 +196,49 @@ final class WebAdminParticipantsController extends AbstractController
         } catch (\Throwable) {
         }
 
+        // Drobečková navigace libovolné hloubky: Úvod › Účastníci › akce › turnus › jméno.
+        $crumbs = [[
+            'label' => 'Účastníci',
+            'url'   => $this->generateUrl('oswis_org_oswis_calendar_web_admin_participants_list'),
+        ]];
+        $turnus = $participant->getEvent();
+        $superEvent = $turnus?->getSuperEvent();
+        if (null !== $superEvent && null !== $superEvent->getName()) {
+            $crumbs[] = ['label' => $superEvent->getName()];
+        }
+        if (null !== $turnus && null !== $turnus->getName()) {
+            $crumbs[] = ['label' => $turnus->getName()];
+        }
+        $crumbs[] = ['label' => ($participant->getContact()?->getName() ?? 'Účastník').' #'.$participantId];
+
+        // Sloučená timeline: komunikační záznamy + kondenzované změny přihlášky, nejnovější nahoře.
+        // Změny se stejným časovým razítkem se sloučí do jedné položky (proti hlučnému per-příznak logu).
+        $timeline = [];
+        foreach ($entries as $commEntry) {
+            $timeline[] = ['at' => $commEntry->getOccurredAt(), 'kind' => 'comm', 'entry' => $commEntry];
+        }
+        $historyGroups = [];
+        foreach ($history as $ev) {
+            $tsKey = $ev['at']->format('Y-m-d\TH:i:s');
+            if (!isset($historyGroups[$tsKey])) {
+                $historyGroups[$tsKey] = ['at' => $ev['at'], 'events' => []];
+            }
+            $historyGroups[$tsKey]['events'][] = $ev;
+        }
+        foreach ($historyGroups as $group) {
+            $timeline[] = ['at' => $group['at'], 'kind' => 'change', 'change' => $this->summarizeHistoryGroup($group['events'])];
+        }
+        usort($timeline, static function (array $a, array $b): int {
+            $ta = $a['at'] instanceof \DateTimeInterface ? $a['at']->getTimestamp() : PHP_INT_MIN;
+            $tb = $b['at'] instanceof \DateTimeInterface ? $b['at']->getTimestamp() : PHP_INT_MIN;
+
+            return $tb <=> $ta;
+        });
+
         return $this->render('@OswisOrgOswisCalendar/web_admin/participant.html.twig', [
             'participant'        => $participant,
+            'crumbs'             => $crumbs,
+            'timeline'           => $timeline,
             'entries'            => $entries,
             'history'            => $history,
             'flagSelectionModel' => $flagSelectionModel,
@@ -202,6 +249,67 @@ final class WebAdminParticipantsController extends AbstractController
             'page_title'         => sprintf('Přihláška #%d', $participantId),
             'pageTitle'          => sprintf('Přihláška #%d', $participantId),
         ]);
+    }
+
+    /**
+     * Shrne skupinu změn přihlášky se stejným časovým razítkem do JEDNÉ položky timeline (kondenzace
+     * hlučného per-příznak logu): vznik přihlášky / změna turnusu / úprava příznaků + výčet změn.
+     *
+     * @param list<array{at: \DateTimeInterface, verb: 'created'|'added'|'removed', kind: 'participant'|'registration'|'flag', category: string|null, label: string}> $events
+     *
+     * @return array{icon: string, color: string, title: string, lines: list<string>}
+     */
+    private function summarizeHistoryGroup(array $events): array
+    {
+        $created = false;
+        /** @var list<string> $flagAdded */
+        $flagAdded = [];
+        /** @var list<string> $flagRemoved */
+        $flagRemoved = [];
+        /** @var list<string> $regAdded */
+        $regAdded = [];
+        /** @var list<string> $regRemoved */
+        $regRemoved = [];
+        foreach ($events as $ev) {
+            if ('participant' === $ev['kind'] && 'created' === $ev['verb']) {
+                $created = true;
+                continue;
+            }
+            if ('flag' === $ev['kind']) {
+                if ('removed' === $ev['verb']) {
+                    $flagRemoved[] = $ev['label'];
+                } else {
+                    $flagAdded[] = $ev['label'];
+                }
+            } elseif ('registration' === $ev['kind']) {
+                if ('removed' === $ev['verb']) {
+                    $regRemoved[] = $ev['label'];
+                } else {
+                    $regAdded[] = $ev['label'];
+                }
+            }
+        }
+        $lines = [];
+        foreach ($regAdded as $l) {
+            $lines[] = $l;
+        }
+        foreach ($regRemoved as $l) {
+            $lines[] = 'zrušeno: '.$l;
+        }
+        if ([] !== $flagAdded) {
+            $lines[] = '+ '.implode(', ', $flagAdded);
+        }
+        if ([] !== $flagRemoved) {
+            $lines[] = '− '.implode(', ', $flagRemoved);
+        }
+        if ($created) {
+            return ['icon' => '★', 'color' => '#006FAD', 'title' => 'Přihláška vytvořena', 'lines' => $lines];
+        }
+        if ([] !== $regAdded || [] !== $regRemoved) {
+            return ['icon' => '➡', 'color' => '#6f42c1', 'title' => 'Změna turnusu', 'lines' => $lines];
+        }
+
+        return ['icon' => '🔖', 'color' => '#198754', 'title' => 'Úprava příznaků', 'lines' => $lines];
     }
 
     /**

--- a/Entity/Event/Event.php
+++ b/Entity/Event/Event.php
@@ -20,6 +20,7 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\JoinColumn;
@@ -100,6 +101,10 @@ class Event implements NameableInterface
     #[ManyToOne(targetEntity: Place::class, fetch: 'EAGER')]
     #[JoinColumn(nullable: true)]
     protected ?Place $place = null;
+
+    /** Volný textový upřesňovák místa (samostatné místo NEBO doplněk k Place entitě), např. „Aula — sraz před vchodem". */
+    #[Column(type: 'string', nullable: true)]
+    protected ?string $placeText = null;
 
     // fetch=EAGER: Doctrine ORM 3's strict identity-map check
     // (EntityIdentityCollisionException) throws when a Participant lazy ghost
@@ -348,6 +353,16 @@ class Event implements NameableInterface
     public function getPlace(?bool $recursive = false): ?Place
     {
         return $this->place ?? ($recursive ? $this->getSuperEvent()?->getPlace() : null) ?? null;
+    }
+
+    public function getPlaceText(): ?string
+    {
+        return $this->placeText;
+    }
+
+    public function setPlaceText(?string $placeText): void
+    {
+        $this->placeText = $placeText;
     }
 
     public function setPlace(?Place $event): void

--- a/Entity/Event/EventCategory.php
+++ b/Entity/Event/EventCategory.php
@@ -10,7 +10,9 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Table;
 use InvalidArgumentException;
@@ -59,6 +61,18 @@ class EventCategory implements NameableInterface
     use ColorTrait;
     use TypeTrait;
 
+    /** Předvyplněný čas začátku aktivity této kategorie (jen čas; přepsatelné per aktivita). */
+    #[Column(type: 'time', nullable: true)]
+    protected ?DateTimeInterface $defaultStartTime = null;
+
+    /** Předvyplněný čas konce aktivity této kategorie (jen čas; když <= start, jde o přes-půlnoční rozsah). */
+    #[Column(type: 'time', nullable: true)]
+    protected ?DateTimeInterface $defaultEndTime = null;
+
+    /** Default veřejnosti aktivit této kategorie (služby neveřejné, běžné aktivity veřejné); přepsatelné per aktivita. */
+    #[Column(type: 'boolean', options: ['default' => false])]
+    protected bool $defaultPublic = false;
+
     public const YEAR_OF_EVENT = 'year-of-event';
     public const BATCH_OF_EVENT = 'batch-of-event';
     public const LECTURE = 'lecture';
@@ -70,6 +84,14 @@ class EventCategory implements NameableInterface
     public const EVIDENCE = 'evidence';
     public const SPORT = 'sport';
     public const FOOD = 'food';
+    /** Nadřazený „blok" programu (nadakce) — sdružuje pod-aktivity (rotace/série); čas se odvozuje z pod-akcí. */
+    public const PROGRAM_BLOCK = 'program-block';
+    /** Služby (rozpis SLUŽEB) — kdo má kdy směnu na daném stanovišti. */
+    public const SERVICE_STEERING = 'service-steering'; // Řízení
+    public const SERVICE_CALLING = 'service-calling';   // Svolávání
+    public const SERVICE_CANTEEN = 'service-canteen';   // Jídelna
+    public const SERVICE_BAR = 'service-bar';           // Stolárna
+    public const SERVICE_KIOSK = 'service-kiosk';       // Kiosek
     public const ALLOWED_TYPES
         = [
             self::YEAR_OF_EVENT,
@@ -83,6 +105,12 @@ class EventCategory implements NameableInterface
             self::EVIDENCE,
             self::SPORT,
             self::FOOD,
+            self::PROGRAM_BLOCK,
+            self::SERVICE_STEERING,
+            self::SERVICE_CALLING,
+            self::SERVICE_CANTEEN,
+            self::SERVICE_BAR,
+            self::SERVICE_KIOSK,
         ];
 
     /**
@@ -107,5 +135,35 @@ class EventCategory implements NameableInterface
     public static function getAllowedTypesCustom(): array
     {
         return [];
+    }
+
+    public function getDefaultStartTime(): ?DateTimeInterface
+    {
+        return $this->defaultStartTime;
+    }
+
+    public function setDefaultStartTime(?DateTimeInterface $defaultStartTime): void
+    {
+        $this->defaultStartTime = $defaultStartTime;
+    }
+
+    public function getDefaultEndTime(): ?DateTimeInterface
+    {
+        return $this->defaultEndTime;
+    }
+
+    public function setDefaultEndTime(?DateTimeInterface $defaultEndTime): void
+    {
+        $this->defaultEndTime = $defaultEndTime;
+    }
+
+    public function isDefaultPublic(): bool
+    {
+        return $this->defaultPublic;
+    }
+
+    public function setDefaultPublic(bool $defaultPublic): void
+    {
+        $this->defaultPublic = $defaultPublic;
     }
 }

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -731,3 +731,8 @@ services:
       - '@OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantMailBulkRepository'
       - '@oswis_org_oswis_calendar.participant.participant_service'
     tags: [ 'console.command' ]
+
+  OswisOrg\OswisCalendarBundle\Command\Setup2026FlagsCommand:
+    autowire: true
+    autoconfigure: true
+    tags: [ 'console.command' ]

--- a/Resources/views/web_admin/_participant_flag_row.html.twig
+++ b/Resources/views/web_admin/_participant_flag_row.html.twig
@@ -1,0 +1,53 @@
+{# Jedna příznaková kategorie jako rozbalovací prvek (ne tabulka). Vstup: cat, participant.
+   summary = name + odznaky + „upravit"; po rozkliknutí editor. display:flex skryje ▸ marker. #}
+{% set single = cat.max == 1 %}
+{% set selectedFlags = cat.flagOffers|filter(fo => fo.selected) %}
+<details style="border-top:1px solid #e3e9f0; padding:.05rem 0;">
+    <summary style="cursor:pointer; display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; padding:.45rem .1rem;">
+        <strong style="min-width:10rem;">{{ cat.categoryName }}{% if cat.min > 0 %} <span class="text-danger" title="povinné">*</span>{% endif %}</strong>
+        <span style="flex:1 1 12rem; min-width:0;">
+            {% for fo in selectedFlags %}
+                <span class="badge" style="background: {{ fo.offer.flag.color|default('#006FAD') }}; color:#fff;">{{ fo.offer.flag.shortName|default(fo.offer.flag.name|default(fo.offer.name|default('—'))) }}{% if fo.textValue %}: {{ fo.textValue }}{% endif %}</span>
+            {% else %}
+                <em class="text-muted">nenastaveno</em>
+            {% endfor %}
+        </span>
+        <span class="text-primary small" style="white-space:nowrap;">✎ upravit</span>
+    </summary>
+    <div style="margin:.3rem 0 .7rem .25rem;">
+        <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_participant_edit_flags', { participantId: participant.id }) }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('participant_edit_flags_' ~ participant.id) }}">
+            <input type="hidden" name="flagGroupOfferId" value="{{ cat.groupOffer.id }}">
+            <div class="small text-muted" style="margin-bottom:.4rem;">
+                {% if single %}vyber právě 1{% else %}min {{ cat.min }}{% if cat.max is not null %}, max {{ cat.max }}{% endif %}{% endif %}
+            </div>
+            {% if single and cat.min == 0 %}
+                <label style="display:block; margin-bottom:.25rem;">
+                    <input type="radio" name="flagOfferIds[]" value="" {{ selectedFlags|length == 0 ? 'checked' : '' }}> <span class="text-muted">— žádný —</span>
+                </label>
+            {% endif %}
+            {% for fo in cat.flagOffers %}
+                <label style="display:block; margin-bottom:.2rem; {{ fo.full ? 'opacity:.5;' : '' }}">
+                    <input type="{{ single ? 'radio' : 'checkbox' }}" name="flagOfferIds[]" value="{{ fo.offer.id }}" {{ fo.selected ? 'checked' : '' }} {{ fo.full ? 'disabled' : '' }}>
+                    {{ fo.offer.flag.name|default(fo.offer.name|default('příznak')) }}
+                    {% if fo.offer.price|default(0) != 0 %}<span class="text-muted">({{ fo.offer.price > 0 ? '+' : '' }}{{ fo.offer.price }} Kč)</span>{% endif %}
+                    {% if fo.remaining is not null %}<span class="text-muted small">[zbývá {{ fo.remaining }}]</span>{% endif %}
+                </label>
+                {% if fo.formValueAllowed %}
+                    <div style="margin:-.05rem 0 .5rem 1.5rem;">
+                        <input type="text" name="flagTextValues[{{ fo.offer.id }}]" value="{{ fo.textValue|default('') }}"
+                               placeholder="{{ fo.formValueLabel|default('Upřesnění') }}" class="form-control form-control-sm" style="max-width:22rem;">
+                    </div>
+                {% endif %}
+            {% else %}
+                <em class="text-muted">žádné nabídky</em>
+            {% endfor %}
+            <div style="margin-top:.5rem; display:flex; align-items:center; gap:.9rem; flex-wrap:wrap;">
+                <button type="submit" class="btn btn-sm btn-primary">Uložit</button>
+                <label class="small" style="margin:0;" title="Obejít naplněnou kapacitu">
+                    <input type="checkbox" name="admin_override" value="1"> překročit kapacitu
+                </label>
+            </div>
+        </form>
+    </div>
+</details>

--- a/Resources/views/web_admin/_participant_timeline.html.twig
+++ b/Resources/views/web_admin/_participant_timeline.html.twig
@@ -1,0 +1,71 @@
+{# Sloučená timeline (komunikace + kondenzované změny přihlášky), nejnovější nahoře.
+   Vlastní prvek v jazyce aplikace: brand modré tečky/linka, nativní .badge, Ciutadella nadpisy.
+   Vstup: timeline (list<{at, kind:'comm'|'change', entry?, change?}>), isAdmin, participantId, resendableMailIds. #}
+{% set adm = isAdmin|default(false) %}
+{% if timeline|default([])|length == 0 %}
+    <p class="text-muted" style="margin:.25rem 0 1.5rem;">Žádné záznamy.</p>
+{% else %}
+    <div class="oswis-tl">
+        {% for item in timeline %}
+            {% if item.kind == 'comm' %}
+                {% set e = item.entry %}
+                {% set internal = not e.isPublicForParticipant() %}
+                <div class="oswis-tl__row">
+                    <div class="oswis-tl__time">
+                        {% if e.occurredAt %}{{ e.occurredAt|date('j. n. Y', 'Europe/Prague') }}<span>{{ e.occurredAt|date('H:i', 'Europe/Prague') }}</span>{% else %}—{% endif %}
+                    </div>
+                    <div class="oswis-tl__rail"><span class="oswis-tl__dot oswis-tl__dot--mail" title="E-mail / komunikace"></span></div>
+                    <div class="oswis-tl__body">
+                        <div class="oswis-tl__title">
+                            {{ e.subject|default('(bez předmětu)') }}
+                            {% if internal and adm %}<span class="badge bg-secondary">interní</span>{% endif %}
+                            {% if adm and resendableMailIds is defined and resendableMailIds[e.id]|default and participantId is defined %}
+                                <form method="post"
+                                      action="{{ path('oswis_org_oswis_calendar_web_admin_participant_resend_mail', { participantId: participantId, mailId: e.id }) }}"
+                                      style="display:inline; margin-left:.4rem;" onsubmit="return confirm('Znovu odeslat tento e-mail účastníkovi?');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('participant_resend_mail_' ~ e.id) }}">
+                                    <button type="submit" class="btn btn-sm btn-outline-info" style="padding:.02rem .4rem; font-size:.78rem;">↻ Resend</button>
+                                </form>
+                            {% endif %}
+                        </div>
+                        <div class="oswis-tl__meta">
+                            {{ e.channel.label() }} · {{ e.direction.label() }}{% if e.summary|default %} — {{ e.summary|slice(0, 120) }}{% if e.summary|length > 120 %}…{% endif %}{% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% else %}
+                {% set c = item.change %}
+                <div class="oswis-tl__row">
+                    <div class="oswis-tl__time">{{ item.at|date('j. n. Y', 'Europe/Prague') }}<span>{{ item.at|date('H:i', 'Europe/Prague') }}</span></div>
+                    <div class="oswis-tl__rail"><span class="oswis-tl__dot oswis-tl__dot--change" title="Změna přihlášky"></span></div>
+                    <div class="oswis-tl__body">
+                        <div class="oswis-tl__title">{{ c.title }}</div>
+                        {% for line in c.lines|slice(0, 2) %}
+                            <div class="oswis-tl__meta">{{ line|length > 110 ? line|slice(0, 110) ~ '…' : line }}</div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+    <style>
+        .oswis-tl { margin: .25rem 0 1.5rem; }
+        .oswis-tl__row { display: flex; gap: .6rem; align-items: stretch; }
+        .oswis-tl__time { width: 5.5rem; flex: none; text-align: right; font-size: .78rem; color: #6c757d; white-space: nowrap; line-height: 1.25; padding-top: .15rem; }
+        .oswis-tl__time span { display: block; font-size: .72rem; }
+        .oswis-tl__rail { width: 1rem; flex: none; position: relative; }
+        .oswis-tl__rail::before { content: ''; position: absolute; left: 50%; top: 0; bottom: 0; width: 2px; background: #d6e3ef; transform: translateX(-50%); }
+        .oswis-tl__row:first-child .oswis-tl__rail::before { top: .35rem; }
+        .oswis-tl__row:last-child .oswis-tl__rail::before { bottom: auto; height: .35rem; }
+        .oswis-tl__dot { position: relative; z-index: 1; display: block; width: .7rem; height: .7rem; margin: .35rem auto 0; border-radius: 50%; background: #006FAD; border: 2px solid #fff; box-shadow: 0 0 0 1px #d6e3ef; }
+        .oswis-tl__body { flex: 1 1 auto; min-width: 0; padding-bottom: .85rem; }
+        .oswis-tl__title { font-weight: 600; }
+        .oswis-tl__meta { color: #6c757d; font-size: .85rem; margin-top: .05rem; word-break: break-word; }
+        @media (max-width: 575.98px) {
+            .oswis-tl__rail { display: none; }
+            .oswis-tl__time { width: auto; text-align: left; }
+            .oswis-tl__row { gap: .35rem; flex-wrap: wrap; }
+            .oswis-tl__body { flex-basis: 100%; }
+        }
+    </style>
+{% endif %}

--- a/Resources/views/web_admin/participant.html.twig
+++ b/Resources/views/web_admin/participant.html.twig
@@ -8,483 +8,322 @@
 {% set event = participant.event(false)|default %}
 {% set superEvent = event.superEvent|default %}
 {% set isFullDetail = showFullDetail|default(false) %}
+{% set paid = participant.paidPrice|default(0) %}
+{% set total = participant.price|default(0) %}
+{% set remaining = participant.remainingPrice|default(0) %}
+{% set pct = total > 0 ? (paid / total * 100)|round : (paid > 0 ? 100 : 0) %}
+{% if pct > 100 %}{% set pct = 100 %}{% endif %}
+{% if pct < 0 %}{% set pct = 0 %}{% endif %}
+{% set acctActive = contact.appUser|default and contact.appUser.activated|default %}
 
 {% block body_content %}
-    <main class="container" style="padding-bottom: 4rem;">
-        {# Header — name + ID badge + state + primary actions #}
-        <div style="display: flex; flex-wrap: wrap; align-items: baseline; gap: .75rem; margin: 1rem 0 .25rem;">
-            <h2 style="margin: 0;">
-                {{ contact.name|default('Účastník #' ~ participant.id) }}
-            </h2>
-            <span class="badge bg-primary" style="font-size: 1rem;">#{{ participant.id }}</span>
-            {% if participant.deletedAt|default %}
-                <span class="badge bg-danger">SMAZÁNO {{ participant.deletedAt|date('j. n. Y H:i') }}</span>
-            {% endif %}
-            {% if contact.appUser|default and contact.appUser.activated|default %}
-                <span class="badge bg-success">účet aktivován</span>
-            {% elseif contact.email|default %}
-                <span class="badge bg-warning text-black">účet neaktivován</span>
-            {% endif %}
+    <div class="container">
+        {# Hlavička — vzor jako web_admin/event.html.twig (h2 + odznaky) #}
+        <div class="row">
+            <div class="col" style="display:flex; align-items:center; gap:.6rem; flex-wrap:wrap;">
+                <h2 style="margin:0;">
+                    {{ contact.name|default('Účastník #' ~ participant.id) }}
+                    <span class="badge bg-primary" style="font-size:.5em; vertical-align:middle;">#{{ participant.id }}</span>
+                    {% if participant.deletedAt|default %}
+                        <span class="badge bg-danger" style="font-size:.5em; vertical-align:middle;">SMAZÁNO {{ participant.deletedAt|date('j. n. Y') }}</span>
+                    {% endif %}
+                    {% if acctActive %}
+                        <span class="badge bg-success" style="font-size:.5em; vertical-align:middle;">účet aktivován</span>
+                    {% elseif contact.email|default %}
+                        <span class="badge bg-warning text-black" style="font-size:.5em; vertical-align:middle;">účet neaktivován</span>
+                    {% endif %}
+                </h2>
+            </div>
         </div>
-        <p class="text-muted" style="margin: 0 0 .75rem;">
-            {{ event.name|default('—') }}
-            {% if superEvent %}
-                · {{ superEvent.name }}
-            {% endif %}
+        <p class="text-muted" style="margin:.15rem 0 1rem;">
+            {{ event.name|default('—') }}{% if superEvent %} · {{ superEvent.name }}{% endif %}
             · vytvořeno {{ participant.createdAt|date('j. n. Y H:i', 'Europe/Prague')|default('—') }}
+            {% if total > 0 and remaining <= 0 %}
+                · <span class="text-success">zaplaceno</span>
+            {% else %}
+                · <span class="text-danger">zbývá {{ remaining }}&nbsp;Kč</span>
+            {% endif %}
         </p>
 
-        {# Quick contact / call links #}
-        <div style="margin-bottom: 1rem;">
+        {# Akce: kontaktní + admin v jednom zalamovacím řádku #}
+        <div style="display:flex; flex-wrap:wrap; gap:.5rem; align-items:center; margin-bottom:1.5rem;">
             {% include '@OswisOrgOswisCalendar/web_admin/communication/_quick_actions.html.twig' with { participant: participant } only %}
-        </div>
-
-        {# Primary admin actions row #}
-        <div style="display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 1.5rem;">
             {% if is_granted('ROLE_ADMIN') %}
                 <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_participant_compose_mail', { participantId: participant.id }) }}"
-                   title="Napsat a odeslat ad-hoc e-mail účastníkovi">
-                    ✎ Nová zpráva (e-mail)
-                </a>
+                   title="Napsat a odeslat ad-hoc e-mail účastníkovi">✎ Nová zpráva</a>
                 <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_participant_manual_note', { participantId: participant.id }) }}"
-                   title="Zaznamenat telefonát, SMS, chat nebo jiný kontakt do komunikační historie">
-                    📞 Záznam komunikace (telefonát / SMS / chat)
-                </a>
-                <a class="btn btn-sm btn-outline-secondary"
+                   title="Zaznamenat telefonát, SMS, chat nebo jiný kontakt">📞 Záznam komunikace</a>
+                <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_imap_unmatched') }}"
-                   title="Nezařazené příchozí / odchozí e-maily z IMAP">
-                    📥 Nezařazené e-maily
-                </a>
-                <form method="post"
-                      action="{{ path('oswis_org_oswis_calendar_web_admin_imap_refresh') }}"
-                      style="display: inline-block; margin: 0;"
-                      title="Stáhnout nové e-maily z IMAP serveru">
+                   title="Nezařazené příchozí / odchozí e-maily z IMAP">📥 Nezařazené e-maily</a>
+                <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_imap_refresh') }}" style="display:inline-block; margin:0;" title="Stáhnout nové e-maily z IMAP serveru">
                     <input type="hidden" name="_token" value="{{ csrf_token('imap_refresh') }}">
-                    <button type="submit" class="btn btn-sm btn-outline-secondary">↻ Stáhnout z IMAP</button>
+                    <button type="submit" class="btn btn-sm btn-outline-primary">↻ Stáhnout z IMAP</button>
                 </form>
-            {% endif %}
-            {% if is_granted('ROLE_ADMIN') and contact and contact.email|default and not (contact.appUser|default and contact.appUser.activated|default) %}
-                <form method="post"
-                      action="{{ path('oswis_org_oswis_calendar_web_admin_participant_resend_activation', { participantId: participant.id }) }}"
-                      style="display: inline-block; margin: 0;"
-                      onsubmit="return confirm('Znovu odeslat aktivační e-mail účastníkovi #{{ participant.id }}?');">
-                    <input type="hidden" name="_token" value="{{ csrf_token('participant_resend_activation_' ~ participant.id) }}">
-                    <button type="submit" class="btn btn-sm btn-outline-info">↻ Znovu poslat aktivační e-mail</button>
-                </form>
-            {% endif %}
-            {% if participant.deletedAt|default and is_granted('ROLE_ADMIN') %}
-                <form method="post"
-                      action="{{ path('oswis_org_oswis_calendar_web_admin_participant_restore', { participantId: participant.id }) }}"
-                      style="display: inline-block; margin: 0;"
-                      onsubmit="return confirm('Opravdu obnovit účastníka #{{ participant.id }}?');">
-                    <input type="hidden" name="_token" value="{{ csrf_token('participant_restore_' ~ participant.id) }}">
-                    <button type="submit" class="btn btn-sm btn-outline-success">↻ Obnovit</button>
-                </form>
+                {% if contact and contact.email|default and not acctActive %}
+                    <form method="post"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_participant_resend_activation', { participantId: participant.id }) }}"
+                          style="display:inline-block; margin:0;"
+                          onsubmit="return confirm('Znovu odeslat aktivační e-mail účastníkovi #{{ participant.id }}?');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('participant_resend_activation_' ~ participant.id) }}">
+                        <button type="submit" class="btn btn-sm btn-outline-info">↻ Aktivační e-mail</button>
+                    </form>
+                {% endif %}
+                {% if participant.deletedAt|default %}
+                    <form method="post"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_participant_restore', { participantId: participant.id }) }}"
+                          style="display:inline-block; margin:0;"
+                          onsubmit="return confirm('Opravdu obnovit účastníka #{{ participant.id }}?');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('participant_restore_' ~ participant.id) }}">
+                        <button type="submit" class="btn btn-sm btn-outline-success">↻ Obnovit</button>
+                    </form>
+                {% endif %}
             {% endif %}
         </div>
 
         {% if not isFullDetail %}
-            {# Legacy arrival / check-in screen still relies on the full e-mail
-               summary include — keep it here for that route only. #}
+            {# Legacy arrival / check-in screen still relies on the full e-mail summary include. #}
             {% include '@OswisOrgOswisCalendar/other/summary/participant-summary.html.twig' with {'isInternal': true} %}
         {% else %}
-            {# ----- Admin-friendly full detail layout ----- #}
-
-            <div class="row g-3" style="margin-bottom: 1rem;">
+            <div class="row">
                 {# Kontakt #}
-                <div class="col-12 col-lg-6">
-                    <div class="card h-100">
-                        <div class="card-body">
-                            <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Kontakt</h5>
-                            <table class="table table-sm" style="margin-bottom: 0;">
-                                <tbody>
-                                    <tr>
-                                        <th style="width: 9rem; white-space: nowrap;">Jméno</th>
-                                        <td>{{ contact.name|default('—') }}</td>
-                                    </tr>
-                                    {# Pohlaví: zobrazené je výsledné (override, jinak auto dle jména přes vokativ).
-                                       Override řeší špatnou auto-detekci (nejednoznačná/cizí jména → default muž) i trans. #}
-                                    <tr>
-                                        <th>Pohlaví</th>
-                                        <td>
-                                            {% set g = contact.gender|default('unisex') %}
-                                            {% set override = contact.genderOverride|default %}
-                                            <strong>{{ g == 'male' ? 'Muž' : (g == 'female' ? 'Žena' : 'neurčeno') }}</strong>
-                                            <span class="text-secondary small">({{ override ? 'ručně' : 'automaticky dle jména' }})</span>
-                                            <form method="post" style="display:inline-flex; gap:.25rem; margin-left:.5rem; vertical-align:middle;"
-                                                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_set_gender', {participantId: participantId}) }}">
-                                                <input type="hidden" name="_token" value="{{ csrf_token('participant_set_gender_' ~ participantId) }}">
-                                                <select name="gender" class="form-select form-select-sm" style="width:auto;" title="Ruční override pohlaví">
-                                                    <option value="" {{ override ? '' : 'selected' }}>automaticky</option>
-                                                    <option value="male" {{ override == 'male' ? 'selected' : '' }}>Muž</option>
-                                                    <option value="female" {{ override == 'female' ? 'selected' : '' }}>Žena</option>
-                                                </select>
-                                                <button type="submit" class="btn btn-sm btn-outline-primary">Uložit</button>
-                                            </form>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th>E-mail</th>
-                                        <td>
-                                            {% if contact.email|default %}
-                                                <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
-                                            {% else %}
-                                                —
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th>Telefon</th>
-                                        <td>
-                                            {% if contact.phone|default %}
-                                                <a href="tel:{{ contact.phone }}">{{ contact.phone }}</a>
-                                            {% else %}
-                                                —
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th>Uživatelský účet</th>
-                                        <td>
-                                            {% if contact.appUser|default %}
-                                                {{ contact.appUser.username|default(contact.appUser.email|default('—')) }}
-                                                {% if contact.appUser.activated|default %}
-                                                    <span class="badge bg-success" style="margin-left: .5rem;">aktivován</span>
-                                                {% else %}
-                                                    <span class="badge bg-warning text-black" style="margin-left: .5rem;">neaktivován</span>
-                                                {% endif %}
-                                            {% else %}
-                                                —
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                <div class="col-12 col-xl-6">
+                    <h3>Kontakt</h3>
+                    <table class="list">
+                        <thead><tr><th>Položka</th><th>Hodnota</th></tr></thead>
+                        <tbody><tr>
+                            <td>Jméno</td>
+                            <td><strong>{{ contact.name|default('—') }}</strong></td>
+                        </tr></tbody>
+                        <tbody><tr>
+                            <td>Pohlaví
+                                <div class="block small">automaticky dle jména, lze přepsat</div>
+                            </td>
+                            <td>
+                                {% set g = contact.gender|default('unisex') %}
+                                {% set override = contact.genderOverride|default %}
+                                <strong>{{ g == 'male' ? 'Muž' : (g == 'female' ? 'Žena' : 'neurčeno') }}</strong>
+                                <span class="small text-muted">({{ override ? 'ručně' : 'automaticky' }})</span>
+                                <form method="post" style="display:inline-flex; gap:.25rem; margin-top:.25rem;"
+                                      action="{{ path('oswis_org_oswis_calendar_web_admin_participant_set_gender', {participantId: participantId}) }}">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('participant_set_gender_' ~ participantId) }}">
+                                    <select name="gender" class="form-select form-select-sm" style="width:auto;" title="Ruční override pohlaví">
+                                        <option value="" {{ override ? '' : 'selected' }}>automaticky</option>
+                                        <option value="male" {{ override == 'male' ? 'selected' : '' }}>Muž</option>
+                                        <option value="female" {{ override == 'female' ? 'selected' : '' }}>Žena</option>
+                                    </select>
+                                    <button type="submit" class="btn btn-sm btn-outline-primary">Uložit</button>
+                                </form>
+                            </td>
+                        </tr></tbody>
+                        <tbody><tr>
+                            <td>E-mail</td>
+                            <td>{% if contact.email|default %}<a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% else %}—{% endif %}</td>
+                        </tr></tbody>
+                        <tbody><tr>
+                            <td>Telefon</td>
+                            <td>{% if contact.phone|default %}<a href="tel:{{ contact.phone }}">{{ contact.phone }}</a>{% else %}—{% endif %}</td>
+                        </tr></tbody>
+                        <tbody><tr>
+                            <td>Uživatelský účet</td>
+                            <td>
+                                {% if contact.appUser|default %}
+                                    {{ contact.appUser.username|default(contact.appUser.email|default('—')) }}
+                                    {% if acctActive %}
+                                        <span class="badge bg-success">aktivován</span>
+                                    {% else %}
+                                        <span class="badge bg-warning text-black">neaktivován</span>
+                                    {% endif %}
+                                {% else %}—{% endif %}
+                            </td>
+                        </tr></tbody>
+                    </table>
                 </div>
 
                 {# Přihláška #}
-                <div class="col-12 col-lg-6">
-                    <div class="card h-100">
-                        <div class="card-body">
-                            <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Přihláška</h5>
-                            <table class="table table-sm" style="margin-bottom: 0;">
-                                <tbody>
-                                    <tr>
-                                        <th style="width: 9rem; white-space: nowrap;">ID přihlášky</th>
-                                        <td><strong>#{{ participant.id }}</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <th>Vytvořeno</th>
-                                        <td>{{ participant.createdAt|date('j. n. Y H:i', 'Europe/Prague')|default('—') }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Akce</th>
-                                        <td>{{ event.name|default('—') }}</td>
-                                    </tr>
-                                    {% if superEvent %}
-                                        <tr>
-                                            <th>Nadřazená akce</th>
-                                            <td>{{ superEvent.name }}</td>
-                                        </tr>
-                                    {% endif %}
-                                    <tr>
-                                        <th>Kategorie</th>
-                                        <td>{{ participant.participantCategory(false).name|default('—') }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Var. symbol</th>
-                                        <td>{{ participant.variableSymbol|default('—') }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                <div class="col-12 col-xl-6">
+                    <h3>Přihláška</h3>
+                    <table class="list">
+                        <thead><tr><th>Položka</th><th>Hodnota</th></tr></thead>
+                        <tbody><tr><td>ID přihlášky</td><td><strong>#{{ participant.id }}</strong></td></tr></tbody>
+                        <tbody><tr><td>Vytvořeno</td><td>{{ participant.createdAt|date('j. n. Y H:i', 'Europe/Prague')|default('—') }}</td></tr></tbody>
+                        <tbody><tr><td>Akce</td><td>{{ event.name|default('—') }}</td></tr></tbody>
+                        {% if superEvent %}
+                            <tbody><tr><td>Nadřazená akce</td><td>{{ superEvent.name }}</td></tr></tbody>
+                        {% endif %}
+                        <tbody><tr><td>Kategorie</td><td>{{ participant.participantCategory(false).name|default('—') }}</td></tr></tbody>
+                        <tbody><tr><td>Var. symbol</td><td>{{ participant.variableSymbol|default('—') }}</td></tr></tbody>
+                    </table>
                 </div>
             </div>
 
             {# Platby #}
-            <div class="card" style="margin-bottom: 1rem;">
-                <div class="card-body">
-                    <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Platby</h5>
-                    <div style="overflow-x: auto;">
-                        <table class="list" style="width: 100%; margin-top: .5rem; table-layout: fixed;">
-                            <colgroup>
-                                <col style="width: 7rem;">
-                                <col style="width: 8rem;">
-                                <col style="width: 8rem;">
-                                <col>
-                                <col style="width: 6rem;">
-                            </colgroup>
-                            <thead>
-                                <tr>
-                                    <th>Datum</th>
-                                    <th>Typ</th>
-                                    <th style="text-align: right;">Částka</th>
-                                    <th>Poznámka</th>
-                                    <th>Akce</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for payment in participant.payments|default([]) %}
-                                    <tr>
-                                        <td style="white-space: nowrap;">{{ payment.dateTime|date('j. n. Y', 'Europe/Prague')|default('—') }}</td>
-                                        <td style="word-break: keep-all;">{{ payment.type|default('—') }}</td>
-                                        <td style="text-align: right; white-space: nowrap; color: {{ payment.numericValue > 0 ? '#006FAD' : '#B62846' }};">
-                                            <strong>{{ payment.numericValue > 0 ? '+' : '' }}{{ payment.numericValue|default(0) }}&nbsp;Kč</strong>
-                                        </td>
-                                        <td style="word-break: break-all; overflow-wrap: anywhere; font-size: .85em;">
-                                            {{ payment.note|default }}
-                                            {% if payment.internalNote|default %}
-                                                <div class="text-secondary" style="margin-top: .15rem;">{{ payment.internalNote }}</div>
-                                            {% endif %}
-                                        </td>
-                                        <td>
-                                            {% if is_granted('ROLE_ADMIN') and payment.id|default %}
-                                                <a class="btn btn-sm btn-outline-secondary"
-                                                   href="{{ path('oswis_org_oswis_calendar_web_admin_payment_edit', { id: payment.id }) }}">Upravit</a>
-                                            {% endif %}
-                                        </td>
-                                    </tr>
-                                {% else %}
-                                    <tr><td colspan="5" style="text-align: center; color: #6c757d;">Zatím žádné platby.</td></tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                    <p style="margin-top: .75rem; margin-bottom: 0;">
-                        <strong>Zaplaceno:</strong> {{ participant.paidPrice|default(0) }}&nbsp;Kč z {{ participant.price|default(0) }}&nbsp;Kč
-                        &nbsp;|&nbsp;
-                        <strong>Zbývá:</strong>
-                        <span class="{{ (participant.remainingPrice|default(0)) == 0 ? 'text-success' : 'text-danger' }}">
-                            {{ participant.remainingPrice|default(0) }}&nbsp;Kč
-                        </span>
-                    </p>
+            <h3 id="platby">Platby</h3>
+            <table class="list">
+                <thead>
+                    <tr>
+                        <th>Datum</th>
+                        <th>Typ</th>
+                        <th class="text-center">Částka</th>
+                        <th>Poznámka</th>
+                        <th class="text-center">Akce</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for payment in participant.payments|default([]) %}
+                        <tr>
+                            <td style="white-space:nowrap;">{{ payment.dateTime|date('j. n. Y', 'Europe/Prague')|default('—') }}</td>
+                            <td>{{ payment.type|default('—') }}</td>
+                            <td class="text-center {{ payment.numericValue > 0 ? 'text-success' : 'text-danger' }}" style="white-space:nowrap;">
+                                <strong>{{ payment.numericValue > 0 ? '+' : '' }}{{ payment.numericValue|default(0) }}&nbsp;Kč</strong>
+                            </td>
+                            <td>
+                                {{ payment.note|default }}
+                                {% if payment.internalNote|default %}<div class="block small text-muted">{{ payment.internalNote }}</div>{% endif %}
+                            </td>
+                            <td class="text-center">
+                                {% if is_granted('ROLE_ADMIN') and payment.id|default %}
+                                    <a class="btn btn-sm btn-outline-primary" href="{{ path('oswis_org_oswis_calendar_web_admin_payment_edit', { id: payment.id }) }}">Upravit</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5" class="text-center text-muted">Zatím žádné platby.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <div class="box" style="margin-bottom:1.5rem;">
+                <div style="display:flex; justify-content:space-between; flex-wrap:wrap; gap:.5rem; margin-bottom:.4rem;">
+                    <span><strong>Zaplaceno {{ paid }}&nbsp;Kč</strong> <span class="text-muted">z {{ total }}&nbsp;Kč</span></span>
+                    <span class="{{ (total > 0 and remaining <= 0) ? 'text-success' : 'text-danger' }}"><strong>{{ (total > 0 and remaining <= 0) ? 'zaplaceno' : 'zbývá ' ~ remaining ~ ' Kč' }}</strong></span>
+                </div>
+                <div class="progress" style="height:.6rem;">
+                    <div class="progress-bar {{ (total > 0 and remaining <= 0) ? 'bg-success' : '' }}" role="progressbar" style="width: {{ pct }}%;" aria-valuenow="{{ pct }}" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>
             </div>
 
-            {# Příznaky (flag groups) — editovatelné, vč. kategorií, které účastník zatím nemá #}
-            <div class="card" style="margin-bottom: 1rem;" id="priznaky">
-                <div class="card-body">
-                    <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Příznaky</h5>
-                    {% if isAdmin|default(false) and flagSelectionModel|default([])|length > 0 %}
-                        <p class="text-muted" style="font-size: .85em; margin-bottom: .75rem;">
-                            Každá kategorie se ukládá zvlášť. Lze přidat i kategorii, kterou účastník zatím nemá
-                            (např. Sleva, Zkrácený pobyt). „Povolit překročení kapacity" obejde naplněnou nabídku.
-                        </p>
-                        {% for cat in flagSelectionModel %}
-                            {% set single = cat.max == 1 %}
-                            <form method="post"
-                                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_edit_flags', { participantId: participant.id }) }}"
-                                  style="border-top: 1px solid #f0f0f0; padding: .5rem 0;">
-                                <input type="hidden" name="_token" value="{{ csrf_token('participant_edit_flags_' ~ participant.id) }}">
-                                <input type="hidden" name="flagGroupOfferId" value="{{ cat.groupOffer.id }}">
-                                <div style="display: flex; flex-wrap: wrap; align-items: center; gap: .5rem;">
-                                    <strong style="min-width: 11rem;">
-                                        {{ cat.categoryName }}
-                                        {% if not cat.hasGroup %}<span class="badge bg-secondary" style="font-weight: normal;">zatím nepřidáno</span>{% endif %}
-                                        <br><small class="text-muted">
-                                            {% if single %}vyber právě 1{% else %}min {{ cat.min }}{% if cat.max is not null %}, max {{ cat.max }}{% endif %}{% endif %}
-                                        </small>
-                                    </strong>
-                                    <div style="flex: 1; min-width: 16rem;">
-                                        {% if single and cat.min == 0 %}
-                                            <label style="margin-right: .75rem; white-space: nowrap;">
-                                                <input type="radio" name="flagOfferIds[]" value=""
-                                                       {{ cat.flagOffers|filter(fo => fo.selected)|length == 0 ? 'checked' : '' }}>
-                                                <span class="text-muted">— žádný —</span>
-                                            </label>
-                                        {% endif %}
-                                        {% for fo in cat.flagOffers %}
-                                            <label style="margin-right: .75rem; white-space: nowrap; {{ fo.full ? 'opacity:.5;' : '' }}">
-                                                <input type="{{ single ? 'radio' : 'checkbox' }}" name="flagOfferIds[]"
-                                                       value="{{ fo.offer.id }}"
-                                                       {{ fo.selected ? 'checked' : '' }}
-                                                       {{ fo.full ? 'disabled' : '' }}>
-                                                {{ fo.offer.flag.name|default(fo.offer.name|default('příznak')) }}
-                                                {% if fo.offer.price|default(0) != 0 %}<span class="text-muted">({{ fo.offer.price > 0 ? '+' : '' }}{{ fo.offer.price }} Kč)</span>{% endif %}
-                                                {% if fo.remaining is not null %}<span class="text-muted" style="font-size: .8em;">[zbývá {{ fo.remaining }}]</span>{% endif %}
-                                            </label>
-                                        {% else %}
-                                            <em class="text-secondary">žádné nabídky</em>
+            {# Příznaky — vlastní prvek (ne tabulka): seskupené kategorie s odznaky + inline editor.
+               Staví na jazyce aplikace: .box, h4 podnadpisy, nativní .badge, .btn. #}
+            <h3 id="priznaky">Příznaky</h3>
+            {% if isAdmin|default(false) and flagSelectionModel|default([])|length > 0 %}
+                {% set userCats = flagSelectionModel|filter(c => c.groupOffer.isPublicOnWeb) %}
+                {% set teamCats = flagSelectionModel|filter(c => not c.groupOffer.isPublicOnWeb) %}
+                <div class="box" style="margin-bottom:1.5rem; padding:.4rem 1rem 1rem;">
+                    {% for grp in [{ 'title': 'Vyplnil účastník v přihlášce', 'cats': userCats }, { 'title': 'Doplňuje tým', 'cats': teamCats }] %}
+                        {% if grp.cats|length > 0 %}
+                            {# Zobraz jen nastavené nebo povinné; prázdné volitelné kategorie schovej za „+ Přidat". #}
+                            {% set shownCats = grp.cats|filter(c => (c.flagOffers|filter(fo => fo.selected)|length) > 0 or c.min > 0) %}
+                            {% set addCats   = grp.cats|filter(c => (c.flagOffers|filter(fo => fo.selected)|length) == 0 and c.min == 0) %}
+                            <h4 style="font-size:1.05rem; margin:{{ loop.first ? '.5rem' : '1.2rem' }} 0 .1rem;">{{ grp.title }}</h4>
+                            {% for cat in shownCats %}
+                                {% include '@OswisOrgOswisCalendar/web_admin/_participant_flag_row.html.twig' with { 'cat': cat, 'participant': participant } only %}
+                            {% else %}
+                                <div class="text-muted small" style="padding:.4rem 0; border-top:1px solid #e3e9f0;">Zatím nic nenastaveno.</div>
+                            {% endfor %}
+                            {% if addCats|length > 0 %}
+                                <details style="margin-top:.5rem;">
+                                    <summary class="btn btn-sm btn-outline-primary" style="display:inline-flex; cursor:pointer;">+ Přidat příznak ({{ addCats|length }})</summary>
+                                    <div style="margin-top:.5rem; border-top:1px solid #e3e9f0;">
+                                        {% for cat in addCats %}
+                                            {% include '@OswisOrgOswisCalendar/web_admin/_participant_flag_row.html.twig' with { 'cat': cat, 'participant': participant } only %}
                                         {% endfor %}
                                     </div>
-                                    <label style="white-space: nowrap; font-size: .8em;" title="Obejít naplněnou kapacitu">
-                                        <input type="checkbox" name="admin_override" value="1"> překročit kapacitu
-                                    </label>
-                                    <button type="submit" class="btn btn-sm btn-primary">Uložit</button>
-                                </div>
-                            </form>
-                        {% endfor %}
-                    {% else %}
-                        {# Read-only fallback (ne-admin, nebo žádné dostupné kategorie) #}
-                        <table class="table table-sm" style="margin-bottom: 0;">
-                            <tbody>
-                                {% for flagGroup in participant.flagGroups|default([]) %}
-                                    <tr>
-                                        <th style="width: 12rem; white-space: nowrap;">
-                                            {{ flagGroup.flagGroupRange.flagCategory.name|default(flagGroup.name|default('Skupina')) }}
-                                        </th>
-                                        <td>
-                                            {% for participantFlag in flagGroup.participantFlags|default([]) %}
-                                                {% if participantFlag.active|default %}
-                                                    <span class="badge"
-                                                          style="background: {{ participantFlag.flagOffer.flag.color|default('#006FAD') }}; color: white; padding: .2em .55em; margin-right: .25em; font-size: .9em;">
-                                                        {{ participantFlag.flagOffer.flag.shortName|default(participantFlag.flagOffer.flag.name|default('—')) }}
-                                                    </span>
-                                                {% endif %}
-                                            {% else %}
-                                                <em class="text-secondary">—</em>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>
-                                {% else %}
-                                    <tr><td><em class="text-secondary">Žádné příznaky.</em></td></tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}
-                </div>
-            </div>
-
-            {# Poznámky — interní/veřejné poznámky k účastníkovi #}
-            <div class="card" style="margin-bottom: 1rem;" id="poznamky">
-                <div class="card-body">
-                    <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Poznámky</h5>
-                    {% set notes = participant.notes|default([]) %}
-
-                    {# Add new note form #}
-                    <form method="post"
-                          action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_create', { participantId: participant.id }) }}"
-                          style="margin-bottom: 1rem;">
-                        <input type="hidden" name="_token" value="{{ csrf_token('participant_note_create_' ~ participant.id) }}">
-                        <div style="display: flex; gap: .5rem; align-items: stretch; flex-wrap: wrap;">
-                            <textarea name="textValue"
-                                      rows="2"
-                                      placeholder="Nová poznámka…"
-                                      required
-                                      style="flex: 1 1 20rem; min-width: 15rem; padding: .375rem .5rem; border: 1px solid #ced4da; border-radius: .375rem;"></textarea>
-                            <label style="display: flex; align-items: center; gap: .25rem; white-space: nowrap;">
-                                <input type="checkbox" name="publicNote" value="1">
-                                <small>veřejná (vidí účastník)</small>
-                            </label>
-                            <button type="submit" class="btn btn-sm btn-primary">+ Přidat poznámku</button>
-                        </div>
-                    </form>
-
-                    {% if notes|length == 0 %}
-                        <p class="text-muted" style="margin: 0;">Žádné poznámky.</p>
-                    {% else %}
-                        {% for note in notes %}
-                            <div style="padding: .5rem .75rem; border-left: 3px solid {{ note.publicNote|default(false) ? '#006FAD' : '#d97706' }}; background: #f8f9fa; margin-bottom: .5rem;">
-                                <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: .5rem; margin-bottom: .25rem;">
-                                    <small class="text-secondary">
-                                        {% set author = note.createdBy|default %}
-                                        {% if author %}
-                                            <strong>{{ author.shortName|default(author.name|default(author.username|default('—'))) }}</strong>
-                                            ·
-                                        {% endif %}
-                                        {{ note.createdAt|date('j. n. Y H:i', 'Europe/Prague')|default('') }}
-                                        {% if note.updatedAt|default and note.updatedAt != note.createdAt %}
-                                            <em> · upraveno {{ note.updatedAt|date('j. n. Y H:i', 'Europe/Prague') }}</em>
-                                        {% endif %}
-                                        · {{ note.publicNote|default(false) ? 'veřejná' : 'interní' }}
-                                    </small>
-                                    <details style="position: relative;">
-                                        <summary style="cursor: pointer; font-size: .85rem; color: #006FAD; list-style: none;">✎ Akce</summary>
-                                        <div style="position: absolute; right: 0; top: 100%; z-index: 5; background: white; border: 1px solid #ced4da; border-radius: .375rem; padding: .5rem .6rem; box-shadow: 0 2px 8px rgba(0,0,0,.1); min-width: 18rem;">
-                                            <form method="post"
-                                                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_edit', { participantId: participant.id, noteId: note.id }) }}"
-                                                  style="margin-bottom: .5rem;">
-                                                <input type="hidden" name="_token" value="{{ csrf_token('participant_note_edit_' ~ note.id) }}">
-                                                <textarea name="textValue"
-                                                          rows="3"
-                                                          style="width: 100%; padding: .25rem .375rem; border: 1px solid #ced4da; border-radius: .25rem;">{{ note.textValue|default('') }}</textarea>
-                                                <label style="display: flex; align-items: center; gap: .25rem; margin: .25rem 0;">
-                                                    <input type="checkbox" name="publicNote" value="1" {{ note.publicNote|default(false) ? 'checked' : '' }}>
-                                                    <small>veřejná</small>
-                                                </label>
-                                                <button type="submit" class="btn btn-sm btn-outline-primary">Uložit</button>
-                                            </form>
-                                            <form method="post"
-                                                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_delete', { participantId: participant.id, noteId: note.id }) }}"
-                                                  onsubmit="return confirm('Opravdu smazat tuto poznámku?');"
-                                                  style="margin: 0; padding-top: .25rem; border-top: 1px solid #e9ecef;">
-                                                <input type="hidden" name="_token" value="{{ csrf_token('participant_note_delete_' ~ note.id) }}">
-                                                <button type="submit" class="btn btn-sm btn-outline-danger">✗ Smazat poznámku</button>
-                                            </form>
-                                        </div>
-                                    </details>
-                                </div>
-                                <div style="white-space: pre-line;">{{ note.textValue|default('') }}</div>
-                            </div>
-                        {% endfor %}
-                    {% endif %}
-                </div>
-            </div>
-
-            {# Historie přihlášky — read-only chronologie změn z verzovaných junction entit (#142). #}
-            <div class="card" style="margin-bottom: 1rem;" id="historie">
-                <div class="card-body">
-                    <details>
-                        <summary style="cursor: pointer; list-style: none;">
-                            <h5 class="card-title" style="display: inline; border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">
-                                Historie přihlášky
-                                <span class="text-secondary" style="font-weight: normal; font-size: .85rem;">
-                                    ({{ history|default([])|length }} {{ (history|default([])|length == 1) ? 'záznam' : 'záznamů' }}) ▾
-                                </span>
-                            </h5>
-                        </summary>
-                        {% set historyRows = history|default([]) %}
-                        {% if historyRows|length == 0 %}
-                            <p class="text-muted" style="margin: .75rem 0 0;">Žádná zaznamenaná historie.</p>
-                        {% else %}
-                            <table class="table table-sm" style="margin: .75rem 0 0;">
-                                <tbody>
-                                    {% for event in historyRows %}
-                                        {% set verbColor = {'created': '#006FAD', 'added': '#198754', 'removed': '#b02a37'} %}
-                                        {% set verbIcon  = {'created': '✚', 'added': '＋', 'removed': '✗'} %}
-                                        {% set kindLabel = {'participant': 'Přihláška', 'registration': 'Akce / turnus', 'flag': 'Příznak'} %}
-                                        <tr>
-                                            <td style="width: 11rem; white-space: nowrap; color: #6c757d; font-size: .85rem;">
-                                                {{ event.at|date('j. n. Y H:i', 'Europe/Prague') }}
-                                            </td>
-                                            <td style="width: 1.5rem; text-align: center; color: {{ verbColor[event.verb]|default('#6c757d') }};">
-                                                {{ verbIcon[event.verb]|default('•') }}
-                                            </td>
-                                            <td style="width: 8rem; white-space: nowrap; color: #6c757d; font-size: .85rem;">
-                                                {{ kindLabel[event.kind]|default(event.kind) }}{% if event.category %}<br><small>{{ event.category }}</small>{% endif %}
-                                            </td>
-                                            <td{% if event.verb == 'removed' %} style="text-decoration: line-through; color: #6c757d;"{% endif %}>
-                                                {{ event.label }}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                            <p class="text-muted" style="margin: .25rem 0 0; font-size: .8rem;">
-                                Rekonstruováno z časových značek příznaků a registrací (přidáno = vznik, přeškrtnuto = smazáno). Změny jednotlivých polí kontaktu se zde nezobrazují.
-                            </p>
+                                </details>
+                            {% endif %}
                         {% endif %}
-                    </details>
+                    {% endfor %}
                 </div>
-            </div>
+            {% else %}
+                {# Read-only fallback (ne-admin, nebo žádné dostupné kategorie) #}
+                <div class="box" style="margin-bottom:1.5rem;">
+                    {% for flagGroup in participant.flagGroups|default([]) %}
+                        <div style="padding:.3rem 0; border-top:1px solid #e3e9f0;">
+                            <strong>{{ flagGroup.flagGroupRange.flagCategory.name|default(flagGroup.name|default('Skupina')) }}:</strong>
+                            {% for participantFlag in flagGroup.participantFlags|default([]) %}
+                                {% if participantFlag.active|default %}
+                                    <span class="badge" style="background: {{ participantFlag.flagOffer.flag.color|default('#006FAD') }}; color:#fff;">
+                                        {{ participantFlag.flagOffer.flag.shortName|default(participantFlag.flagOffer.flag.name|default('—')) }}
+                                    </span>
+                                {% endif %}
+                            {% else %}
+                                <em class="text-muted">—</em>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <em class="text-muted">Žádné příznaky.</em>
+                    {% endfor %}
+                </div>
+            {% endif %}
 
-            {# Komunikace timeline #}
-            <div class="card" style="margin-bottom: 1rem;" id="komunikace">
-                <div class="card-body">
-                    <h5 class="card-title" style="border-bottom: 1px solid #dee2e6; padding-bottom: .25rem;">Komunikace</h5>
-                    {% include '@OswisOrgOswisCalendar/web_admin/communication/_timeline_list.html.twig' with {
-                        entries:           entries|default([]),
-                        isAdmin:           isAdmin|default(true),
-                        participantId:     participantId|default(participant.id),
-                        resendableMailIds: resendableMailIds|default({}),
-                    } only %}
+            {# Poznámky #}
+            <h3 id="poznamky">Poznámky</h3>
+            {% set notes = participant.notes|default([]) %}
+            <form method="post"
+                  action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_create', { participantId: participant.id }) }}"
+                  class="box" style="margin-bottom:1rem;">
+                <input type="hidden" name="_token" value="{{ csrf_token('participant_note_create_' ~ participant.id) }}">
+                <div style="display:flex; gap:.5rem; align-items:flex-start; flex-wrap:wrap;">
+                    <textarea name="textValue" rows="2" placeholder="Nová poznámka…" required
+                              class="form-control form-control-sm" style="flex:1 1 22rem; min-width:15rem;"></textarea>
+                    <label class="small" style="white-space:nowrap; margin-top:.35rem;">
+                        <input type="checkbox" name="publicNote" value="1"> veřejná (vidí účastník)
+                    </label>
+                    <button type="submit" class="btn btn-sm btn-primary">+ Přidat</button>
                 </div>
-            </div>
+            </form>
+            {% if notes|length == 0 %}
+                <p class="text-muted">Žádné poznámky.</p>
+            {% else %}
+                <table class="list" style="margin-bottom:1.5rem;">
+                    <thead><tr><th>Kdy / kdo</th><th>Poznámka</th><th class="text-center">Akce</th></tr></thead>
+                    {% for note in notes %}
+                        <tbody><tr>
+                            <td class="small" style="white-space:nowrap;">
+                                {{ note.createdAt|date('j. n. Y H:i', 'Europe/Prague')|default('') }}
+                                {% set author = note.createdBy|default %}
+                                {% if author %}<div class="block small text-muted">{{ author.shortName|default(author.name|default(author.username|default('—'))) }}</div>{% endif %}
+                                <span class="badge {{ note.publicNote|default(false) ? 'bg-info' : 'bg-secondary' }}">{{ note.publicNote|default(false) ? 'veřejná' : 'interní' }}</span>
+                            </td>
+                            <td style="white-space:pre-line;">{{ note.textValue|default('') }}</td>
+                            <td class="text-center">
+                                <details>
+                                    <summary class="btn btn-sm btn-outline-primary" style="list-style:none;">✎</summary>
+                                    <div style="text-align:left; margin-top:.4rem; min-width:16rem;">
+                                        <form method="post"
+                                              action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_edit', { participantId: participant.id, noteId: note.id }) }}"
+                                              style="margin-bottom:.5rem;">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('participant_note_edit_' ~ note.id) }}">
+                                            <textarea name="textValue" rows="3" class="form-control form-control-sm">{{ note.textValue|default('') }}</textarea>
+                                            <label class="small" style="display:block; margin:.25rem 0;">
+                                                <input type="checkbox" name="publicNote" value="1" {{ note.publicNote|default(false) ? 'checked' : '' }}> veřejná
+                                            </label>
+                                            <button type="submit" class="btn btn-sm btn-outline-primary">Uložit</button>
+                                        </form>
+                                        <form method="post"
+                                              action="{{ path('oswis_org_oswis_calendar_web_admin_participant_note_delete', { participantId: participant.id, noteId: note.id }) }}"
+                                              onsubmit="return confirm('Opravdu smazat tuto poznámku?');" style="margin:0;">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('participant_note_delete_' ~ note.id) }}">
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">✗ Smazat</button>
+                                        </form>
+                                    </div>
+                                </details>
+                            </td>
+                        </tr></tbody>
+                    {% endfor %}
+                </table>
+            {% endif %}
+
+            {# Historie a komunikace #}
+            <h3 id="historie">Historie a komunikace</h3>
+            <span id="komunikace"></span>
+            {% include '@OswisOrgOswisCalendar/web_admin/_participant_timeline.html.twig' with {
+                timeline:          timeline|default([]),
+                isAdmin:           isAdmin|default(true),
+                participantId:     participantId|default(participant.id),
+                resendableMailIds: resendableMailIds|default({}),
+            } only %}
         {% endif %}
-    </main>
+    </div>
 {% endblock body_content %}

--- a/Service/Participant/ParticipantFlagUpdateService.php
+++ b/Service/Participant/ParticipantFlagUpdateService.php
@@ -82,7 +82,8 @@ final class ParticipantFlagUpdateService
      * flushes — the second one recomputes the cached usage counts, which read committed rows and so
      * must run after the first flush.
      *
-     * @param list<int> $selectedFlagOfferIds ids of the RegistrationFlagOffers that should remain/become active
+     * @param list<int>               $selectedFlagOfferIds ids of the RegistrationFlagOffers that should remain/become active
+     * @param array<int, string|null> $textValues           offerId => volný text; aplikuje se JEN na nabídky s povolenou form-value (isFormValueAllowed), ostatní klíče se ignorují
      *
      * @throws FlagCapacityExceededException when adding would exceed a flag offer's capacity (only when $admin=false)
      * @throws FlagOutOfRangeException       when the resulting count breaks a min/max constraint
@@ -94,6 +95,7 @@ final class ParticipantFlagUpdateService
         RegistrationFlagGroupOffer $groupOffer,
         array $selectedFlagOfferIds,
         bool $admin = false,
+        array $textValues = [],
     ): void {
         // Security boundary: the group offer must belong to this participant's (recursive) offer set.
         $availableIds = array_map(
@@ -145,7 +147,9 @@ final class ParticipantFlagUpdateService
         $newFlags = new ArrayCollection();
         foreach ($selectedOffers as $offerId => $flagOffer) {
             if (isset($existingByOfferId[$offerId])) {
-                $newFlags->add($existingByOfferId[$offerId]);
+                $kept = $existingByOfferId[$offerId];
+                $this->applyTextValue($kept, $flagOffer, $textValues); // umožní editaci textu u zachovaného příznaku
+                $newFlags->add($kept);
                 continue;
             }
             // Mirror the registration form (FlagGroupOfParticipantType): a freshly constructed
@@ -154,6 +158,7 @@ final class ParticipantFlagUpdateService
             // Activate explicitly — exactly as the registration path does — so the flag is active.
             $newFlag = new ParticipantFlag($flagOffer, $group);
             $newFlag->activate();
+            $this->applyTextValue($newFlag, $flagOffer, $textValues);
             $newFlags->add($newFlag);
         }
 
@@ -194,7 +199,7 @@ final class ParticipantFlagUpdateService
      *     min: int,
      *     max: int|null,
      *     hasGroup: bool,
-     *     flagOffers: list<array{offer: RegistrationFlagOffer, selected: bool, remaining: int|null, full: bool}>
+     *     flagOffers: list<array{offer: RegistrationFlagOffer, selected: bool, remaining: int|null, full: bool, formValueAllowed: bool, formValueLabel: string|null, textValue: string|null}>
      * }>
      */
     public function getFlagSelectionModel(Participant $participant): array
@@ -202,25 +207,31 @@ final class ParticipantFlagUpdateService
         $model = [];
         foreach ($this->getAvailableGroupOffers($participant, true) as $groupOffer) {
             $group = $this->findGroup($participant, $groupOffer);
-            $activeOfferIds = [];
+            /** @var array<int, ParticipantFlag> $activeFlagByOfferId */
+            $activeFlagByOfferId = [];
             if ($group instanceof ParticipantFlagGroup) {
                 foreach ($group->getParticipantFlags(true) as $participantFlag) {
                     $activeOfferId = $participantFlag->getFlagOffer()?->getId();
                     if (null !== $activeOfferId) {
-                        $activeOfferIds[$activeOfferId] = true;
+                        $activeFlagByOfferId[$activeOfferId] = $participantFlag;
                     }
                 }
             }
             $flagOffers = [];
             foreach ($groupOffer->getFlagOffers(false) as $offer) {
-                $selected = null !== $offer->getId() && isset($activeOfferIds[$offer->getId()]);
+                $offerId = $offer->getId();
+                $activeFlag = null !== $offerId ? ($activeFlagByOfferId[$offerId] ?? null) : null;
+                $selected = $activeFlag instanceof ParticipantFlag;
                 $remaining = $offer->getRemainingCapacity();
                 $flagOffers[] = [
-                    'offer'     => $offer,
-                    'selected'  => $selected,
-                    'remaining' => $remaining,
+                    'offer'            => $offer,
+                    'selected'         => $selected,
+                    'remaining'        => $remaining,
                     // "full" only blocks NEW selections — an already-selected flag is never disabled.
-                    'full'      => !$selected && null !== $remaining && $remaining < 1,
+                    'full'             => !$selected && null !== $remaining && $remaining < 1,
+                    'formValueAllowed' => $offer->isFormValueAllowed(),
+                    'formValueLabel'   => $offer->getFormValueLabel(),
+                    'textValue'        => $activeFlag?->getTextValue(),
                 ];
             }
             $model[] = [
@@ -234,6 +245,27 @@ final class ParticipantFlagUpdateService
         }
 
         return $model;
+    }
+
+    /**
+     * Nastaví volný text příznaku z mapy offerId => text, ale JEN když nabídka form-value povoluje
+     * (isFormValueAllowed). Prázdný/whitespace text → null. Nabídky bez form-value nebo bez klíče
+     * v mapě nechá beze změny.
+     *
+     * @param array<int, string|null> $textValues
+     */
+    private function applyTextValue(ParticipantFlag $flag, RegistrationFlagOffer $flagOffer, array $textValues): void
+    {
+        if (!$flagOffer->isFormValueAllowed()) {
+            return;
+        }
+        $offerId = $flagOffer->getId();
+        if (null === $offerId || !array_key_exists($offerId, $textValues)) {
+            return;
+        }
+        $raw = $textValues[$offerId];
+        $trimmed = null === $raw ? '' : trim($raw);
+        $flag->setTextValue('' === $trimmed ? null : $trimmed);
     }
 
     private function findGroup(


### PR DESCRIPTION
## Co
- **Admin editace příznaků** vč. per-flag textové hodnoty (`textValue`/`applyTextValue`) — service + API + web admin.
- **`Setup2026FlagsCommand`** — idempotentní konfigurace stravovacích + dopravních příznaků pro 2026 reg-offer (master flagy se reusují, offery `Capacity(null,null)` = bez stropu).
- **Detail účastníka přepsán na nativní vzhled aplikace**: `.list`/`.box`, seskupené příznaky s „+ Přidat příznak (N)", vlastní vertikální timeline historie/komunikace, čisté řádky změn (bez boxy ➡/⬅).

## Pozn.
Tato větev je postavená nad program-modul Fáze-1 modelem, takže nese i `a8e83e2` (EventCategory program-block typy + `Event.placeText`) — aditivní, párováno s migrací v app PR. Schema:validate zelený.

## Ověření
- PHPStan level max: **0 chyb**
- `doctrine:schema:validate`: **zelený**
- lint:twig: OK; Encore build čistý

🤖 Generated with [Claude Code](https://claude.com/claude-code)