### PR TITLE
feat(web-admin): zakládání mail skupin/kategorií + okno ve formuláři

### DIFF
--- a/Controller/WebAdmin/WebAdminMailConfigController.php
+++ b/Controller/WebAdmin/WebAdminMailConfigController.php
@@ -15,6 +15,7 @@ use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Participant\MailPreviewService;
 use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,9 +26,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  * edit ParticipantMailGroup / ParticipantMailCategory / TwigTemplate rows
  * directly in the DB.
  *
- * Scope (MVP): index page + edit form per entity. CREATE / DELETE not yet
- * exposed — those workflows are rare enough to still need DB access if
- * required.
+ * Scope: index page + edit + create (optionally prefilled via ?from=<id> —
+ * covers the yearly season setup: clone last year's groups/categories and
+ * adjust the year). DELETE stays unexposed (rare enough for DB access).
  */
 #[IsGranted('ROLE_ADMIN')]
 final class WebAdminMailConfigController extends AbstractController
@@ -103,6 +104,112 @@ final class WebAdminMailConfigController extends AbstractController
             'kind'       => 'category',
             'pageTitle'  => sprintf('Mail kategorie: %s', $category->getName() ?? '#'.$id),
             'page_title' => sprintf('Mail kategorie: %s :: ADMIN', $category->getName() ?? '#'.$id),
+        ]);
+    }
+
+    /**
+     * Create a new ParticipantMailGroup, optionally prefilled from an existing one (?from=<id>).
+     * The date window and automaticMailing flag are deliberately NOT copied: an empty window means
+     * "always applies", so a freshly cloned group must start disabled and windowless — enabling it
+     * is a separate, explicit decision after the window is set.
+     */
+    public function newGroup(Request $request): Response
+    {
+        $group = new ParticipantMailGroup();
+        $fromId = $request->query->getInt('from');
+        $from = $fromId > 0 ? $this->em->find(ParticipantMailGroup::class, $fromId) : null;
+        if ($from instanceof ParticipantMailGroup) {
+            $group->setName($from->getName());
+            $group->setShortName($from->getShortName());
+            $group->setDescription($from->getDescription());
+            $group->setPriority($from->getPriority());
+            $group->setTwigTemplate($from->getTwigTemplate());
+            $group->setCategory($from->getCategory());
+            $group->setEvent($from->getEvent());
+            $group->setOnlyActive($from->isOnlyActive());
+            $group->setFilterExpression($from->getFilterExpression());
+        }
+        $form = $this->createForm(ParticipantMailGroupEditType::class, $group);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            // The group form has no slug field and nothing else calls updateSlug(), so a
+            // form-created group would persist with slug NULL (unlike the historic rows).
+            $group->updateSlug();
+            $this->em->persist($group);
+            $this->em->flush();
+            $this->addFlash('success', sprintf(
+                'Mail group „%s" založena%s.',
+                $group->getName() ?? '#'.$group->getId(),
+                $group->isAutomaticMailing() ? '' : ' (automatické rozesílání je vypnuté)',
+            ));
+
+            return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_mail_config'));
+        }
+
+        $pageTitle = null !== $from ? sprintf('Nová mail group (kopie „%s")', $from->getName() ?? '#'.$fromId) : 'Nová mail group';
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/mail_config/edit.html.twig', [
+            'form'       => $form,
+            'entity'     => $group,
+            'kind'       => 'group',
+            'pageTitle'  => $pageTitle,
+            'page_title' => $pageTitle.' :: ADMIN',
+        ]);
+    }
+
+    /**
+     * Create a new ParticipantMailCategory, optionally prefilled via ?from=<id>. The auto-mail
+     * engine deduplicates per category type ("one mail of this type per participant"), so a
+     * duplicate type would silently split one campaign across two categories — rejected here.
+     */
+    public function newCategory(Request $request): Response
+    {
+        $category = new ParticipantMailCategory();
+        $fromId = $request->query->getInt('from');
+        $from = $fromId > 0 ? $this->em->find(ParticipantMailCategory::class, $fromId) : null;
+        if ($from instanceof ParticipantMailCategory) {
+            $category->setName($from->getName());
+            $category->setShortName($from->getShortName());
+            $category->setDescription($from->getDescription());
+            $category->setType($from->getType());
+            $category->setPriority($from->getPriority());
+        }
+        $form = $this->createForm(ParticipantMailCategoryEditType::class, $category);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $type = $category->getType();
+            // DQL, not findOneBy: the entity is in the NONSTRICT L2 cache region, and findOneBy can
+            // return a stale ghost for a row deleted outside the ORM — which would block a legitimate
+            // re-creation here. Plain DQL always reads the database.
+            $duplicate = empty($type) ? null
+                : $this->em->createQueryBuilder()
+                    ->select('c')->from(ParticipantMailCategory::class, 'c')
+                    ->where('c.type = :type')->setParameter('type', $type)
+                    ->setMaxResults(1)->getQuery()->getOneOrNullResult();
+            if ($duplicate instanceof ParticipantMailCategory) {
+                $form->get('type')->addError(new FormError(sprintf(
+                    'Kategorie s typem „%s" už existuje (#%d „%s") — typ musí být unikátní, jinak se kampaň rozpadne mezi dvě kategorie.',
+                    $type,
+                    $duplicate->getId() ?? 0,
+                    $duplicate->getName() ?? '?',
+                )));
+            } else {
+                $this->em->persist($category);
+                $this->em->flush();
+                $this->addFlash('success', sprintf('Mail kategorie „%s" založena.', $category->getName() ?? '#'.$category->getId()));
+
+                return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_mail_config'));
+            }
+        }
+
+        $pageTitle = null !== $from ? sprintf('Nová mail kategorie (kopie „%s")', $from->getName() ?? '#'.$fromId) : 'Nová mail kategorie';
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/mail_config/edit.html.twig', [
+            'form'       => $form,
+            'entity'     => $category,
+            'kind'       => 'category',
+            'pageTitle'  => $pageTitle,
+            'page_title' => $pageTitle.' :: ADMIN',
         ]);
     }
 

--- a/Form/WebAdmin/ParticipantMailGroupEditType.php
+++ b/Form/WebAdmin/ParticipantMailGroupEditType.php
@@ -12,6 +12,8 @@ use OswisOrg\OswisCoreBundle\Entity\TwigTemplate\TwigTemplate;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -53,6 +55,25 @@ final class ParticipantMailGroupEditType extends AbstractType
             ->add('automaticMailing', CheckboxType::class, [
                 'label'    => 'Automatické rozesílání',
                 'required' => false,
+                'help'     => '⚠️ POZOR: skupina s prázdným oknem platí VŽDY — zapnutí bez nastaveného '
+                    .'okna začne rozesílat do 5 minut (cron). Nejdřív nastav okno, pak teprve zapni.',
+            ])
+            ->add('startDateTime', DateTimeType::class, [
+                'label'    => 'Okno OD',
+                'required' => false,
+                'widget'   => 'single_text',
+                'help'     => 'Začátek platnosti skupiny. Prázdné = bez omezení zdola.',
+            ])
+            ->add('endDateTime', DateTimeType::class, [
+                'label'    => 'Okno DO',
+                'required' => false,
+                'widget'   => 'single_text',
+                'help'     => 'Konec platnosti skupiny. Prázdné = bez omezení shora.',
+            ])
+            ->add('priority', IntegerType::class, [
+                'label'    => 'Priorita',
+                'required' => false,
+                'help'     => 'Vyšší priorita vyhrává, když stejný typ pokrývá víc skupin (varianta s filtrem + záchytná bez filtru).',
             ])
             ->add('onlyActive', CheckboxType::class, [
                 'label'    => 'Pouze aktivní účastníci',

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -550,11 +550,21 @@ oswis_org_oswis_calendar_web_admin_catalog:
     tab: 'flags|categories|offers|flag-offers'
   methods: [GET]
 
+oswis_org_oswis_calendar_web_admin_mail_group_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::newGroup
+  path: "/web_admin/e-maily/skupiny/nova"
+  methods: [GET, POST]
+
 oswis_org_oswis_calendar_web_admin_mail_group_edit:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::editGroup
   path: "/web_admin/e-maily/skupiny/{id}/upravit"
   requirements:
     id: '\d+'
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_mail_category_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminMailConfigController::newCategory
+  path: "/web_admin/e-maily/kategorie/nova"
   methods: [GET, POST]
 
 oswis_org_oswis_calendar_web_admin_mail_category_edit:

--- a/Resources/views/web_admin/mail_config/index.html.twig
+++ b/Resources/views/web_admin/mail_config/index.html.twig
@@ -28,12 +28,18 @@
                    class="btn btn-sm"
                    style="border-radius: .375rem .375rem 0 0; {{ activeTab == tab.value ? 'background: #006FAD; color: white;' : 'background: #f8f9fa; color: #006FAD;' }}">
                     {{ tab.label }}
-                    <span class="badge" style="background: rgba(255,255,255,.3); margin-left: .25rem;">{{ tab.count }}</span>
+                    {# Badge colours are set per state: the old rgba(255,255,255,.3) background made
+                       the white badge text invisible on inactive (light) tabs. #}
+                    <span class="badge" style="margin-left: .25rem; {{ activeTab == tab.value ? 'background: rgba(255,255,255,.3); color: #fff;' : 'background: #dbe9f2; color: #005a8c;' }}">{{ tab.count }}</span>
                 </a>
             {% endfor %}
         </div>
 
         {% if activeTab == 'groups' %}
+            <p style="margin-bottom: .75rem;">
+                <a class="btn btn-sm btn-success"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_mail_group_new') }}">+ Nová mail-skupina</a>
+            </p>
             <table class="list" style="width: 100%;">
                 <thead>
                     <tr>
@@ -44,6 +50,7 @@
                         <th>Kategorie</th>
                         <th>Událost</th>
                         <th style="width: 4rem; text-align: center;" title="Automatické odeslání">Auto</th>
+                        <th style="width: 11rem;" title="Okno platnosti — prázdné okno = platí vždy (zapnutá skupina bez okna rozesílá okamžitě)">Okno</th>
                         <th style="width: 6rem; text-align: center;" title="Posílat jen aktivním účastníkům">Jen aktivní</th>
                         <th style="width: 10rem;" title="Volitelný filtr příjemců (výrazový jazyk seznamu přihlášek)">Filtr</th>
                         <th style="width: 6rem;"></th>
@@ -59,6 +66,15 @@
                             <td>{{ g.category ? g.category.name : '—' }}</td>
                             <td>{{ g.event ? (g.event.shortName ?: g.event.name) : '— (globální)' }}</td>
                             <td style="text-align: center;">{{ g.automaticMailing ? '✓' : '—' }}</td>
+                            <td style="font-size: .85em;">
+                                {% if g.startDateTime or g.endDateTime %}
+                                    {{ g.startDateTime ? g.startDateTime|date('j. n. Y H:i') : '…' }} – {{ g.endDateTime ? g.endDateTime|date('j. n. Y H:i') : '…' }}
+                                {% elseif g.automaticMailing %}
+                                    <span style="color: #b02a37; font-weight: 600;" title="Zapnutá skupina bez okna platí vždy!">⚠️ vždy</span>
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </td>
                             <td style="text-align: center;">{{ g.onlyActive ? '✓' : '—' }}</td>
                             <td>
                                 {% if g.filterExpression %}
@@ -67,17 +83,23 @@
                                     —
                                 {% endif %}
                             </td>
-                            <td>
+                            <td style="white-space: nowrap;">
                                 <a class="btn btn-sm btn-outline-primary"
                                    href="{{ path('oswis_org_oswis_calendar_web_admin_mail_group_edit', { id: g.id }) }}">✎ Upravit</a>
+                                <a class="btn btn-sm btn-outline-secondary" title="Založit novou skupinu předvyplněnou z této (okno a automatika se nekopírují)"
+                                   href="{{ path('oswis_org_oswis_calendar_web_admin_mail_group_new', { from: g.id }) }}">⧉ Kopie</a>
                             </td>
                         </tr>
                     {% else %}
-                        <tr><td colspan="10" style="text-align: center; color: #6c757d;">Žádné mail-skupiny.</td></tr>
+                        <tr><td colspan="11" style="text-align: center; color: #6c757d;">Žádné mail-skupiny.</td></tr>
                     {% endfor %}
                 </tbody>
             </table>
         {% elseif activeTab == 'categories' %}
+            <p style="margin-bottom: .75rem;">
+                <a class="btn btn-sm btn-success"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_mail_category_new') }}">+ Nová kategorie</a>
+            </p>
             <table class="list" style="width: 100%;">
                 <thead>
                     <tr>
@@ -97,9 +119,11 @@
                             <td><code style="font-size: .85em;">{{ c.type|default('—') }}</code></td>
                             <td style="text-align: center;">{{ c.priority|default('—') }}</td>
                             <td><code style="font-size: .85em;">{{ c.slug|default('—') }}</code></td>
-                            <td>
+                            <td style="white-space: nowrap;">
                                 <a class="btn btn-sm btn-outline-primary"
                                    href="{{ path('oswis_org_oswis_calendar_web_admin_mail_category_edit', { id: c.id }) }}">✎ Upravit</a>
+                                <a class="btn btn-sm btn-outline-secondary" title="Založit novou kategorii předvyplněnou z této (typ musí být unikátní — před uložením ho uprav)"
+                                   href="{{ path('oswis_org_oswis_calendar_web_admin_mail_category_new', { from: c.id }) }}">⧉ Kopie</a>
                             </td>
                         </tr>
                     {% else %}


### PR DESCRIPTION
Roční setup mailů jde nově naklikat v adminu (Kopie z loňska), formulář skupiny má okno OD/DO s varováním u automatiky, stráž duplicitního typu, updateSlug při založení. Kryto funkčním testem MailConfigCrudTest v app repu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144nYzkNgzGWoitFDNcQ2DT