### PR TITLE
fix(web-admin): seznam přihlášek — filtr/řazení/kategorie nesmí ztratit rozsah akce

### DIFF
--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -143,6 +143,13 @@ class WebAdminParticipantsListController extends AbstractController
             $defaultEvent = $this->eventService->getDefaultEvent();
             if (null !== $defaultEvent) {
                 $events = [$defaultEvent];
+                // Carry the implicit default event forward as an explicit scope slug. Without this,
+                // scopeParams (→ the filter form's hidden fields) omits the event, so clicking a
+                // status pill submits `?participantCategorySlug=…&filter=…` with no event — and the
+                // presence of participantCategorySlug disables this very fallback → the list silently
+                // widens to ALL events. Making the default scope explicit keeps pills/tabs scoped.
+                $defaultSlug = (string) $defaultEvent->getSlug();
+                $eventSlugs = '' === $defaultSlug ? [] : [$defaultSlug];
                 $isDefaultScope = true;
             }
         }

--- a/Resources/views/other/participant-list/participant-list.html.twig
+++ b/Resources/views/other/participant-list/participant-list.html.twig
@@ -3,7 +3,11 @@
    (pick scope, pick a filter pill) is always visible; power features (flag facets, boolean
    expression, sub-event depth) live in a collapsed "Pokročilé" panel so ordinary users aren't
    overwhelmed and the page stays compact. #}
-{% set qbase = app.request.query.all %}
+{# Base for link/merge controls (event picker, category switcher, sort headers, pagination).
+   MUST start from the canonical scope (scopeParams) — the raw query alone omits the IMPLICIT
+   default event, so on the landing view sort/category/paging links would drop the event scope
+   and silently widen to all events. The raw query overlays it (explicit params win). #}
+{% set qbase = scopeParams|merge(app.request.query.all) %}
 <div class="container participants-page">
 
     {# ---- PAGE TITLE ----------------------------------------------------- #}


### PR DESCRIPTION
## Oprava: seznam přihlášek ztrácel rozsah akce

Dvě manifestace téhož root cause na `/web_admin/seznam-prihlasek`:

1. **Controller** — default event scope se přidal do `$events`, ne do `$eventSlugs` → `scopeParams` nenesl eventSlug → filter pilulky / vyhledávání / chipy / export ztrácely rozsah akce (kliknutí na „zaplacené" vylistovalo VŠECHNY akce).
2. **Šablona `qbase`** — řazení, přepínač kategorie, event picker, stránkování používaly surové `app.request.query.all` (bez implicitního default eventu) → taky ztrácely rozsah na landing view.

Oprava: default event scope zexplicitnit + `qbase = scopeParams|merge(app.request.query.all)`. Root cause → failing test → fix. PHPStan max 0, lint:twig OK, regresní test (obě manifestace), AdminSmoke+UnifiedList bez regrese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)