### PR TITLE
fix(flags): podpora neomezené kapacity (null) u příznaků

### DIFF
--- a/Command/Setup2026FlagsCommand.php
+++ b/Command/Setup2026FlagsCommand.php
@@ -227,7 +227,10 @@ final class Setup2026FlagsCommand extends Command
             $io->writeln('    + flag offer "'.$offerSlug.'"');
             $flagOffer = new RegistrationFlagOffer(
                 $flag,
-                new Capacity(null, null), // bez kapacitního stropu
+                // Bez kapacitního stropu — admin dietní/dopravní příznaky nejsou omezený zdroj.
+                // null tu funguje díky RegistrationFlagOffer::setBaseCapacity(), který (na rozdíl
+                // od CapacityTrait) zachová null → příznak nemá čítač a jde vždy přiřadit.
+                new Capacity(null, null),
                 new Price(0, 0),          // zdarma, bez zálohy
                 new FlagAmountRange(0, null),
                 null,

--- a/Entity/Registration/RegistrationFlagOffer.php
+++ b/Entity/Registration/RegistrationFlagOffer.php
@@ -190,6 +190,17 @@ class RegistrationFlagOffer implements NameableInterface
         return $remaining < 1 ? 0 : $remaining;
     }
 
+    /**
+     * Příznak smí být zcela bez kapacitního stropu. Na rozdíl od {@see CapacityTrait::setBaseCapacity()}
+     * (kde se null koeruje na 0) zachováváme null = „neomezeno": pak {@see getCapacityInt()} i
+     * {@see getRemainingCapacity()} vrací null, příznak nemá čítač „[zbývá N]" a jde vždy přiřadit.
+     * Vědomě zúženo jen na příznaky — sdílený trait (a tím Event/RegistrationOffer) neměníme.
+     */
+    public function setBaseCapacity(?int $baseCapacity): void
+    {
+        $this->baseCapacity = null === $baseCapacity ? null : max(0, $baseCapacity);
+    }
+
     public function getFlagGroupName(): ?string
     {
         if (null !== $this->getFlagFormGroup()) {


### PR DESCRIPTION
## Problém
Admin dietní/dopravní příznaky (Setup2026) se zakládaly s `Capacity(null, null)` = „bez stropu", jenže `CapacityTrait::setBaseCapacity()` koeruje `null ??= 0`. Do DB se tak uložila `base_capacity = 0` → příznaky se v editoru zobrazovaly jako **`[zbývá 0]`** a nešlo je přiřadit (jen přes „překročit kapacitu").

## Oprava
- `RegistrationFlagOffer::setBaseCapacity()` nově zachová `null` jako „neomezeno" (na rozdíl od sdíleného traitu). Pak `getCapacityInt()` i `getRemainingCapacity()` vrací `null` → příznak nemá čítač a jde vždy přiřadit.
- Vědomě zúženo **jen na příznaky** — `Event`/`RegistrationOffer` zůstávají beze změny (sdílený trait neměníme, žádný dopad na kapacitu registrací během živé sezóny).
- `Setup2026FlagsCommand` vrácen na `Capacity(null, null)`.

## Ověření
- PHPStan level max: 0 chyb.
- Runtime check: `Capacity(null,null)` → `getCapacityInt`/`getRemainingCapacity` = `null`, `hasRemainingCapacity` = `true`; capped (600) beze změny.
- Produkce: 10 existujících řádků (id 208–217) přenastaveno na `base_capacity = NULL` (read-path už null zvládal i na nasazeném kódu) — ověřeno v prohlížeči, příznaky bez čítače a přiřaditelné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)