### PR TITLE
fix(media): zprovoznit upload souborů/obrázků (A3)

### DIFF
--- a/Controller/Event/EventFileAction.php
+++ b/Controller/Event/EventFileAction.php
@@ -3,6 +3,7 @@
 namespace OswisOrg\OswisCalendarBundle\Controller\Event;
 
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventFile;
+use OswisOrg\OswisCalendarBundle\Form\MediaObject\EventFileType;
 use OswisOrg\OswisCoreBundle\Controller\AbstractClass\AbstractFileAction;
 
 final class EventFileAction extends AbstractFileAction
@@ -10,6 +11,11 @@ final class EventFileAction extends AbstractFileAction
     public static function getFileClassName(): string
     {
         return EventFile::class;
+    }
+
+    public static function getFileFormClass(): string
+    {
+        return EventFileType::class;
     }
 
     public static function getFileNewInstance(): EventFile

--- a/Controller/Event/EventImageAction.php
+++ b/Controller/Event/EventImageAction.php
@@ -3,6 +3,7 @@
 namespace OswisOrg\OswisCalendarBundle\Controller\Event;
 
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventImage;
+use OswisOrg\OswisCalendarBundle\Form\MediaObject\EventImageType;
 use OswisOrg\OswisCoreBundle\Controller\AbstractClass\AbstractImageAction;
 use OswisOrg\OswisCoreBundle\Entity\AbstractClass\AbstractImage;
 
@@ -12,6 +13,11 @@ final class EventImageAction extends AbstractImageAction
     public static function getFileClassName(): string
     {
         return EventImage::class;
+    }
+
+    public static function getFileFormClass(): string
+    {
+        return EventImageType::class;
     }
 
     public static function getFileNewInstance(): AbstractImage

--- a/Entity/Event/EventFile.php
+++ b/Entity/Event/EventFile.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
-use Gedmo\Mapping\Annotation\Uploadable;
+use Vich\UploaderBundle\Mapping\Attribute\Uploadable;
 use OswisOrg\OswisCalendarBundle\Controller\Event\EventFileAction;
 use OswisOrg\OswisCoreBundle\Entity\AbstractClass\AbstractFile;
 use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Publicity;
@@ -22,7 +22,7 @@ use OswisOrg\OswisCoreBundle\Traits\Common\PriorityTrait;
 use OswisOrg\OswisCoreBundle\Traits\Common\TypeTrait;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints\NotNull;
-use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
+use Vich\UploaderBundle\Mapping\Attribute\UploadableField;
 
 #[ApiResource(
     operations: [

--- a/Entity/Event/EventImage.php
+++ b/Entity/Event/EventImage.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
-use Gedmo\Mapping\Annotation\Uploadable;
+use Vich\UploaderBundle\Mapping\Attribute\Uploadable;
 use OswisOrg\OswisCalendarBundle\Controller\Event\EventImageAction;
 use OswisOrg\OswisCoreBundle\Entity\AbstractClass\AbstractImage;
 use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Publicity;
@@ -24,7 +24,7 @@ use OswisOrg\OswisCoreBundle\Traits\Common\PriorityTrait;
 use OswisOrg\OswisCoreBundle\Traits\Common\TypeTrait;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints\NotNull;
-use Vich\UploaderBundle\Mapping\Annotation\UploadableField;
+use Vich\UploaderBundle\Mapping\Attribute\UploadableField;
 
 #[ApiResource(
     operations: [


### PR DESCRIPTION
Zprovoznění upload feature (A3) — soubory/obrázky k Event/Contact/Web byly komplexně 500 + 0 záznamů. 3 kořeny: (1) akce cpaly form factory entitu místo FormType → nová getFileFormClass(); (2) entity bez class-level Vich #[Uploadable] → migrace na čistou Vich Attribute; (3) chybějící vich *_file mappingy + WebFileType. Ověřeno end-to-end na klonu (Vich přesun na disk OK), PHPStan max 0. Detail: project_media_upload_fix_2026-07-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)