### PR TITLE
🔒 fix(security): admin controllery s PII/platbami vynucují ROLE_ADMIN

### DIFF
--- a/Controller/WebAdmin/AggregationsController.php
+++ b/Controller/WebAdmin/AggregationsController.php
@@ -6,8 +6,10 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Exception;
 use OswisOrg\OswisCalendarBundle\Service\Aggregations\AggregationsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\Response;
 
+#[IsGranted('ROLE_ADMIN')]
 class AggregationsController extends AbstractController
 {
     public function __construct(

--- a/Controller/WebAdmin/WebAdminParticipantPaymentsImportController.php
+++ b/Controller/WebAdmin/WebAdminParticipantPaymentsImportController.php
@@ -7,11 +7,13 @@ use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantPaymentsImport;
 use OswisOrg\OswisCalendarBundle\Form\Participant\ParticipantPaymentsImportType;
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantPaymentsImportService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[IsGranted('ROLE_ADMIN')]
 final class WebAdminParticipantPaymentsImportController extends AbstractController
 {
     public function __construct(

--- a/Controller/WebAdmin/WebAdminParticipantsListController.php
+++ b/Controller/WebAdmin/WebAdminParticipantsListController.php
@@ -34,6 +34,7 @@ use OswisOrg\OswisCoreBundle\Export\ExportResponseFactory;
 use OswisOrg\OswisCoreBundle\Service\ExportService;
 use OswisOrg\OswisCoreBundle\Utils\StringUtils;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,6 +55,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Volume: scoped views load the full set (full-export need, no pagination); unscoped views
  * default to pagination and offer an explicit "show all" with a warning.
  */
+#[IsGranted('ROLE_ADMIN')]
 class WebAdminParticipantsListController extends AbstractController
 {
     public const string FILTER_ALL               = 'all';

--- a/Controller/WebAdmin/WebAdminPaymentController.php
+++ b/Controller/WebAdmin/WebAdminPaymentController.php
@@ -13,10 +13,12 @@ use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantPaymentReposi
 use OswisOrg\OswisCalendarBundle\Service\Participant\ParticipantMailService;
 use OswisOrg\OswisCalendarBundle\Service\Participant\PaymentMatchingService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[IsGranted('ROLE_ADMIN')]
 class WebAdminPaymentController extends AbstractController
 {
     public function __construct(


### PR DESCRIPTION
Doprovod k **oswis-org/oswis-core-bundle#42** (access_control `^/web_admin` floor `ROLE_CUSTOMER` → `ROLE_MANAGER`).

Tyto 4 web-admin controllery neměly **žádný** `#[IsGranted]` a spoléhaly jen na (děravý) firewall floor → přidán class-level `#[IsGranted('ROLE_ADMIN')]` (defense-in-depth + správná granularita, shodně se sesterským `WebAdminParticipantsController`):

- `WebAdminParticipantsListController` — seznam VŠECH účastníků (osobní data)
- `WebAdminPaymentController` — platby
- `AggregationsController` — finanční agregace
- `WebAdminParticipantPaymentsImportController` — import plateb (zapisuje data)

**Ověřeno:** `WebAdminAuthorizationTest` (customer → 403) + `AdminSmokeTest` (admin → 200). PHPStan max 0.

⚠️ **Prioritní deploy** společně s core#42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)