### PR TITLE
fix(security): EventFile/EventImage vyžadují ROLE_MANAGER

### DIFF
--- a/Entity/Event/EventFile.php
+++ b/Entity/Event/EventFile.php
@@ -33,7 +33,10 @@ use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
             controller: EventFileAction::class,
             deserialize: false
         ),
-    ]
+    ],
+    // Bez tohoto byl resource dostupný bez tokenu (firewall /api nemá access_control,
+    // autorizaci drží jen security na resource). Sjednoceno s WebImage/WebFile.
+    security: "is_granted('ROLE_MANAGER')"
 )]
 #[Entity]
 #[Table(name: 'calendar_event_file')]

--- a/Entity/Event/EventImage.php
+++ b/Entity/Event/EventImage.php
@@ -34,7 +34,10 @@ use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
             controller: EventImageAction::class,
             deserialize: false
         ),
-    ]
+    ],
+    // Bez tohoto byl resource dostupný bez tokenu (firewall /api nemá access_control,
+    // autorizaci drží jen security na resource). Sjednoceno s WebImage/WebFile.
+    security: "is_granted('ROLE_MANAGER')"
 )]
 #[Uploadable]
 #[Entity]


### PR DESCRIPTION
## Bezpečnost: nechráněné media resourcy

`ContactFile`/`ContactImage` (resp. `EventFile`/`EventImage`) neměly žádné `security:`. Protože firewall `/api` nemá `access_control`, byly GET kolekce čitelné **bez tokenu** (200) a POST upload endpointy dosažitelné bez tokenu. Sjednoceno s `WebImage`/`WebFile` → resource-level `is_granted('ROLE_MANAGER')`.

**Ověřeno živě:** GET i POST bez tokenu → 401 (dřív 200/500). PHPStan max 0. Regresní test v aplikaci (`MediaResourceAuthTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)