### PR TITLE
feat(automail): dry-run náhled automailů (bezpečné ověření před rozesláním)

### DIFF
--- a/Command/SendMailCommand.php
+++ b/Command/SendMailCommand.php
@@ -100,7 +100,46 @@ final class SendMailCommand extends Command
                     ));
                 }
                 $io->writeln(sprintf('Pending bulků: %d, příjemců zbývá celkem: %d', count($pending), $totalRemaining));
-                $io->writeln($withAutomails ? 'Automaily: ZAPNUTO (běh by zpracoval aktivní automail skupiny).' : 'Automaily: vypnuto (--automails pro zapnutí).');
+
+                if ($withAutomails) {
+                    $io->section('Automaily (náhled — nic se neodešle)');
+                    $preview = $this->participantService->previewAutoMails(null, null, $automailLimit);
+                    if ([] === $preview) {
+                        $io->writeln('Žádná aktivní automail skupina (automaticMailing=1 a okno obsahuje teď).');
+                    } else {
+                        $totalRecipients = 0;
+                        foreach ($preview as $group) {
+                            $totalRecipients += $group['recipients'];
+                            $window = (null === $group['start'] && null === $group['end'])
+                                ? '⚠ bez okna (platí VŽDY)'
+                                : sprintf(
+                                    '%s – %s',
+                                    $group['start']?->format('j.n.Y H:i') ?? '−∞',
+                                    $group['end']?->format('j.n.Y H:i') ?? '∞',
+                                );
+                            $io->writeln(sprintf(
+                                '  • „%s" [%s] · akce: %s · okno: %s · obeslalo by %d%s příjemců',
+                                $group['name'],
+                                $group['type'] ?? '?',
+                                $group['event'] ?? '?',
+                                $window,
+                                $group['recipients'],
+                                $group['cappedAtLimit'] ? '+ (strop '.$automailLimit.'/skupinu)' : '',
+                            ));
+                            if (null !== $group['filterError']) {
+                                $io->writeln(sprintf('      ⚠ neplatný filtr → skupina by se PŘESKOČILA: %s', $group['filterError']));
+                            }
+                        }
+                        $io->writeln(sprintf(
+                            'Automaily by odeslaly celkem ~%d e-mailů z %d aktivních skupin (strop %d/skupinu).',
+                            $totalRecipients,
+                            count($preview),
+                            $automailLimit,
+                        ));
+                    }
+                } else {
+                    $io->writeln('Automaily: vypnuto (--automails pro zapnutí).');
+                }
 
                 return Command::SUCCESS;
             }

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -706,4 +706,65 @@ class ParticipantService
         return ['sent' => $sent, 'failed' => $failed, 'errors' => $errors];
     }
 
+    /**
+     * Dry-run counterpart to {@see sendAutoMails()} — reports, per active auto-mail group, how many
+     * recipients a real run would mail RIGHT NOW, WITHOUT sending anything. Mirrors the same selection
+     * (armed + in-window groups, recursive event scope, per-type unmailed dedup, and per-entity
+     * applicability incl. the filter expression) so the count is the real "if I flip it on now" number,
+     * capped at $limit exactly like the live run. Lets the team preview an armed campaign before enabling
+     * automaticMailing (empty window = applies always → a real run would send within one cron tick).
+     *
+     * @return list<array{name: string, type: string|null, event: string|null, start: ?\DateTimeInterface, end: ?\DateTimeInterface, filterError: ?string, recipients: int, cappedAtLimit: bool}>
+     */
+    public function previewAutoMails(?Event $event = null, ?string $type = null, int $limit = 100): array
+    {
+        $preview = [];
+        foreach ($this->participantMailService->getAutoMailGroups($event, $type) ?? new ArrayCollection() as $group) {
+            $groupEvent = $group->getEvent();
+            $groupType = $group->getType();
+            $filterError = $this->filterEvaluator->validate($group->getFilterExpression());
+            $recipients = 0;
+            if ($groupEvent instanceof Event && null !== $groupType && null === $filterError) {
+                $remaining = max(1, $limit);
+                $afterId = 0;
+                while ($remaining > 0) {
+                    $ids = $this->participantRepository->findUnmailedParticipantIds(
+                        $groupEvent,
+                        $groupType,
+                        max(1, $limit),
+                        4,
+                        !$group->isOnlyActive(),
+                        $afterId,
+                    );
+                    if ([] === $ids) {
+                        break;
+                    }
+                    foreach ($ids as $id) {
+                        $afterId = $id;
+                        $participant = $this->em->find(Participant::class, $id);
+                        if (!$participant instanceof Participant || !$group->isApplicable($participant)) {
+                            continue;
+                        }
+                        ++$recipients;
+                        if (--$remaining <= 0) {
+                            break;
+                        }
+                    }
+                }
+            }
+            $preview[] = [
+                'name'          => $group->getName() ?? '?',
+                'type'          => $groupType,
+                'event'         => $groupEvent?->getName() ?? $groupEvent?->getShortName(),
+                'start'         => $group->getStartDateTime(),
+                'end'           => $group->getEndDateTime(),
+                'filterError'   => $filterError,
+                'recipients'    => $recipients,
+                'cappedAtLimit' => $recipients >= max(1, $limit),
+            ];
+        }
+
+        return $preview;
+    }
+
 }

--- a/Service/Participant/ParticipantService.php
+++ b/Service/Participant/ParticipantService.php
@@ -742,7 +742,14 @@ class ParticipantService
                     foreach ($ids as $id) {
                         $afterId = $id;
                         $participant = $this->em->find(Participant::class, $id);
-                        if (!$participant instanceof Participant || !$group->isApplicable($participant)) {
+                        $applicable = $participant instanceof Participant && $group->isApplicable($participant);
+                        if ($participant instanceof Participant) {
+                            // Preview is read-only → detach each candidate so a high --automail-limit
+                            // scan can't accumulate the whole event in memory (the em->find loop is the
+                            // known automail OOM pattern; here it is safe to bound because we never write).
+                            $this->em->detach($participant);
+                        }
+                        if (!$applicable) {
                             continue;
                         }
                         ++$recipients;


### PR DESCRIPTION
## Proč
`oswis:mail:send --dry-run --automails` dosud o automail skupinách nevypsal **nic** — dry-run větev skončila early jen s poznámkou „Automaily: ZAPNUTO". Nešlo tedy **bezpečně ověřit**, koho by zapnutí ozbrojené kampaně (`automaticMailing=1`) reálně obeslalo. To je nejrizikovější operace systému (hromadná rozesílka reálným účastníkům), a automaily 2026 už jsou na produkci ozbrojené (auto=0, čekají na srpen).

## Co
- **`ParticipantService::previewAutoMails()`** — zrcadlí výběrovou logiku `sendAutoMails()` (ozbrojené + v okně skupiny, rekurzivní event scope, per-type unmailed dedup, per-entity applicability vč. filter expression), ale jen **počítá** příjemce a **nic neodesílá**. Strop = stejný `--automail-limit` jako ostrý běh.
- **`SendMailCommand` dry-run** teď per skupinu vypíše: typ, akci, **okno** (`⚠ bez okna (platí VŽDY)` když prázdné), počet příjemců (+ příznak stropu) a případný neplatný filtr (skupina by se přeskočila).

## Audit, ze kterého to vzešlo
Prošel jsem celý automail engine (command → `sendAutoMails` → `findAutoMailGroups` → `findUnmailedParticipantIds` → `sendMessage`/`countSent`). **Bez chyb:** okno v SQL i entity re-checku konzistentní a inkluzivní (null = vždy); dedup per-Participant per-type (`sent IS NOT NULL`) → vratší lidé mají nový Participant → dostanou mail; failed se retryne, úspěch se vyloučí (oba `sent IS NOT NULL`) → žádný double-send ani zaseknutí. Jediná díra byl chybějící náhled — tento PR.

## Ověření
- Naostro na klonu: dočasně ozbrojená skupina (ročník) → náhled ukázal `obeslalo by 100+ (strop 100/skupinu)` s rekurzí do turnusů → revert. Prázdná cesta i „bez okna" hláška OK.
- Funkční test (v appce, `feat/automail-dry-run-preview`) hlídá invariant **„náhled nic nepošle"** (počet ParticipantMail beze změny) + report ozbrojené skupiny.
- PHPStan max 0.

## Použití týmem (srpen)
`sudo -u web4 APP_ENV=prod symfony php bin/console oswis:mail:send --dry-run --automails --automail-limit=5000` → uvidí přesně, koho by zapnutí obeslalo, než nastaví `auto=1`.

Doprovod: **seznamovak-up/oswis-seznamovak-up#75** (funkční test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)