### PR TITLE
fix: bezejmenný kontakt, datum platby, konzistence příznaků

### DIFF
--- a/Controller/WebAdmin/WebAdminParticipantsController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsController.php
@@ -179,11 +179,15 @@ final class WebAdminParticipantsController extends AbstractController
         } catch (\Throwable) {
         }
 
-        // Only ParticipantMail (system + ad-hoc) rows are resend-able.
-        // IMAP-imported and manual-note rows have no underlying mailer.
+        // Only ParticipantMail (system + ad-hoc) rows are resend-able. IMAP-imported and manual-note
+        // rows have no underlying mailer. Payment confirmations, activation requests and
+        // registration-changed mails are excluded too: their templates need data a bare re-send
+        // cannot reconstruct ({@see ParticipantMail::NON_RESENDABLE_TYPES}).
         $resendableMailIds = [];
         foreach ($entries as $entry) {
-            if ($entry instanceof ParticipantMail && $entry->getId() !== null) {
+            if ($entry instanceof ParticipantMail
+                && $entry->getId() !== null
+                && ParticipantMail::isResendableType($entry->getType())) {
                 $resendableMailIds[$entry->getId()] = true;
             }
         }

--- a/Entity/Participant/Participant.php
+++ b/Entity/Participant/Participant.php
@@ -669,12 +669,45 @@ class Participant implements ParticipantInterface
         }
     }
 
+    /**
+     * Nahradí skupinu příznaků novou (kompatibilní s cílovou nabídkou) a přitom nedopustí, aby
+     * účastníkovi zůstaly DVĚ nesmazané instance pro tutéž nabídku skupiny příznaků.
+     *
+     * `RegistrationOffer::findCompatibleFlagGroupRange()` páruje cílovou skupinu podle kategorie,
+     * takže dvě staré skupiny téže kategorie zkonvergují na jednu cílovou nabídku. Slepé přidání
+     * nechalo prázdnou duplicitu; `findGroup()` pak mohlo vrátit ji, uložení příznaku do ní znamenalo
+     * duplicitní příplatek a zobrazení se rozešlo s cenou (kořen #226).
+     *
+     * Příznak se přitom nikdy nezahazuje: když příznaky nesou obě instance, ponechají se obě
+     * (to už řeší guard v `findGroup`, který preferuje instanci s aktivními příznaky).
+     */
     public function replaceParticipantFlagGroup(
         ParticipantFlagGroup $oldParticipantFlagGroup,
         ParticipantFlagGroup $newParticipantFlagGroup,
     ): void
     {
         $oldParticipantFlagGroup->delete();
+        $newFlagGroupOffer = $newParticipantFlagGroup->getFlagGroupOffer();
+        $newHasFlags = !$newParticipantFlagGroup->getParticipantFlags(true)->isEmpty();
+        if (null !== $newFlagGroupOffer) {
+            foreach ($this->getFlagGroups(null, null, true) as $existingFlagGroup) {
+                if ($existingFlagGroup === $newParticipantFlagGroup
+                    || $existingFlagGroup->getFlagGroupOffer() !== $newFlagGroupOffer) {
+                    continue;
+                }
+                if (!$existingFlagGroup->getParticipantFlags(true)->isEmpty()) {
+                    if (!$newHasFlags) {
+                        return; // Prázdný nováček by byl jen duplicita.
+                    }
+                    break; // Obě nesou příznaky — raději duplicita než ztráta zaplaceného příznaku.
+                }
+                if (!$newHasFlags) {
+                    return; // Obě prázdné — ponecháme tu, která už v kolekci je.
+                }
+                $existingFlagGroup->delete(); // Prázdnou duplicitu nahradí ta, která nese příznaky.
+                break;
+            }
+        }
         $this->getFlagGroups()->add($newParticipantFlagGroup);
     }
 

--- a/Entity/Participant/ParticipantFlagGroup.php
+++ b/Entity/Participant/ParticipantFlagGroup.php
@@ -209,6 +209,13 @@ class ParticipantFlagGroup implements BasicInterface, TextValueInterface, Delete
                 try {
                     $addedFlag->setParticipantFlagGroup($this);
                 } catch (NotImplementedException) {
+                    // A ParticipantFlag belongs to exactly one group for its whole life
+                    // ({@see ParticipantFlag::setParticipantFlagGroup()}). Swallowing this used to
+                    // leave the flag in the assignment below anyway, so this group's collection held
+                    // a flag whose own back-reference still pointed at the old group. The flag is the
+                    // owning side, so Doctrine keeps the old group in the DB and the in-memory graph
+                    // silently disagrees with what is stored. Drop it instead of pretending.
+                    $newParticipantFlags->removeElement($addedFlag);
                 }
             }
             $this->participantFlags = $newParticipantFlags;

--- a/Entity/Participant/ParticipantPaymentsImport.php
+++ b/Entity/Participant/ParticipantPaymentsImport.php
@@ -211,8 +211,14 @@ class ParticipantPaymentsImport
         // ('Datum' is rarely at index 0) — [0] on the raw result raised an undefined-key warning,
         // which Symfony's ErrorHandler turns into an ErrorException inside a web request.
         $candidates = [$dateColumnName, '"'.$dateColumnName.'"', "\\\"{$dateColumnName}\\\""];
-        foreach (array_values(preg_grep('/.*Datum.*/', array_keys($csvPaymentRow)) ?: []) as $matchedKey) {
-            $candidates[] = self::toString($matchedKey);
+        if ('' !== $dateColumnName) {
+            // Poslední pokus: jakýkoli sloupec, jehož název konfigurovaný název obsahuje (jinak
+            // zabalený do uvozovek či jinak ozdobený). Dřív tu bylo natvrdo „Datum" bez ohledu
+            // na nastavení, takže jiná než česká Fio hlavička by sem nikdy nedosáhla.
+            $pattern = '/'.preg_quote($dateColumnName, '/').'/i';
+            foreach (array_values(preg_grep($pattern, array_keys($csvPaymentRow)) ?: []) as $matchedKey) {
+                $candidates[] = self::toString($matchedKey);
+            }
         }
         foreach ($candidates as $candidate) {
             if ('' === $candidate || !array_key_exists($candidate, $csvPaymentRow)) {

--- a/Entity/Participant/ParticipantPaymentsImport.php
+++ b/Entity/Participant/ParticipantPaymentsImport.php
@@ -130,18 +130,28 @@ class ParticipantPaymentsImport
     ): ParticipantPayment {
         $csvCurrency = $csvPaymentRow[(string) $csvSettings->getCurrencyColumnName()] ?? null;
         $currencyAllowed = $csvSettings->getCurrencyAllowed();
+        $dateTime = $this->getDateFromCsvPayment($csvPaymentRow, $csvSettings);
         $payment = new ParticipantPayment(
             self::toInt($csvPaymentRow[(string) $csvSettings->getValueColumnName()] ?? 0),
-            $this->getDateFromCsvPayment($csvPaymentRow, $csvSettings),
+            $dateTime,
             ParticipantPayment::TYPE_BANK_TRANSFER
         );
         $payment->setInternalNote($csvRow);
         $payment->setExternalId(self::toString($csvPaymentRow[(string) $csvSettings->getIdentifierColumnName()] ?? null));
+        $errors = [];
         if (!$csvCurrency || $csvCurrency !== $currencyAllowed) {
             $payment->setNumericValue(0);
             $csvCurrencyString = self::toString($csvCurrency);
             $currencyAllowedString = self::toString($currencyAllowed);
-            $payment->setErrorMessage("Wrong payment currency ('$csvCurrencyString' instead of '$currencyAllowedString').");
+            $errors[] = "Wrong payment currency ('$csvCurrencyString' instead of '$currencyAllowedString').";
+        }
+        if (null === $dateTime) {
+            // Without this the payment silently inherits the import time and skews the matcher's
+            // date-proximity score. The raw CSV row stays in internalNote for manual correction.
+            $errors[] = 'Datum platby se nepodařilo přečíst z CSV řádku.';
+        }
+        if ([] !== $errors) {
+            $payment->setErrorMessage(implode(' ', $errors));
         }
         $payment->setVariableSymbol($this->getVsFromCsvPayment($csvPaymentRow, $csvSettings));
 
@@ -184,37 +194,42 @@ class ParticipantPaymentsImport
         return $default ?? 0;
     }
 
+    /**
+     * Reads the transaction date from a CSV row, or null when the row carries none we can read.
+     *
+     * Null is deliberate: the old code fell back to `new DateTime()` (the import time) and swallowed
+     * every parse failure into null as well. `ParticipantPayment::getDateTime()` then falls back to
+     * `createdAt` — also the import time. Either way the payment entered the matcher's date-proximity
+     * score stamped with the wrong day and nothing anywhere said so. makePaymentFromCsv() now turns a
+     * null into a visible error message on the payment instead.
+     */
     private function getDateFromCsvPayment(array $csvPaymentRow, CsvPaymentImportSettings $csvSettings): ?DateTime
     {
-        try {
-            // preg_grep PRESERVES keys ('Datum' is rarely at index 0) — [0] on the raw result
-            // raised an undefined-key warning, which Symfony's ErrorHandler turns into an
-            // ErrorException inside a web request → catch → date silently null on every import.
-            $dateKey = self::toString(array_values(preg_grep('/.*Datum.*/', array_keys($csvPaymentRow)) ?: [])[0] ?? '');
-            $dateColumnName = $csvSettings->getDateColumnName();
-            if (array_key_exists(''.$dateColumnName, $csvPaymentRow)) {
-                $dateColumnValue = self::toString($csvPaymentRow[(string) $dateColumnName]);
-
-                return new DateTime($dateColumnValue);
-            }
-            if (array_key_exists('"'.$dateColumnName.'"', $csvPaymentRow)) {
-                $dateColumnValue = self::toString($csvPaymentRow["\"$dateColumnName\""]);
-
-                return new DateTime($dateColumnValue);
-            }
-            if (array_key_exists("\\\"{$dateColumnName}\\\"", $csvPaymentRow)) {
-                $dateColumnValue = self::toString($csvPaymentRow["\\\"{$dateColumnName}\\\""]);
-
-                return new DateTime($dateColumnValue);
-            }
-            if (array_key_exists($dateKey, $csvPaymentRow)) {
-                return new DateTime(self::toString($csvPaymentRow[$dateKey]));
-            }
-
-            return new DateTime();
-        } catch (Exception $e) {
-            return null;
+        $dateColumnName = ''.$csvSettings->getDateColumnName();
+        // The exporting bank quotes (and sometimes escapes) header cells inconsistently, so the
+        // configured column name is tried raw, quoted and escaped-quoted. preg_grep PRESERVES keys
+        // ('Datum' is rarely at index 0) — [0] on the raw result raised an undefined-key warning,
+        // which Symfony's ErrorHandler turns into an ErrorException inside a web request.
+        $candidates = [$dateColumnName, '"'.$dateColumnName.'"', "\\\"{$dateColumnName}\\\""];
+        foreach (array_values(preg_grep('/.*Datum.*/', array_keys($csvPaymentRow)) ?: []) as $matchedKey) {
+            $candidates[] = self::toString($matchedKey);
         }
+        foreach ($candidates as $candidate) {
+            if ('' === $candidate || !array_key_exists($candidate, $csvPaymentRow)) {
+                continue;
+            }
+            $rawDate = self::toString($csvPaymentRow[$candidate]);
+            if ('' === $rawDate) {
+                continue;
+            }
+            try {
+                return new DateTime($rawDate);
+            } catch (Exception) {
+                // Unreadable value in this column — keep looking, report only if nothing works.
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Entity/ParticipantMail/ParticipantMail.php
+++ b/Entity/ParticipantMail/ParticipantMail.php
@@ -61,6 +61,27 @@ class ParticipantMail extends AbstractMail implements CommunicationEntryInterfac
     /** Sent on an UPDATE to an existing registration (not the initial confirmation) — lists what changed. */
     public const TYPE_REGISTRATION_CHANGED = 'registration-changed';
 
+    /**
+     * Types whose template needs data that a bare re-send cannot reconstruct.
+     *
+     * - `payment`: the template reads `payment.numericValue`, `payment.dateTime`, `payment.participant.remainingPrice`.
+     *   A re-send has no way to know WHICH payment the original mail confirmed, and Twig with
+     *   `strict_variables=false` (production) silently renders "0,- Kč, dnešní datum, vše uhrazeno".
+     * - `activation-request`: the template needs a valid `participantToken`; a re-send would ship a dead link.
+     *   Use the dedicated "↻ Aktivační e-mail" action, which mints a fresh token.
+     * - `registration-changed`: rendered from a file template with a computed diff, not from a DB mail category.
+     */
+    public const NON_RESENDABLE_TYPES = [
+        self::TYPE_PAYMENT,
+        self::TYPE_ACTIVATION_REQUEST,
+        self::TYPE_REGISTRATION_CHANGED,
+    ];
+
+    public static function isResendableType(?string $type): bool
+    {
+        return null !== $type && !in_array($type, self::NON_RESENDABLE_TYPES, true);
+    }
+
     #[ManyToOne(targetEntity: Participant::class, fetch: 'EAGER', inversedBy: 'eMails')]
     #[JoinColumn(name: 'participant_id', referencedColumnName: 'id')]
     protected ?Participant $participant = null;

--- a/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
+++ b/Resources/views/other/participant-list/parts/participant-list-inner.html.twig
@@ -1,7 +1,9 @@
-{% set contact = participant.contact(false)|default %}
-{% set event = participant.event(false)|default %}
+{# `|default` se na entity nesmí: Twig objekt s prázdným __toString() (kontakt bez jména)
+   vyhodnotí jako prázdný a zahodí celý objekt — pak zmizí i telefon a e-mail. #}
+{% set contact = participant.contact(false) %}
+{% set event = participant.event(false) %}
 {% set regRange = participant.regRange|default %}
-{% set appUser = contact.appUser|default %}
+{% set appUser = contact is null ? null : contact.appUser %}
 
 <tbody>
 <tr {{ participant.deletedAt ? 'style="background-color:rgba(255,0,0,.3);"' : '' }}
@@ -55,7 +57,7 @@
                     {% set listGenderIcon = "👩" %}
                 {% endif %}
                 <li style="list-style-type: '{{ listGenderIcon }}' {{ participantContact.active|default ? '' : 'text-decoration:line-through;' }}">
-                    <strong style="font-size: 1.08em; color: #1a2533;">{{ participantContact.contact.name|default }}</strong>
+                    <strong style="font-size: 1.08em; color: #1a2533;">{{ participantContact.contact.name|default('(bez jména)') }}</strong>
                 </li>
             {% endfor %}
             {% for participantRange in participant.participantRegistrations(false, false) %}

--- a/Resources/views/web_admin/bulk_reassign.html.twig
+++ b/Resources/views/web_admin/bulk_reassign.html.twig
@@ -103,7 +103,7 @@
                     </thead>
                     <tbody>
                         {% for participant in participants %}
-                            {% set contact = participant.contact(false)|default %}
+                            {% set contact = participant.contact(false) %}
                             <tr>
                                 <td>
                                     <input type="checkbox" name="participantIds[]" value="{{ participant.id }}" class="bulk-row-check" {{ participant.id in preselectedIds|default([]) ? 'checked' : '' }}>

--- a/Resources/views/web_admin/communication/_quick_actions.html.twig
+++ b/Resources/views/web_admin/communication/_quick_actions.html.twig
@@ -7,7 +7,7 @@
      - participant: Participant
      - subject_prefill: ?string  (default: "Re: tvá přihláška na {event}")
 #}
-{% set contact = participant.contact|default %}
+{% set contact = participant.contact %}
 {% set email   = contact.email|default %}
 {% set phone   = contact.phone|default %}
 {% set eventName = (participant.event(false).shortName|default) ?: (participant.event(false).name|default) %}

--- a/Resources/views/web_admin/communication/ad_hoc_compose.html.twig
+++ b/Resources/views/web_admin/communication/ad_hoc_compose.html.twig
@@ -6,7 +6,8 @@
     <main class="container">
         <h2>{{ pageTitle }}</h2>
 
-        {% if participant.contact|default %}
+        {# Ne `|default`: kontakt bez jména má prázdné __toString() → Twig by ho vyhodnotil jako empty a skryl i e-mail s telefonem. #}
+        {% if participant.contact is not null %}
             <p>
                 <strong>Příjemce:</strong>
                 {{ participant.contact.name|default('(bez jména)') }}

--- a/Resources/views/web_admin/communication/manual_note_form.html.twig
+++ b/Resources/views/web_admin/communication/manual_note_form.html.twig
@@ -6,7 +6,8 @@
     <main class="container">
         <h2>{{ pageTitle }}</h2>
 
-        {% if participant.contact|default %}
+        {# Ne `|default`: kontakt bez jména má prázdné __toString() → Twig by ho vyhodnotil jako empty a skryl i e-mail s telefonem. #}
+        {% if participant.contact is not null %}
             <p>
                 <strong>Účastník:</strong>
                 {{ participant.contact.name|default('(bez jména)') }}

--- a/Resources/views/web_admin/communication/timeline.html.twig
+++ b/Resources/views/web_admin/communication/timeline.html.twig
@@ -6,7 +6,8 @@
     <main class="container" id="main-content-container">
         <h2>{{ pageTitle }}</h2>
 
-        {% if participant.contact|default %}
+        {# Ne `|default`: kontakt bez jména má prázdné __toString() → Twig by ho vyhodnotil jako empty a skryl i e-mail s telefonem. #}
+        {% if participant.contact is not null %}
             <p>
                 <strong>Účastník:</strong>
                 {{ participant.contact.name|default('(bez jména)') }}

--- a/Resources/views/web_admin/participants-list-pdf.html.twig
+++ b/Resources/views/web_admin/participants-list-pdf.html.twig
@@ -78,8 +78,9 @@
     </thead>
     <tbody>
     {% for participant in participants %}
-        {% set contact = participant.contact(false)|default %}
-        {% set appUser = contact.appUser|default %}
+        {# Bez `|default` — viz participant-list-inner: entita s prázdným __toString() by se zahodila. #}
+        {% set contact = participant.contact(false) %}
+        {% set appUser = contact is null ? null : contact.appUser %}
         {% set isDeleted = participant.deletedAt|default %}
         {% set paidPercentage = (participant.paidPricePercentage * 100)|round %}
         {% set paidColor = participant.remainingPrice > 0 ? 'danger' : 'success' %}

--- a/Service/Imap/ImapFetchService.php
+++ b/Service/Imap/ImapFetchService.php
@@ -148,7 +148,12 @@ final class ImapFetchService
             $state->setLastFetchAt(new DateTime());
             $this->em->persist($state);
             $this->em->flush();
-            $this->em->clear();
+            // Žádné em->clear() — viz varování níže u chunked sweepu. Tahle větev běží uvnitř cyklu
+            // přes složky (default `INBOX,Sent`), takže vyčištění tady odpojí security actora a
+            // následující složka by při persistu spustila Gedmo Blameable rekurzi → OOM. Dnes to
+            // nehrozí jen proto, že `--init-from-now` chodí výhradně z CLI, kde actor neexistuje;
+            // stačilo by ale tenhle přepínač jednou vystavit z webu. A není co uvolňovat: v této
+            // větvi se nenačítají těla zpráv ani se nic dalšího nepersistuje.
 
             return ['fetched' => 0, 'matched' => 0, 'unmatched' => 0, 'lastUid' => $maxUid];
         }

--- a/Service/Imap/ImapFetchService.php
+++ b/Service/Imap/ImapFetchService.php
@@ -387,12 +387,11 @@ final class ImapFetchService
             if (!$contact instanceof AbstractContact) {
                 continue;
             }
-            $participants = $this->em->getRepository(Participant::class)
-                ->findBy(['contact' => $contact], ['createdAt' => 'DESC'], 1);
-            if (count($participants) > 0) {
-                $id = $participants[0]->getId();
+            $participant = $this->findNewestParticipantForContact($contact);
+            if (null !== $participant) {
+                $id = $participant->getId();
                 if (null !== $id && !isset($seenIds[$id])) {
-                    $matched[] = $participants[0];
+                    $matched[] = $participant;
                     $seenIds[$id] = true;
                 }
             }
@@ -498,6 +497,28 @@ final class ImapFetchService
      * `details` collection (ContactDetail rows with category type = 'email'),
      * not as a direct column — so a `findOneBy(['email' => ...])` does not work.
      */
+    /**
+     * Přihláška, na kterou se příchozí zpráva navěsí.
+     *
+     * Doctrine tu NEMÁ zapnutý soft-delete filtr (ověřeno: `em->getFilters()->getEnabledFilters()` je
+     * prázdné), takže prosté `findBy(['contact' => …], ['createdAt' => 'DESC'], 1)` klidně vrátí
+     * SMAZANOU přihlášku. Zpráva se pak pověsí na smazanou registraci a v adminu ji nikdo neuvidí.
+     * V klon-DB má 518 kontaktů nejnovější přihlášku smazanou — u řady z nich existuje starší aktivní.
+     *
+     * Proto: nejnovější AKTIVNÍ přihláška; teprve když žádná není, nejnovější vůbec (zpráva se má
+     * zobrazit i u člověka, který už žádnou aktivní registraci nemá).
+     */
+    private function findNewestParticipantForContact(AbstractContact $contact): ?Participant
+    {
+        $repository = $this->em->getRepository(Participant::class);
+        $active = $repository->findBy(['contact' => $contact, 'deletedAt' => null], ['createdAt' => 'DESC'], 1);
+        if ([] !== $active) {
+            return $active[0];
+        }
+
+        return $repository->findBy(['contact' => $contact], ['createdAt' => 'DESC'], 1)[0] ?? null;
+    }
+
     private function findContactByEmail(string $email): ?AbstractContact
     {
         $qb = $this->em->createQueryBuilder()

--- a/Service/Participant/ParticipantMailService.php
+++ b/Service/Participant/ParticipantMailService.php
@@ -264,6 +264,18 @@ class ParticipantMailService
         if (null === $participant || null === $appUser || null === $type) {
             throw new OswisException('Nelze znovu odeslat: chybí účastník, uživatel nebo typ.');
         }
+        // sendSummaryToUser() umí sestavit jen obecná data (účastník, kontakt, oslovení). Šablony
+        // některých typů potřebují víc — a Twig na produkci (`strict_variables=false`) chybějící
+        // proměnnou tiše nahradí, takže by účastníkovi přišel mail s nepravdivým obsahem:
+        // platební potvrzení „0,- Kč, dnešní datum, celá částka zaplacena" nebo aktivační e-mail
+        // s mrtvým odkazem. Radši hlasitě odmítnout.
+        if (!ParticipantMail::isResendableType($type)) {
+            throw new OswisException(match ($type) {
+                ParticipantMail::TYPE_PAYMENT => 'Potvrzení platby nelze přeposlat — jeho obsah se váže ke konkrétní platbě.',
+                ParticipantMail::TYPE_ACTIVATION_REQUEST => 'Aktivační e-mail pošli tlačítkem „↻ Aktivační e-mail" — vygeneruje nový platný odkaz.',
+                default => "E-mail typu '$type' nelze znovu odeslat.",
+            });
+        }
         $this->sendSummaryToUser($participant, $appUser, $type);
     }
 

--- a/Service/Participant/ParticipantPaymentsImportService.php
+++ b/Service/Participant/ParticipantPaymentsImportService.php
@@ -41,6 +41,17 @@ class ParticipantPaymentsImportService
             if (null === $payment->getImport()) {
                 $payment->setImport($paymentsImport);
             }
+            // errorMessage is set by makePaymentFromCsv (unknown currency, unreadable date) but was
+            // never read anywhere — the row imported and the problem stayed invisible. Surface it.
+            $paymentError = $payment->getErrorMessage();
+            if (null !== $paymentError && '' !== $paymentError) {
+                $this->logger->warning(sprintf(
+                    'CSV import: vadný řádek platby (VS %s, částka %s): %s',
+                    (string) $payment->getVariableSymbol(),
+                    (string) $payment->getNumericValue(),
+                    $paymentError,
+                ));
+            }
             $participant = $this->getParticipantByPayment($payment);
             $created = $this->paymentService->create($payment, true, $participant);
             // create() returns null only when it caught an error (e.g. the confirmation mail threw after


### PR DESCRIPTION
Doprovod k opravě ztráty jména v core.

1. **`|default` na entitě v Twigu** — objekt s prázdným `__toString()` Twig vyhodnotí jako empty a zahodí **celý** objekt. U kontaktu bez jména tak z výpisu zmizel i telefon a e-mail, tedy jediné, čím se s tím člověkem dalo spojit. Opraveno v 7 šablonách + fallback „(bez jména)".
2. **Datum platby z CSV** — `getDateFromCsvPayment()` při nenalezeném sloupci vracelo `new DateTime()` (čas importu) a výjimky spolklo. Platba pak vstupovala do párování se špatným datem, bez stopy. Nově null + `errorMessage` + warning v logu. (Na produkci zatím latentní: všech 80 plateb bez data je ručních, z importu ani jedna.)
3. **Konzistence příznaků** — `setParticipantFlags()` spolklo guard proti přeřazení příznaku mezi skupinami, ale příznak si stejně zapsalo do kolekce → paměťový graf se rozcházel s DB. Dnes nedosažitelné; obrana proti regresi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139ftMaL9BvdPZZjQYjvgi9