### PR TITLE
feat(web-admin): program PDF buttons on event detail (F7.3) — NEMERGOVAT zatím

### DIFF
--- a/Resources/views/web_admin/event.html.twig
+++ b/Resources/views/web_admin/event.html.twig
@@ -37,6 +37,29 @@
                         {% endif %}
                     </div>
                 {% endif %}
+                {% if is_granted('ROLE_MANAGER') and event.slug|default %}
+                    {# Program-module tiskové výstupy (STOPA 1.3). Turnus-level = jen eventSlug;
+                       na turnusu bez programu vrací controller 404 „chybí podklad" (ne chybu). #}
+                    <div style="display: inline-flex; gap: .5rem; flex-wrap: wrap; align-items: center;">
+                        <span class="small text-muted" style="margin-right: .25rem;">Program (PDF):</span>
+                        <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                           href="{{ path('oswis_org_oswis_calendar_web_admin_program_full', { eventSlug: event.slug }) }}">
+                            Celý program
+                        </a>
+                        <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                           href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', { eventSlug: event.slug }) }}">
+                            Instruktorský
+                        </a>
+                        <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                           href="{{ path('oswis_org_oswis_calendar_web_admin_program_roster', { eventSlug: event.slug }) }}">
+                            Rozpis služeb
+                        </a>
+                        <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                           href="{{ path('oswis_org_oswis_calendar_web_admin_program_team', { eventSlug: event.slug }) }}">
+                            Itinerář týmu
+                        </a>
+                    </div>
+                {% endif %}
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Adds a **Program (PDF)** button group to the event detail header (`/web_admin/udalost/{slug}`): Celý program · Instruktorský · Rozpis služeb · Itinerář týmu (turnus-level routes, `{eventSlug}` only, ROLE_MANAGER).

⚠️ **NEMERGOVAT / NENASAZOVAT zatím:**
- Web-admin změna = konzultace předem (čeká na rozhodnutí usera).
- Nemá živou utilitu, dokud na produ nejsou program data (tabulky prázdné). Na turnusu bez programu vrací controller graceful 404 „chybí podklad" (ne 500).

Ověřeno: Twig lint clean, všechny 4 routy existují. Aditivní, existující btn styl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)