### PR TITLE
feat(program): editor — přehledová stránka (slice 1)

### DIFF
--- a/ApiPlatform/EventVisibleToUserExtension.php
+++ b/ApiPlatform/EventVisibleToUserExtension.php
@@ -52,6 +52,15 @@ class EventVisibleToUserExtension implements QueryCollectionExtensionInterface, 
         }
         $participants = $this->participantService->getParticipants([ParticipantRepository::CRITERIA_APP_USER => $user]);
         $events = array_map(static fn (Participant $p) => $p->getEvent(), $participants->toArray());
+        // Program-release gate (žádost usera): účastník uvidí PROGRAMOVÝ podstrom turnusu jen když je
+        // program turnusu ZVEŘEJNĚN (Event::isProgramReleased — programReleasedAt nastaveno a už nastalo).
+        // Svůj turnus (a veřejné ročník/turnus) vidí vždy; program se staví skrytě a tým ho zveřejní až
+        // hotový a zkontrolovaný. Prázdné releasedIds → IN () nic nematchne → program skrytý.
+        $now = new \DateTime();
+        $releasedIds = array_values(array_filter(array_map(
+            static fn (?Event $e) => (null !== $e && $e->isProgramReleased($now)) ? $e->getId() : null,
+            $events,
+        )));
         $rootAlias = $queryBuilder->getRootAliases()[0];
         $queryBuilder
             ->leftJoin("$rootAlias.superEvent", 'superEvent')
@@ -59,24 +68,26 @@ class EventVisibleToUserExtension implements QueryCollectionExtensionInterface, 
         // A participant sees the whole PUBLIC program subtree of their turnus (blok → podakce → …),
         // not just direct children — so the app can render the full programme with foreign groups
         // dimmed. Internal services (publicInApp = false) stay hidden. Strictly ADDITIVE: walks the
-        // superEvent chain a few levels up and only WIDENS visibility to publicInApp=true events.
-        $ancestorConditions = ['superEvent IN (:user_event_ids)'];
+        // superEvent chain a few levels up and only WIDENS visibility to publicInApp=true events —
+        // ale jen u turnusů s VYDANÝM programem (:released_event_ids).
+        $ancestorConditions = ['superEvent IN (:released_event_ids)'];
         $prevAncestor = 'superEvent';
         for ($i = 2; $i <= 5; $i++) {
             $join = "ancestorEvt$i";
             $queryBuilder->leftJoin("$prevAncestor.superEvent", $join);
-            $ancestorConditions[] = "$join IN (:user_event_ids)";
+            $ancestorConditions[] = "$join IN (:released_event_ids)";
             $prevAncestor = $join;
         }
         $queryBuilder
             ->andWhere(sprintf(
                 '(%s.id IN (:user_event_ids)'
-                .' OR %s.superEvent IN (:user_event_ids)'
+                .' OR %s.superEvent IN (:released_event_ids)'
                 .' OR (%s.publicInApp = true AND visibilityCategory.type IN (:public_category_types))'
                 .' OR (%s.publicInApp = true AND (%s)))',
                 $rootAlias, $rootAlias, $rootAlias, $rootAlias, implode(' OR ', $ancestorConditions),
             ))
             ->setParameter('user_event_ids', array_map(static fn (?Event $event) => $event?->getId(), $events))
+            ->setParameter('released_event_ids', $releasedIds)
             ->setParameter('public_category_types', [EventCategory::YEAR_OF_EVENT, EventCategory::BATCH_OF_EVENT]);
     }
 

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -262,6 +262,13 @@ final class WebAdminProgramController extends AbstractController
 
                 return new RedirectResponse($pageUrl);
             }
+            // Scoping: přiřazovaný účastník i tým musí patřit do turnusu (POST id nesmí obejít scopované selecty).
+            if ($participant instanceof Participant) {
+                $this->assertBelongsToTurnus($turnus, $participant->getEvent());
+            }
+            if ($team instanceof StaffTeam) {
+                $this->assertBelongsToTurnus($turnus, $team->getEvent());
+            }
             $assignment = new EventStaffAssignment('' !== $externalName ? $externalName : null, '' !== $roleLabel ? $roleLabel : null);
             $assignment->setEvent($activity);
             if ($participant instanceof Participant) {
@@ -510,6 +517,8 @@ final class WebAdminProgramController extends AbstractController
         }
         $participant = $this->em->find(Participant::class, (int) $request->request->get('participant'));
         if ($participant instanceof Participant) {
+            // Scoping: přidávaný člen musí patřit do turnusu (POST id nesmí obejít scopovaný select).
+            $this->assertBelongsToTurnus($turnus, $participant->getEvent());
             $team->addMember($participant);
             $this->em->flush();
             $this->addFlash('success', 'Člen přidán do týmu.');

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -7,7 +7,9 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
+use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ProgramDayEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -127,6 +129,65 @@ final class WebAdminProgramController extends AbstractController
             'back_url'   => $backUrl,
             'pageTitle'  => 'Nová aktivita programu',
             'page_title' => 'Nová aktivita programu :: ADMIN',
+        ]);
+    }
+
+    /** Přidání dne programu (label + datum) do turnusu; datum seskupí aktivity v přehledu. */
+    public function newDay(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $day = new ProgramDay();
+        $day->setEvent($turnus);
+
+        return $this->handleDayForm($request, $eventSlug, $day, 'Nový den programu', 'Den přidán.');
+    }
+
+    /** Úprava dne programu. */
+    public function editDay(Request $request, string $eventSlug, int $dayId): Response
+    {
+        $this->resolveEvent($eventSlug);
+        $day = $this->em->find(ProgramDay::class, $dayId)
+            ?? throw $this->createNotFoundException("Den #$dayId nenalezen.");
+
+        return $this->handleDayForm($request, $eventSlug, $day, 'Upravit den programu', 'Den uložen.');
+    }
+
+    /** Smazání dne programu (aktivity zůstanou — jen se přestanou pod tento den seskupovat). */
+    public function deleteDay(Request $request, string $eventSlug, int $dayId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $day = $this->em->find(ProgramDay::class, $dayId)
+            ?? throw $this->createNotFoundException("Den #$dayId nenalezen.");
+        if (!$this->isCsrfTokenValid('program_day_delete_'.$dayId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $this->em->remove($day);
+        $this->em->flush();
+        $this->addFlash('warning', 'Den programu smazán.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]));
+    }
+
+    private function handleDayForm(Request $request, string $eventSlug, ProgramDay $day, string $title, string $flash): Response
+    {
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+        $form = $this->createForm(ProgramDayEditType::class, $day);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (empty($day->getSlug())) {
+                $day->updateSlug();
+            }
+            $this->em->persist($day);
+            $this->em->flush();
+            $this->addFlash('success', $flash);
+
+            return new RedirectResponse($backUrl);
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/day_edit.html.twig', [
+            'form'      => $form,
+            'back_url'  => $backUrl,
+            'pageTitle' => $title,
         ]);
     }
 

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -7,6 +7,7 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventGroup;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventSection;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
@@ -547,6 +548,114 @@ final class WebAdminProgramController extends AbstractController
         return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_teams', ['eventSlug' => $eventSlug]));
     }
 
+    /**
+     * Série programu (spec: EventGroup type='program-series' + `sameActivity`; přehled čísluje
+     * sameActivity série římsky). EventGroup NEMÁ vazbu na turnus → série se zakládá rovnou z
+     * VYBRANÝCH aktivit turnusu (rodí se se svými akcemi → je vždy vázaná na turnus přes ně, žádná
+     * prázdná dvojznačná série, žádný cross-turnus). Přiřazení je scopované (každá akce ověřena).
+     * ⚠️ Záměrně NE přes sdílený EventEditType (ročníky mají brand-série → filtrovaný select by je smazal).
+     */
+    public function series(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $seriesUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_series', ['eventSlug' => $eventSlug]);
+
+        if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('program_series_create_'.$turnus->getId(), (string) $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException('Neplatný CSRF token.');
+            }
+            $name = trim((string) $request->request->get('name'));
+            $sameActivity = $request->request->getBoolean('sameActivity');
+            $validActs = [];
+            foreach ($request->request->all('activities') as $rawId) {
+                if (!is_numeric($rawId)) {
+                    continue;
+                }
+                $act = $this->em->find(Event::class, (int) $rawId);
+                if ($act instanceof Event && $this->isUnderTurnus($turnus->getId(), $act)) {
+                    $validActs[] = $act;
+                }
+            }
+            if (count($validActs) < 2) {
+                $this->addFlash('danger', 'Vyber aspoň dvě aktivity z tohoto turnusu.');
+
+                return new RedirectResponse($seriesUrl);
+            }
+            $group = new EventGroup();
+            $group->setName('' !== $name ? $name : 'Série');
+            $group->setType('program-series');
+            $group->setSameActivity($sameActivity);
+            if (empty($group->getSlug())) {
+                $group->updateSlug();
+            }
+            $this->em->persist($group);
+            foreach ($validActs as $act) {
+                $act->setGroup($group);
+            }
+            $this->em->flush();
+            $this->addFlash('success', 'Série vytvořena.');
+
+            return new RedirectResponse($seriesUrl);
+        }
+
+        $activities = [];
+        $seriesMap = [];
+        foreach ($turnus->getSubEvents() as $act) {
+            $g = $act->getGroup();
+            $gid = ($g instanceof EventGroup && 'program-series' === $g->getType()) ? $g->getId() : null;
+            $activities[] = ['id' => $act->getId(), 'name' => $act->getName(), 'start' => $act->getStartDateTimeRecursive()?->format('j.n. H:i'), 'seriesId' => $gid];
+            if (null !== $gid && $g instanceof EventGroup) {
+                $seriesMap[$gid] ??= ['id' => $gid, 'name' => $g->getName() ?? ('#'.$gid), 'sameActivity' => $g->isSameActivity(), 'activities' => []];
+                $seriesMap[$gid]['activities'][] = $act->getName();
+            }
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/series.html.twig', [
+            'eventSlug'  => $eventSlug,
+            'turnusId'   => $turnus->getId(),
+            'activities' => $activities,
+            'series'     => array_values($seriesMap),
+            'back_url'   => $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]),
+        ]);
+    }
+
+    /** Zrušení série (rozpustí ji — akcím se vymaže group; EventGroup se smaže). */
+    public function deleteSeries(Request $request, string $eventSlug, int $seriesId): RedirectResponse
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $group = $this->em->find(EventGroup::class, $seriesId) ?? throw $this->createNotFoundException("Série #$seriesId nenalezena.");
+        $this->assertSeriesBelongsToTurnus($turnus, $group);
+        if (!$this->isCsrfTokenValid('program_series_delete_'.$seriesId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        foreach ($group->getEvents() as $ev) {
+            if ($ev instanceof Event) {
+                $ev->setGroup(null);
+            }
+        }
+        $this->em->remove($group);
+        $this->em->flush();
+        $this->addFlash('warning', 'Série zrušena.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_series', ['eventSlug' => $eventSlug]));
+    }
+
+    /** Odebrání jedné aktivity ze série (vymaže její group). */
+    public function removeSeriesActivity(Request $request, string $eventSlug, int $activityId): RedirectResponse
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $activity = $this->em->find(Event::class, $activityId) ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $activity);
+        if (!$this->isCsrfTokenValid('program_series_remove_'.$activityId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $activity->setGroup(null);
+        $this->em->flush();
+        $this->addFlash('warning', 'Aktivita odebrána ze série.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_series', ['eventSlug' => $eventSlug]));
+    }
+
     private function resolveEvent(string $eventSlug): Event
     {
         return $this->eventRepository->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug])
@@ -558,15 +667,33 @@ final class WebAdminProgramController extends AbstractController
      * přes `{eventSlug}` jednoho turnusu manipulovat s entitou jiného (IDOR). `$event` je buď entita
      * sama (aktivita = Event, chodíme po superEvent řetězci), nebo její `getEvent()` (den/sekce/tým).
      */
-    private function assertBelongsToTurnus(Event $turnus, ?Event $event, int $depth = 6): void
+    private function isUnderTurnus(?int $turnusId, ?Event $event, int $depth = 6): bool
     {
-        $turnusId = $turnus->getId();
         for ($i = 0; $i <= $depth && null !== $event; $i++) {
             if (null !== $turnusId && $event->getId() === $turnusId) {
-                return;
+                return true;
             }
             $event = $event->getSuperEvent();
         }
-        throw $this->createNotFoundException('Položka nepatří do tohoto turnusu.');
+
+        return false;
+    }
+
+    private function assertBelongsToTurnus(Event $turnus, ?Event $event, int $depth = 6): void
+    {
+        if (!$this->isUnderTurnus($turnus->getId(), $event, $depth)) {
+            throw $this->createNotFoundException('Položka nepatří do tohoto turnusu.');
+        }
+    }
+
+    /** Série (EventGroup nemá vazbu na turnus) patří k turnusu, když aspoň jedna její akce je pod turnusem. */
+    private function assertSeriesBelongsToTurnus(Event $turnus, EventGroup $series): void
+    {
+        foreach ($series->getEvents() as $ev) {
+            if ($ev instanceof Event && $this->isUnderTurnus($turnus->getId(), $ev)) {
+                return;
+            }
+        }
+        throw $this->createNotFoundException('Série nepatří do tohoto turnusu.');
     }
 }

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -26,6 +31,7 @@ final class WebAdminProgramController extends AbstractController
     public function __construct(
         private readonly ProgramDataService $programData,
         private readonly EventRepository $eventRepository,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 
@@ -38,6 +44,47 @@ final class WebAdminProgramController extends AbstractController
             'eventSlug' => $eventSlug,
             'tree'      => $this->programData->getProgramTree($turnus),
             'sections'  => $this->programData->getSections($turnus, false),
+        ]);
+    }
+
+    /**
+     * Úprava jedné aktivity (= pod-událost) z editoru programu. Reuse {@see EventEditType} +
+     * {@see WebAdminEventController::edit} vzoru (start/end jsou v formuláři nemapované, přiřadí se
+     * ručně). Po uložení zpět na přehled programu (back_url), ne na obecnou stránku události.
+     */
+    public function editActivity(Request $request, string $eventSlug, int $activityId): Response
+    {
+        $this->resolveEvent($eventSlug); // 404 když turnus neexistuje
+        $activity = $this->em->find(Event::class, $activityId)
+            ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+
+        $form = $this->createForm(EventEditType::class, $activity);
+        $form->get('startDate')->setData($activity->getStartDateTime());
+        $form->get('endDate')->setData($activity->getEndDateTime());
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $start = $form->get('startDate')->getData();
+            $end = $form->get('endDate')->getData();
+            if ($start instanceof DateTime) {
+                $activity->setStartDateTime($start);
+            }
+            if ($end instanceof DateTime) {
+                $activity->setEndDateTime($end);
+            }
+            $this->em->flush();
+            $this->addFlash('success', sprintf('Aktivita „%s" uložena.', $activity->getName() ?? ''));
+
+            return new RedirectResponse($backUrl);
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/event_edit.html.twig', [
+            'event'     => $activity,
+            'form'      => $form,
+            'back_url'  => $backUrl,
+            'pageTitle' => sprintf('Upravit aktivitu: %s', $activity->getName() ?? ''),
+            'page_title' => sprintf('Upravit aktivitu: %s :: ADMIN', $activity->getName() ?? ''),
         ]);
     }
 

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -11,12 +11,15 @@ use OswisOrg\OswisCalendarBundle\Entity\Event\EventSection;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\StaffTeam;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventSectionEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ProgramDayEditType;
+use OswisOrg\OswisCalendarBundle\Form\WebAdmin\StaffTeamEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventStaffAssignmentRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\StaffTeamRepository;
 use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
 use OswisOrg\OswisCalendarBundle\State\EventDuplicateProcessor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -44,7 +47,34 @@ final class WebAdminProgramController extends AbstractController
         private readonly EventStaffAssignmentRepository $assignmentRepository,
         private readonly ParticipantRepository $participantRepository,
         private readonly EventDuplicateProcessor $duplicateProcessor,
+        private readonly StaffTeamRepository $teamRepository,
     ) {
+    }
+
+    /**
+     * Staff okruh turnusu pro obsazení / členství týmů = účastníci turnusu mimo běžné „attendee"
+     * (organizer/staff/manager…). CRITERIA_PARTICIPANT_TYPE bere jen jeden typ, tak sloučíme přes typy.
+     *
+     * @return list<array{id: int|null, name: string}>
+     */
+    private function staffPool(Event $turnus): array
+    {
+        $pool = [];
+        foreach (['organizer', 'staff', 'manager'] as $type) {
+            foreach ($this->participantRepository->getParticipants([
+                ParticipantRepository::CRITERIA_EVENT                 => $turnus,
+                ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 3,
+                ParticipantRepository::CRITERIA_PARTICIPANT_TYPE      => $type,
+            ]) as $p) {
+                if ($p instanceof Participant && null !== $p->getId()) {
+                    $pool[$p->getId()] = ['id' => $p->getId(), 'name' => $this->programData->staffName($p)];
+                }
+            }
+        }
+        $pool = array_values($pool);
+        usort($pool, static fn (array $a, array $b): int => strcoll($a['name'], $b['name']));
+
+        return $pool;
     }
 
     public function index(string $eventSlug): Response
@@ -220,9 +250,11 @@ final class WebAdminProgramController extends AbstractController
             $participantId = (int) $request->request->get('participant');
             $externalName = trim((string) $request->request->get('externalName'));
             $roleLabel = trim((string) $request->request->get('roleLabel'));
+            $teamId = (int) $request->request->get('team');
             $participant = $participantId > 0 ? $this->em->find(Participant::class, $participantId) : null;
-            if (!$participant instanceof Participant && '' === $externalName) {
-                $this->addFlash('danger', 'Vyber člověka ze seznamu, nebo zadej externí jméno.');
+            $team = $teamId > 0 ? $this->em->find(StaffTeam::class, $teamId) : null;
+            if (!$participant instanceof Participant && '' === $externalName && !$team instanceof StaffTeam) {
+                $this->addFlash('danger', 'Vyber člověka, tým, nebo zadej externí jméno.');
 
                 return new RedirectResponse($pageUrl);
             }
@@ -230,6 +262,9 @@ final class WebAdminProgramController extends AbstractController
             $assignment->setEvent($activity);
             if ($participant instanceof Participant) {
                 $assignment->setParticipant($participant);
+            }
+            if ($team instanceof StaffTeam) {
+                $assignment->setTeam($team);
             }
             $this->em->persist($assignment);
             $this->em->flush();
@@ -241,30 +276,35 @@ final class WebAdminProgramController extends AbstractController
         $assignments = [];
         foreach ($this->assignmentRepository->getByEvent($activity) as $a) {
             $participant = $a->getParticipant();
+            $team = $a->getTeam();
+            if ($participant instanceof Participant) {
+                $name = $this->programData->staffName($participant);
+                $kind = 'person';
+            } elseif ($team instanceof StaffTeam) {
+                $name = 'Tým: '.($team->getName() ?? '?');
+                $kind = 'team';
+            } else {
+                $name = (string) $a->getExternalName();
+                $kind = 'external';
+            }
             $assignments[] = [
                 'id'        => $a->getId(),
-                'name'      => $participant instanceof Participant ? $this->programData->staffName($participant) : (string) $a->getExternalName(),
+                'name'      => $name,
                 'roleLabel' => $a->getRoleLabel(),
-                'external'  => !$participant instanceof Participant,
+                'kind'      => $kind,
             ];
         }
-        $staffPool = [];
-        foreach ($this->participantRepository->getParticipants([
-            ParticipantRepository::CRITERIA_EVENT                 => $turnus,
-            ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 3,
-            ParticipantRepository::CRITERIA_PARTICIPANT_TYPE      => 'staff',
-        ]) as $p) {
-            if ($p instanceof Participant) {
-                $staffPool[] = ['id' => $p->getId(), 'name' => $this->programData->staffName($p)];
-            }
+        $teams = [];
+        foreach ($this->teamRepository->getByEvent($turnus) as $t) {
+            $teams[] = ['id' => $t->getId(), 'name' => $t->getName() ?? ('#'.$t->getId())];
         }
-        usort($staffPool, static fn (array $a, array $b): int => strcoll($a['name'], $b['name']));
 
         return $this->render('@OswisOrgOswisCalendar/web_admin/program/activity_staff.html.twig', [
             'eventSlug'   => $eventSlug,
             'activity'    => $activity,
             'assignments' => $assignments,
-            'staffPool'   => $staffPool,
+            'staffPool'   => $this->staffPool($turnus),
+            'teams'       => $teams,
             'back_url'    => $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]),
         ]);
     }
@@ -392,6 +432,99 @@ final class WebAdminProgramController extends AbstractController
         $this->em->flush();
 
         return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]));
+    }
+
+    /**
+     * Týmy/podtýmy turnusu (spec: StaffTeam per turnus, M2M členství). Seznam + založení + správa
+     * členů; přiřazení týmu k aktivitě je v obsazení ({@see activityStaff}).
+     */
+    public function teams(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+        $teamsUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_teams', ['eventSlug' => $eventSlug]);
+
+        $newTeam = new StaffTeam();
+        $newTeam->setEvent($turnus);
+        $form = $this->createForm(StaffTeamEditType::class, $newTeam);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (empty($newTeam->getSlug())) {
+                $newTeam->updateSlug();
+            }
+            $this->em->persist($newTeam);
+            $this->em->flush();
+            $this->addFlash('success', 'Tým vytvořen.');
+
+            return new RedirectResponse($teamsUrl);
+        }
+
+        $teams = [];
+        foreach ($this->teamRepository->getByEvent($turnus) as $t) {
+            $members = [];
+            foreach ($t->getMembers() as $m) {
+                $members[] = ['id' => $m->getId(), 'name' => $this->programData->staffName($m)];
+            }
+            $teams[] = ['id' => $t->getId(), 'name' => $t->getName() ?? ('#'.$t->getId()), 'members' => $members];
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/teams.html.twig', [
+            'eventSlug' => $eventSlug,
+            'teams'     => $teams,
+            'staffPool' => $this->staffPool($turnus),
+            'form'      => $form,
+            'back_url'  => $backUrl,
+        ]);
+    }
+
+    public function deleteTeam(Request $request, string $eventSlug, int $teamId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        if (!$this->isCsrfTokenValid('program_team_delete_'.$teamId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $this->em->remove($team);
+        $this->em->flush();
+        $this->addFlash('warning', 'Tým smazán.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_teams', ['eventSlug' => $eventSlug]));
+    }
+
+    public function addTeamMember(Request $request, string $eventSlug, int $teamId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        if (!$this->isCsrfTokenValid('program_team_member_'.$teamId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $participant = $this->em->find(Participant::class, (int) $request->request->get('participant'));
+        if ($participant instanceof Participant) {
+            $team->addMember($participant);
+            $this->em->flush();
+            $this->addFlash('success', 'Člen přidán do týmu.');
+        } else {
+            $this->addFlash('danger', 'Vyber člověka ze seznamu.');
+        }
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_teams', ['eventSlug' => $eventSlug]));
+    }
+
+    public function removeTeamMember(Request $request, string $eventSlug, int $teamId, int $participantId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        if (!$this->isCsrfTokenValid('program_team_member_remove_'.$teamId.'_'.$participantId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $participant = $this->em->find(Participant::class, $participantId);
+        if ($participant instanceof Participant) {
+            $team->removeMember($participant);
+            $this->em->flush();
+            $this->addFlash('warning', 'Člen odebrán z týmu.');
+        }
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_teams', ['eventSlug' => $eventSlug]));
     }
 
     private function resolveEvent(string $eventSlug): Event

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
+
+use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
+use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Program editor ve web adminu (spec `docs/superpowers/specs/2026-06-12-program-module-design.md`, krok 8) —
+ * KROK 1: přehledová stránka `/web_admin/program/{eventSlug}`, na kterou se v dalších slicech navěsí
+ * blbuvzdorné formuláře (přidat/upravit/duplikovat den, aktivitu, sekci). Editace = manažerská role
+ * (spec: „edit práva vázat na manažerskou roli; běžný člen týmu = čtení + svůj itinerář").
+ *
+ * Data z {@see ProgramDataService} (read-only pole, ne entity do šablony — per turnus, malý graf).
+ * Zápisové operace už existují jako API (STOPA 1.2, calendar v0.2.49), editor je jejich klient.
+ */
+#[IsGranted('ROLE_MANAGER')]
+final class WebAdminProgramController extends AbstractController
+{
+    public function __construct(
+        private readonly ProgramDataService $programData,
+        private readonly EventRepository $eventRepository,
+    ) {
+    }
+
+    public function index(string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/index.html.twig', [
+            'event'     => $turnus,
+            'eventSlug' => $eventSlug,
+            'tree'      => $this->programData->getProgramTree($turnus),
+            'sections'  => $this->programData->getSections($turnus, false),
+        ]);
+    }
+
+    private function resolveEvent(string $eventSlug): Event
+    {
+        return $this->eventRepository->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug])
+            ?? throw $this->createNotFoundException("Turnus '$eventSlug' nenalezen.");
+    }
+}

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -88,6 +88,48 @@ final class WebAdminProgramController extends AbstractController
         ]);
     }
 
+    /**
+     * Přidání nové aktivity (pod-události) do turnusu z editoru programu. Nová událost dostane
+     * `superEvent = turnus`; slug se odvodí z názvu, když ho uživatel nevyplní (žádný listener
+     * ho negeneruje — viz feedback_app). Po uložení zpět na přehled programu.
+     */
+    public function newActivity(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $activity = new Event(superEvent: $turnus);
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+
+        $form = $this->createForm(EventEditType::class, $activity);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $start = $form->get('startDate')->getData();
+            $end = $form->get('endDate')->getData();
+            if ($start instanceof DateTime) {
+                $activity->setStartDateTime($start);
+            }
+            if ($end instanceof DateTime) {
+                $activity->setEndDateTime($end);
+            }
+            if (empty($activity->getSlug())) {
+                $activity->updateSlug();
+            }
+            $this->em->persist($activity);
+            $this->em->flush();
+            $this->addFlash('success', sprintf('Aktivita „%s" přidána do programu.', $activity->getName() ?? ''));
+
+            return new RedirectResponse($backUrl);
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/event_edit.html.twig', [
+            'event'      => $activity,
+            'form'       => $form,
+            'back_url'   => $backUrl,
+            'pageTitle'  => 'Nová aktivita programu',
+            'page_title' => 'Nová aktivita programu :: ADMIN',
+        ]);
+    }
+
     private function resolveEvent(string $eventSlug): Event
     {
         return $this->eventRepository->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug])

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -366,6 +366,34 @@ final class WebAdminProgramController extends AbstractController
         ));
     }
 
+    /**
+     * Zveřejnění / skrytí PROGRAMU turnusu účastníkům (žádost usera): přepne `programReleasedAt` na
+     * turnusu. Skrytý program se staví a účastníci ho v aplikaci nevidí; tým ho zveřejní až hotový a
+     * zkontrolovaný. Brána: {@see \OswisOrg\OswisCalendarBundle\ApiPlatform\EventVisibleToUserExtension}.
+     */
+    public function toggleProgramRelease(Request $request, string $eventSlug): RedirectResponse
+    {
+        // Přes em->find (ne getEvent/DQL) — entita z DQL query se s L2 NONSTRICT cache spolehlivě
+        // netrackovala pro dirty-update a flush nic nezapsal; find vrátí managed instanci.
+        $turnusId = $this->resolveEvent($eventSlug)->getId();
+        $turnus = $this->em->find(Event::class, $turnusId)
+            ?? throw $this->createNotFoundException("Turnus '$eventSlug' nenalezen.");
+        if (!$this->isCsrfTokenValid('program_release_'.$turnusId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        if ($turnus->isProgramReleased()) {
+            $turnus->setProgramReleasedAt(null);
+            $this->addFlash('warning', 'Program SKRYT — účastníci ho v aplikaci nevidí.');
+        } else {
+            $turnus->setProgramReleasedAt(new DateTime());
+            $this->addFlash('success', 'Program ZVEŘEJNĚN účastníkům.');
+        }
+        $this->em->persist($turnus);
+        $this->em->flush();
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]));
+    }
+
     private function resolveEvent(string $eventSlug): Event
     {
         return $this->eventRepository->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug])

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -7,12 +7,15 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventCategory;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventGroup;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventSection;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantGroup;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\StaffTeam;
+use OswisOrg\OswisCoreBundle\Entity\NonPersistent\Nameable;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventSectionEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ProgramDayEditType;
@@ -78,6 +81,89 @@ final class WebAdminProgramController extends AbstractController
         return $pool;
     }
 
+    /**
+     * Pásky (ParticipantGroup) pro rotační sloty — hledáme na turnusu i jeho nadřazených událostech
+     * (ročník), protože skupiny mohou být definované na rodiči (viz reference_flag_groups_belong_to_parent_offer).
+     * 0 pásků = prázdná nabídka (datový úkol týmu); pole targetGroup je code-ready, ne rozbité.
+     *
+     * @return list<ParticipantGroup>
+     */
+    private function paseks(Event $turnus): array
+    {
+        $events = [];
+        $event = $turnus;
+        for ($i = 0; $i < 6 && null !== $event; $i++) {
+            if (null !== $event->getId()) {
+                $events[] = $event;
+            }
+            $event = $event->getSuperEvent();
+        }
+        if ([] === $events) {
+            return [];
+        }
+
+        /** @var list<ParticipantGroup> $groups */
+        $groups = $this->em->getRepository(ParticipantGroup::class)
+            ->createQueryBuilder('g')
+            ->andWhere('g.event IN (:events)')
+            ->setParameter('events', $events)
+            ->orderBy('g.mealOrder', 'ASC')
+            ->addOrderBy('g.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $groups;
+    }
+
+    /**
+     * Kategorie „blok programu" ({@see EventCategory::PROGRAM_BLOCK}) — je naseedovaná; defenzivně ji
+     * založíme, kdyby na cílovém prostředí chyběla, ať vytvoření bloku nespadne.
+     */
+    private function resolveBlockCategory(): EventCategory
+    {
+        $category = $this->em->getRepository(EventCategory::class)
+            ->findOneBy(['type' => EventCategory::PROGRAM_BLOCK]);
+        if ($category instanceof EventCategory) {
+            return $category;
+        }
+        $category = new EventCategory(new Nameable('Blok programu'), EventCategory::PROGRAM_BLOCK, '#6c757d');
+        $this->em->persist($category);
+        $this->em->flush();
+
+        return $category;
+    }
+
+    /**
+     * Aktivní bloky (nadakce s kategorií program-block) turnusu — nabídka pro přiřazení/přesun aktivity
+     * pod blok v editačním formuláři.
+     *
+     * @return list<Event>
+     */
+    private function turnusBlocks(Event $turnus): array
+    {
+        $blocks = [];
+        foreach ($turnus->getSubEvents() as $sub) {
+            if (null === $sub->getDeletedAt()
+                && EventCategory::PROGRAM_BLOCK === $sub->getCategory()?->getType()) {
+                $blocks[] = $sub;
+            }
+        }
+
+        return $blocks;
+    }
+
+    /** Má událost aspoň jednu NEsmazanou podakci? (nadakce/blok → nesmí se vnořit do jiného bloku.) */
+    private function hasActiveSubEvents(Event $event): bool
+    {
+        foreach ($event->getSubEvents() as $sub) {
+            if (null === $sub->getDeletedAt()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function index(string $eventSlug): Response
     {
         $turnus = $this->resolveEvent($eventSlug);
@@ -103,24 +189,40 @@ final class WebAdminProgramController extends AbstractController
         $this->assertBelongsToTurnus($turnus, $activity);
         $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
 
-        $form = $this->createForm(EventEditType::class, $activity);
+        $form = $this->createForm(EventEditType::class, $activity, [
+            'groups' => $this->paseks($turnus),
+            'blocks' => $this->turnusBlocks($turnus),
+        ]);
         $form->get('startDate')->setData($activity->getStartDateTime());
         $form->get('endDate')->setData($activity->getEndDateTime());
+        $currentParent = $activity->getSuperEvent();
+        if (null !== $currentParent && EventCategory::PROGRAM_BLOCK === $currentParent->getCategory()?->getType()) {
+            $form->get('parentBlock')->setData($currentParent); // předvyplní aktuální blok, když je aktivita slotem
+        }
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $start = $form->get('startDate')->getData();
-            $end = $form->get('endDate')->getData();
-            if ($start instanceof DateTime) {
-                $activity->setStartDateTime($start);
-            }
-            if ($end instanceof DateTime) {
-                $activity->setEndDateTime($end);
-            }
-            $this->em->flush();
-            $this->addFlash('success', sprintf('Aktivita „%s" uložena.', $activity->getName() ?? ''));
+            // Přesun do/z bloku: nadakci (je program-block nebo má podakce) NELZE vnořit do bloku (MaxDepth 3).
+            $targetBlock = $form->get('parentBlock')->getData();
+            $nadakceIntoBlock = $targetBlock instanceof Event
+                && (EventCategory::PROGRAM_BLOCK === $activity->getCategory()?->getType() || $this->hasActiveSubEvents($activity));
+            if ($nadakceIntoBlock) {
+                $this->addFlash('danger', 'Blok/nadakci nelze vložit do jiného bloku (má vlastní podakce). Změna neuložena.');
+            } else {
+                $start = $form->get('startDate')->getData();
+                $end = $form->get('endDate')->getData();
+                if ($start instanceof DateTime) {
+                    $activity->setStartDateTime($start);
+                }
+                if ($end instanceof DateTime) {
+                    $activity->setEndDateTime($end);
+                }
+                $activity->setSuperEvent($targetBlock instanceof Event ? $targetBlock : $turnus);
+                $this->em->flush();
+                $this->addFlash('success', sprintf('Aktivita „%s" uložena.', $activity->getName() ?? ''));
 
-            return new RedirectResponse($backUrl);
+                return new RedirectResponse($backUrl);
+            }
         }
 
         return $this->render('@OswisOrgOswisCalendar/web_admin/event_edit.html.twig', [
@@ -136,14 +238,31 @@ final class WebAdminProgramController extends AbstractController
      * Přidání nové aktivity (pod-události) do turnusu z editoru programu. Nová událost dostane
      * `superEvent = turnus`; slug se odvodí z názvu, když ho uživatel nevyplní (žádný listener
      * ho negeneruje — viz feedback_app). Po uložení zpět na přehled programu.
+     *
+     * Volitelný `?block={id}` zakládá aktivitu jako PODAKCI bloku (rotační slot) — `superEvent = blok`
+     * místo turnusu. Blok musí patřit do turnusu (IDOR guard přes {@see assertBelongsToTurnus}).
      */
     public function newActivity(Request $request, string $eventSlug): Response
     {
         $turnus = $this->resolveEvent($eventSlug);
+        $block = null;
+        $blockId = $request->query->get('block');
+        if (is_numeric($blockId)) {
+            $block = $this->em->find(Event::class, (int) $blockId)
+                ?? throw $this->createNotFoundException("Blok #$blockId nenalezen.");
+            $this->assertBelongsToTurnus($turnus, $block);
+        }
+        // superEvent řídí pole parentBlock (předvyplněné z ?block); default = turnus.
         $activity = new Event(superEvent: $turnus);
         $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
 
-        $form = $this->createForm(EventEditType::class, $activity);
+        $form = $this->createForm(EventEditType::class, $activity, [
+            'groups' => $this->paseks($turnus),
+            'blocks' => $this->turnusBlocks($turnus),
+        ]);
+        if (null !== $block) {
+            $form->get('parentBlock')->setData($block);
+        }
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -158,9 +277,13 @@ final class WebAdminProgramController extends AbstractController
             if (empty($activity->getSlug())) {
                 $activity->updateSlug();
             }
+            $targetBlock = $form->get('parentBlock')->getData();
+            $activity->setSuperEvent($targetBlock instanceof Event ? $targetBlock : $turnus);
             $this->em->persist($activity);
             $this->em->flush();
-            $this->addFlash('success', sprintf('Aktivita „%s" přidána do programu.', $activity->getName() ?? ''));
+            $this->addFlash('success', $targetBlock instanceof Event
+                ? sprintf('Podakce „%s" přidána do bloku „%s".', $activity->getName() ?? '', $targetBlock->getName() ?? '')
+                : sprintf('Aktivita „%s" přidána do programu.', $activity->getName() ?? ''));
 
             return new RedirectResponse($backUrl);
         }
@@ -169,8 +292,57 @@ final class WebAdminProgramController extends AbstractController
             'event'      => $activity,
             'form'       => $form,
             'back_url'   => $backUrl,
-            'pageTitle'  => 'Nová aktivita programu',
+            'pageTitle'  => null !== $block
+                ? sprintf('Nová podakce bloku: %s', $block->getName() ?? '')
+                : 'Nová aktivita programu',
             'page_title' => 'Nová aktivita programu :: ADMIN',
+        ]);
+    }
+
+    /**
+     * Vytvoření BLOKU programu (nadakce) — Event s kategorií `program-block`, `superEvent = turnus`,
+     * vlastní čas NULL (odvozuje se z podakcí přes rekurzivní gettery). Blok sdružuje rotační sloty
+     * (aktivita×pásek×čas) nebo série; podakce se do něj přidají tlačítkem „+ podakce"
+     * (= newActivity s `?block`). Spec 2.2: „Vytvořit blok s podakcemi", blbuvzdorné, čas odvozený.
+     */
+    public function newBlock(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+
+        if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('program_block_new_'.($turnus->getId() ?? 0), (string) $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException('Neplatný CSRF token.');
+            }
+            $name = trim((string) $request->request->get('name'));
+            if ('' === $name) {
+                $this->addFlash('danger', 'Zadej název bloku (např. „Dopolední rotace stanovišť").');
+
+                return new RedirectResponse($this->generateUrl(
+                    'oswis_org_oswis_calendar_web_admin_program_block_new',
+                    ['eventSlug' => $eventSlug],
+                ));
+            }
+            $block = new Event(superEvent: $turnus);
+            $block->setName($name);
+            $block->setCategory($this->resolveBlockCategory());
+            $block->updateSlug();
+            $this->em->persist($block);
+            $this->em->flush();
+            $this->addFlash('success', sprintf(
+                'Blok „%s" vytvořen — teď do něj přidej podakce tlačítkem „+ podakce".',
+                $name,
+            ));
+
+            return new RedirectResponse($backUrl);
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/block_new.html.twig', [
+            'eventSlug'  => $eventSlug,
+            'turnusId'   => $turnus->getId(),
+            'back_url'   => $backUrl,
+            'pageTitle'  => 'Nový blok programu',
+            'page_title' => 'Nový blok programu :: ADMIN',
         ]);
     }
 
@@ -420,6 +592,48 @@ final class WebAdminProgramController extends AbstractController
             'oswis_org_oswis_calendar_web_admin_program_activity_edit',
             ['eventSlug' => $eventSlug, 'activityId' => $clone->getId()],
         ));
+    }
+
+    /**
+     * Smazání aktivity (pod-události) z programu — SOFT delete přes `setDeletedAt` (Event NENÍ Gedmo
+     * SoftDeleteable; `em->remove` by ho smazal natvrdo a spadl na FK, kdyby měl obsazení/přihlášky).
+     * Soft-delete zachová vazby (obsazení, přihlášky), je vratné v DB, a `getProgramTree` smazané
+     * odfiltruje → z programu i výstupů zmizí. BLOK se maže i s podakcemi (celá rotace); kaskáda
+     * projde celý podstrom. IDOR: aktivita musí patřit do turnusu. Spec: „potvrzení u mazání".
+     */
+    public function deleteActivity(Request $request, string $eventSlug, int $activityId): RedirectResponse
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $activity = $this->em->find(Event::class, $activityId)
+            ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $activity);
+        if (!$this->isCsrfTokenValid('program_activity_delete_'.$activityId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+
+        // Podstrom (podakce bloku…) → soft-delete i děti, ať nezůstanou osiřelé pod smazaným blokem.
+        $descendants = [];
+        $stack = [$activity];
+        for ($guard = 0; [] !== $stack && $guard < 500; $guard++) {
+            $node = array_pop($stack);
+            foreach ($node->getSubEvents() as $sub) {
+                $descendants[] = $sub;
+                $stack[] = $sub;
+            }
+        }
+        $name = $activity->getName() ?? '';
+        $now = new DateTime();
+        foreach ($descendants as $child) {
+            $child->setDeletedAt($now);
+        }
+        $activity->setDeletedAt($now);
+        $this->em->flush();
+
+        $this->addFlash('warning', [] !== $descendants
+            ? sprintf('Blok „%s" smazán i s %d podakcemi (skryt z programu).', $name, count($descendants))
+            : sprintf('Aktivita „%s" smazána (skryta z programu).', $name));
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]));
     }
 
     /**

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -18,6 +18,7 @@ use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventStaffAssignmentRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
+use OswisOrg\OswisCalendarBundle\State\EventDuplicateProcessor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +43,7 @@ final class WebAdminProgramController extends AbstractController
         private readonly EntityManagerInterface $em,
         private readonly EventStaffAssignmentRepository $assignmentRepository,
         private readonly ParticipantRepository $participantRepository,
+        private readonly EventDuplicateProcessor $duplicateProcessor,
     ) {
     }
 
@@ -340,6 +342,28 @@ final class WebAdminProgramController extends AbstractController
             'back_url'  => $backUrl,
             'pageTitle' => $title,
         ]);
+    }
+
+    /**
+     * Duplikace aktivity (spec: vícenásobné sloty = duplikace, žádný recurrence engine). Klon BEZ
+     * dětí přes {@see EventDuplicateProcessor::duplicate} (sdíleno s API), pak rovnou na jeho editaci,
+     * aby uživatel upravil čas/skupinu.
+     */
+    public function duplicateActivity(Request $request, string $eventSlug, int $activityId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $source = $this->em->find(Event::class, $activityId)
+            ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        if (!$this->isCsrfTokenValid('program_activity_duplicate_'.$activityId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $clone = $this->duplicateProcessor->duplicate($source, name: ($source->getName() ?? 'Aktivita').' (kopie)');
+        $this->addFlash('success', 'Aktivita zduplikována — uprav čas/skupinu.');
+
+        return new RedirectResponse($this->generateUrl(
+            'oswis_org_oswis_calendar_web_admin_program_activity_edit',
+            ['eventSlug' => $eventSlug, 'activityId' => $clone->getId()],
+        ));
     }
 
     private function resolveEvent(string $eventSlug): Event

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -7,10 +7,12 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventSection;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
+use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventSectionEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ProgramDayEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventStaffAssignmentRepository;
@@ -279,6 +281,65 @@ final class WebAdminProgramController extends AbstractController
         $this->addFlash('warning', 'Obsazení odebráno.');
 
         return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_activity_staff', ['eventSlug' => $eventSlug, 'activityId' => $activityId]));
+    }
+
+    /** Přidání informační sekce (patička/info) k turnusu. */
+    public function newSection(Request $request, string $eventSlug): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $section = new EventSection();
+        $section->setEvent($turnus);
+
+        return $this->handleSectionForm($request, $eventSlug, $section, 'Nová sekce programu', 'Sekce přidána.');
+    }
+
+    /** Úprava informační sekce. */
+    public function editSection(Request $request, string $eventSlug, int $sectionId): Response
+    {
+        $this->resolveEvent($eventSlug);
+        $section = $this->em->find(EventSection::class, $sectionId)
+            ?? throw $this->createNotFoundException("Sekce #$sectionId nenalezena.");
+
+        return $this->handleSectionForm($request, $eventSlug, $section, 'Upravit sekci programu', 'Sekce uložena.');
+    }
+
+    /** Smazání informační sekce. */
+    public function deleteSection(Request $request, string $eventSlug, int $sectionId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $section = $this->em->find(EventSection::class, $sectionId)
+            ?? throw $this->createNotFoundException("Sekce #$sectionId nenalezena.");
+        if (!$this->isCsrfTokenValid('program_section_delete_'.$sectionId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $this->em->remove($section);
+        $this->em->flush();
+        $this->addFlash('warning', 'Sekce smazána.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]));
+    }
+
+    private function handleSectionForm(Request $request, string $eventSlug, EventSection $section, string $title, string $flash): Response
+    {
+        $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
+        $form = $this->createForm(EventSectionEditType::class, $section);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            if (empty($section->getSlug())) {
+                $section->updateSlug();
+            }
+            $this->em->persist($section);
+            $this->em->flush();
+            $this->addFlash('success', $flash);
+
+            return new RedirectResponse($backUrl);
+        }
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/section_edit.html.twig', [
+            'form'      => $form,
+            'back_url'  => $backUrl,
+            'pageTitle' => $title,
+        ]);
     }
 
     private function resolveEvent(string $eventSlug): Event

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -7,10 +7,14 @@ namespace OswisOrg\OswisCalendarBundle\Controller\WebAdmin;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\EventEditType;
 use OswisOrg\OswisCalendarBundle\Form\WebAdmin\ProgramDayEditType;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventRepository;
+use OswisOrg\OswisCalendarBundle\Repository\Event\EventStaffAssignmentRepository;
+use OswisOrg\OswisCalendarBundle\Repository\Participant\ParticipantRepository;
 use OswisOrg\OswisCalendarBundle\Service\Program\ProgramDataService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -34,6 +38,8 @@ final class WebAdminProgramController extends AbstractController
         private readonly ProgramDataService $programData,
         private readonly EventRepository $eventRepository,
         private readonly EntityManagerInterface $em,
+        private readonly EventStaffAssignmentRepository $assignmentRepository,
+        private readonly ParticipantRepository $participantRepository,
     ) {
     }
 
@@ -189,6 +195,90 @@ final class WebAdminProgramController extends AbstractController
             'back_url'  => $backUrl,
             'pageTitle' => $title,
         ]);
+    }
+
+    /**
+     * Obsazení aktivity (spec 2026-06-12: EventStaffAssignment — účastník z týmových přihlášek NEBO
+     * externí jméno + role). Týmy (StaffTeam ±) = navazující slice. Ruční přiřazení, žádné auto-návrhy
+     * rotace (services se domlouvají v týmu, jen se zapíší — user 2026-06-13).
+     */
+    public function activityStaff(Request $request, string $eventSlug, int $activityId): Response
+    {
+        $turnus = $this->resolveEvent($eventSlug);
+        $activity = $this->em->find(Event::class, $activityId)
+            ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $pageUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_activity_staff', ['eventSlug' => $eventSlug, 'activityId' => $activityId]);
+
+        if ($request->isMethod('POST')) {
+            if (!$this->isCsrfTokenValid('program_staff_add_'.$activityId, (string) $request->request->get('_token'))) {
+                throw $this->createAccessDeniedException('Neplatný CSRF token.');
+            }
+            $participantId = (int) $request->request->get('participant');
+            $externalName = trim((string) $request->request->get('externalName'));
+            $roleLabel = trim((string) $request->request->get('roleLabel'));
+            $participant = $participantId > 0 ? $this->em->find(Participant::class, $participantId) : null;
+            if (!$participant instanceof Participant && '' === $externalName) {
+                $this->addFlash('danger', 'Vyber člověka ze seznamu, nebo zadej externí jméno.');
+
+                return new RedirectResponse($pageUrl);
+            }
+            $assignment = new EventStaffAssignment('' !== $externalName ? $externalName : null, '' !== $roleLabel ? $roleLabel : null);
+            $assignment->setEvent($activity);
+            if ($participant instanceof Participant) {
+                $assignment->setParticipant($participant);
+            }
+            $this->em->persist($assignment);
+            $this->em->flush();
+            $this->addFlash('success', 'Obsazení přidáno.');
+
+            return new RedirectResponse($pageUrl);
+        }
+
+        $assignments = [];
+        foreach ($this->assignmentRepository->getByEvent($activity) as $a) {
+            $participant = $a->getParticipant();
+            $assignments[] = [
+                'id'        => $a->getId(),
+                'name'      => $participant instanceof Participant ? $this->programData->staffName($participant) : (string) $a->getExternalName(),
+                'roleLabel' => $a->getRoleLabel(),
+                'external'  => !$participant instanceof Participant,
+            ];
+        }
+        $staffPool = [];
+        foreach ($this->participantRepository->getParticipants([
+            ParticipantRepository::CRITERIA_EVENT                 => $turnus,
+            ParticipantRepository::CRITERIA_EVENT_RECURSIVE_DEPTH => 3,
+            ParticipantRepository::CRITERIA_PARTICIPANT_TYPE      => 'staff',
+        ]) as $p) {
+            if ($p instanceof Participant) {
+                $staffPool[] = ['id' => $p->getId(), 'name' => $this->programData->staffName($p)];
+            }
+        }
+        usort($staffPool, static fn (array $a, array $b): int => strcoll($a['name'], $b['name']));
+
+        return $this->render('@OswisOrgOswisCalendar/web_admin/program/activity_staff.html.twig', [
+            'eventSlug'   => $eventSlug,
+            'activity'    => $activity,
+            'assignments' => $assignments,
+            'staffPool'   => $staffPool,
+            'back_url'    => $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]),
+        ]);
+    }
+
+    /** Odebrání jednoho obsazení aktivity. */
+    public function deleteStaff(Request $request, string $eventSlug, int $activityId, int $assignmentId): RedirectResponse
+    {
+        $this->resolveEvent($eventSlug);
+        $assignment = $this->em->find(EventStaffAssignment::class, $assignmentId)
+            ?? throw $this->createNotFoundException("Obsazení #$assignmentId nenalezeno.");
+        if (!$this->isCsrfTokenValid('program_staff_delete_'.$assignmentId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Neplatný CSRF token.');
+        }
+        $this->em->remove($assignment);
+        $this->em->flush();
+        $this->addFlash('warning', 'Obsazení odebráno.');
+
+        return new RedirectResponse($this->generateUrl('oswis_org_oswis_calendar_web_admin_program_activity_staff', ['eventSlug' => $eventSlug, 'activityId' => $activityId]));
     }
 
     private function resolveEvent(string $eventSlug): Event

--- a/Controller/WebAdmin/WebAdminProgramController.php
+++ b/Controller/WebAdmin/WebAdminProgramController.php
@@ -96,9 +96,10 @@ final class WebAdminProgramController extends AbstractController
      */
     public function editActivity(Request $request, string $eventSlug, int $activityId): Response
     {
-        $this->resolveEvent($eventSlug); // 404 když turnus neexistuje
+        $turnus = $this->resolveEvent($eventSlug);
         $activity = $this->em->find(Event::class, $activityId)
             ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $activity);
         $backUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_index', ['eventSlug' => $eventSlug]);
 
         $form = $this->createForm(EventEditType::class, $activity);
@@ -185,9 +186,10 @@ final class WebAdminProgramController extends AbstractController
     /** Úprava dne programu. */
     public function editDay(Request $request, string $eventSlug, int $dayId): Response
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $day = $this->em->find(ProgramDay::class, $dayId)
             ?? throw $this->createNotFoundException("Den #$dayId nenalezen.");
+        $this->assertBelongsToTurnus($turnus, $day->getEvent());
 
         return $this->handleDayForm($request, $eventSlug, $day, 'Upravit den programu', 'Den uložen.');
     }
@@ -195,9 +197,10 @@ final class WebAdminProgramController extends AbstractController
     /** Smazání dne programu (aktivity zůstanou — jen se přestanou pod tento den seskupovat). */
     public function deleteDay(Request $request, string $eventSlug, int $dayId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $day = $this->em->find(ProgramDay::class, $dayId)
             ?? throw $this->createNotFoundException("Den #$dayId nenalezen.");
+        $this->assertBelongsToTurnus($turnus, $day->getEvent());
         if (!$this->isCsrfTokenValid('program_day_delete_'.$dayId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -241,6 +244,7 @@ final class WebAdminProgramController extends AbstractController
         $turnus = $this->resolveEvent($eventSlug);
         $activity = $this->em->find(Event::class, $activityId)
             ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $activity);
         $pageUrl = $this->generateUrl('oswis_org_oswis_calendar_web_admin_program_activity_staff', ['eventSlug' => $eventSlug, 'activityId' => $activityId]);
 
         if ($request->isMethod('POST')) {
@@ -312,9 +316,10 @@ final class WebAdminProgramController extends AbstractController
     /** Odebrání jednoho obsazení aktivity. */
     public function deleteStaff(Request $request, string $eventSlug, int $activityId, int $assignmentId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $assignment = $this->em->find(EventStaffAssignment::class, $assignmentId)
             ?? throw $this->createNotFoundException("Obsazení #$assignmentId nenalezeno.");
+        $this->assertBelongsToTurnus($turnus, $assignment->getEvent());
         if (!$this->isCsrfTokenValid('program_staff_delete_'.$assignmentId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -338,9 +343,10 @@ final class WebAdminProgramController extends AbstractController
     /** Úprava informační sekce. */
     public function editSection(Request $request, string $eventSlug, int $sectionId): Response
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $section = $this->em->find(EventSection::class, $sectionId)
             ?? throw $this->createNotFoundException("Sekce #$sectionId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $section->getEvent());
 
         return $this->handleSectionForm($request, $eventSlug, $section, 'Upravit sekci programu', 'Sekce uložena.');
     }
@@ -348,9 +354,10 @@ final class WebAdminProgramController extends AbstractController
     /** Smazání informační sekce. */
     public function deleteSection(Request $request, string $eventSlug, int $sectionId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $section = $this->em->find(EventSection::class, $sectionId)
             ?? throw $this->createNotFoundException("Sekce #$sectionId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $section->getEvent());
         if (!$this->isCsrfTokenValid('program_section_delete_'.$sectionId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -391,9 +398,10 @@ final class WebAdminProgramController extends AbstractController
      */
     public function duplicateActivity(Request $request, string $eventSlug, int $activityId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $source = $this->em->find(Event::class, $activityId)
             ?? throw $this->createNotFoundException("Aktivita #$activityId nenalezena.");
+        $this->assertBelongsToTurnus($turnus, $source);
         if (!$this->isCsrfTokenValid('program_activity_duplicate_'.$activityId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -479,8 +487,9 @@ final class WebAdminProgramController extends AbstractController
 
     public function deleteTeam(Request $request, string $eventSlug, int $teamId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        $this->assertBelongsToTurnus($turnus, $team->getEvent());
         if (!$this->isCsrfTokenValid('program_team_delete_'.$teamId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -493,8 +502,9 @@ final class WebAdminProgramController extends AbstractController
 
     public function addTeamMember(Request $request, string $eventSlug, int $teamId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        $this->assertBelongsToTurnus($turnus, $team->getEvent());
         if (!$this->isCsrfTokenValid('program_team_member_'.$teamId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -512,8 +522,9 @@ final class WebAdminProgramController extends AbstractController
 
     public function removeTeamMember(Request $request, string $eventSlug, int $teamId, int $participantId): RedirectResponse
     {
-        $this->resolveEvent($eventSlug);
+        $turnus = $this->resolveEvent($eventSlug);
         $team = $this->em->find(StaffTeam::class, $teamId) ?? throw $this->createNotFoundException("Tým #$teamId nenalezen.");
+        $this->assertBelongsToTurnus($turnus, $team->getEvent());
         if (!$this->isCsrfTokenValid('program_team_member_remove_'.$teamId.'_'.$participantId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Neplatný CSRF token.');
         }
@@ -531,5 +542,22 @@ final class WebAdminProgramController extends AbstractController
     {
         return $this->eventRepository->getEvent([EventRepository::CRITERIA_SLUG => $eventSlug])
             ?? throw $this->createNotFoundException("Turnus '$eventSlug' nenalezen.");
+    }
+
+    /**
+     * Scoping: dítě (aktivita/den/sekce/tým/assignment) musí patřit do turnusu z URL — jinak by šlo
+     * přes `{eventSlug}` jednoho turnusu manipulovat s entitou jiného (IDOR). `$event` je buď entita
+     * sama (aktivita = Event, chodíme po superEvent řetězci), nebo její `getEvent()` (den/sekce/tým).
+     */
+    private function assertBelongsToTurnus(Event $turnus, ?Event $event, int $depth = 6): void
+    {
+        $turnusId = $turnus->getId();
+        for ($i = 0; $i <= $depth && null !== $event; $i++) {
+            if (null !== $turnusId && $event->getId() === $turnusId) {
+                return;
+            }
+            $event = $event->getSuperEvent();
+        }
+        throw $this->createNotFoundException('Položka nepatří do tohoto turnusu.');
     }
 }

--- a/Entity/Event/Event.php
+++ b/Entity/Event/Event.php
@@ -164,6 +164,16 @@ class Event implements NameableInterface
     #[Column(type: 'boolean', options: ['default' => false])]
     protected bool $highlight = false;
 
+    /**
+     * Zveřejnění PROGRAMU turnusu účastníkům (nová žádost usera): NULL = program skrytý (staví se,
+     * účastníci ho v aplikaci nevidí), datum = zveřejněno od té chvíle. Na TURNUSU; brána je v
+     * {@see \OswisOrg\OswisCalendarBundle\ApiPlatform\EventVisibleToUserExtension} — dokud není
+     * vydáno, účastník vidí svůj turnus, ale ne jeho programový podstrom. Tým program dokončí,
+     * zkontroluje a pak zveřejní jedním tlačítkem.
+     */
+    #[Column(type: 'datetime', nullable: true)]
+    protected ?\DateTimeInterface $programReleasedAt = null;
+
     // fetch=EAGER: Doctrine ORM 3's strict identity-map check
     // (EntityIdentityCollisionException) throws when a Participant lazy ghost
     // is initialised mid-request after the same participant was already
@@ -477,6 +487,22 @@ class Event implements NameableInterface
     public function setHighlight(bool $highlight): void
     {
         $this->highlight = $highlight;
+    }
+
+    public function getProgramReleasedAt(): ?\DateTimeInterface
+    {
+        return $this->programReleasedAt;
+    }
+
+    public function setProgramReleasedAt(?\DateTimeInterface $programReleasedAt): void
+    {
+        $this->programReleasedAt = $programReleasedAt;
+    }
+
+    /** Program turnusu je účastníkům viditelný, jen když je zveřejněn a od zveřejnění už nastal čas. */
+    public function isProgramReleased(?\DateTimeInterface $now = null): bool
+    {
+        return null !== $this->programReleasedAt && $this->programReleasedAt <= ($now ?? new \DateTime());
     }
 
     public function setPlace(?Place $event): void

--- a/Entity/Event/EventStaffAssignment.php
+++ b/Entity/Event/EventStaffAssignment.php
@@ -117,8 +117,11 @@ class EventStaffAssignment implements BasicInterface
 
     public function validateHasAssignee(ExecutionContextInterface $context): void
     {
-        if (null === $this->participant && (null === $this->externalName || '' === trim($this->externalName))) {
-            $context->buildViolation('EventStaffAssignment musí mít buď účastníka, nebo externí jméno.')
+        // Dle specu je přiřazení buď osoba (účastník / externí jméno) NEBO tým/podtým. Dřív validátor
+        // tým nezohledňoval → přiřazení celého týmu by neprošlo.
+        $hasExternal = null !== $this->externalName && '' !== trim($this->externalName);
+        if (null === $this->participant && !$hasExternal && null === $this->team) {
+            $context->buildViolation('EventStaffAssignment musí mít účastníka, tým, nebo externí jméno.')
                 ->atPath('externalName')
                 ->addViolation();
         }

--- a/Form/WebAdmin/EventEditType.php
+++ b/Form/WebAdmin/EventEditType.php
@@ -7,6 +7,7 @@ namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
 use OswisOrg\OswisAddressBookBundle\Entity\Place;
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventCategory;
+use OswisOrg\OswisCalendarBundle\Entity\Participant\ParticipantGroup;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -105,6 +106,29 @@ final class EventEditType extends AbstractType
                 'required' => false,
                 'help'     => 'Samostatné místo nebo upřesnění k vybranému místu (např. „Aula — sraz před vchodem").',
             ])
+            // Zařazení do bloku (rotace) — přesun/přiřazení aktivity pod nadakci. Nabídku bloků plní
+            // kontroler (bloky turnusu), non-mapped (superEvent nastavuje kontroler ručně + hlídá hloubku).
+            ->add('parentBlock', EntityType::class, [
+                'label'        => 'Blok (rotace)',
+                'class'        => Event::class,
+                'choices'      => $options['blocks'],
+                'choice_label' => 'name',
+                'required'     => false,
+                'mapped'       => false,
+                'placeholder'  => '— na úrovni dne (mimo blok) —',
+                'help'         => 'Zařadit aktivitu jako podakci bloku (rotace), nebo ji nechat samostatně v programu dne.',
+            ])
+            // Cílová skupina (pásek) — rotační sloty. Nabídka se plní z kontroleru (pásky turnusu/
+            // ročníku), aby form nedělal vlastní dotaz (IDOR) a při 0 páscích byl prázdný, ne rozbitý.
+            ->add('targetGroup', EntityType::class, [
+                'label'        => 'Cílová skupina (pásek)',
+                'class'        => ParticipantGroup::class,
+                'choices'      => $options['groups'],
+                'choice_label' => 'name',
+                'required'     => false,
+                'placeholder'  => '— všichni (mimo rotaci) —',
+                'help'         => 'Jen u rotačního slotu — komu je slot určen (např. MODRÁ). Prázdné = pro všechny.',
+            ])
             // Programová pole aktivity (spec 2026-06-12 krok 4). Dosud šla nastavit jen přes API —
             // teď i z web adminu (editor programu / obecná editace události).
             ->add('signupMode', ChoiceType::class, [
@@ -153,6 +177,12 @@ final class EventEditType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Event::class,
+            // Nabídka pásků (ParticipantGroup) pro pole targetGroup; naplní kontroler dle turnusu.
+            'groups'     => [],
+            // Nabídka bloků (Event program-block) pro pole parentBlock; naplní kontroler dle turnusu.
+            'blocks'     => [],
         ]);
+        $resolver->setAllowedTypes('groups', 'array');
+        $resolver->setAllowedTypes('blocks', 'array');
     }
 }

--- a/Form/WebAdmin/EventEditType.php
+++ b/Form/WebAdmin/EventEditType.php
@@ -10,6 +10,7 @@ use OswisOrg\OswisCalendarBundle\Entity\Event\EventCategory;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -103,6 +104,44 @@ final class EventEditType extends AbstractType
                 'label'    => 'Místo (text/upřesnění)',
                 'required' => false,
                 'help'     => 'Samostatné místo nebo upřesnění k vybranému místu (např. „Aula — sraz před vchodem").',
+            ])
+            // Programová pole aktivity (spec 2026-06-12 krok 4). Dosud šla nastavit jen přes API —
+            // teď i z web adminu (editor programu / obecná editace události).
+            ->add('signupMode', ChoiceType::class, [
+                'label'   => 'Přihlašování',
+                'choices' => [
+                    'Bez přihlašování (jen položka programu)'        => Event::SIGNUP_MODE_NONE,
+                    'Dobrovolné (účastník si přidá do svého programu)' => Event::SIGNUP_MODE_OPTIONAL,
+                    'Povinné přihlášení v aplikaci (hlídá kapacitu)'  => Event::SIGNUP_MODE_REQUIRED,
+                    'Zapisuje tým osobně (nástěnka/kiosek)'           => Event::SIGNUP_MODE_STAFF,
+                ],
+                'required' => true,
+                'help'     => 'Jak se účastník na aktivitu dostane.',
+            ])
+            ->add('signupNote', TextType::class, [
+                'label'    => 'Poznámka k zápisu',
+                'required' => false,
+                'help'     => 'Kde/jak se zapisuje — zobrazí se u aktivity (např. „Registrace v kiosku v hotovosti").',
+            ])
+            ->add('signupDeadline', DateTimeType::class, [
+                'label'    => 'Uzávěrka přihlašování',
+                'required' => false,
+                'widget'   => 'single_text',
+                'input'    => 'datetime',
+            ])
+            ->add('price', IntegerType::class, [
+                'label'    => 'Cena (Kč)',
+                'required' => false,
+                'help'     => 'Placené aktivity (typicky hotově v kiosku). Prázdné = zdarma.',
+            ])
+            ->add('highlight', CheckboxType::class, [
+                'label'    => 'Zvýraznit v programu',
+                'required' => false,
+            ])
+            ->add('publicInApp', CheckboxType::class, [
+                'label'    => 'Veřejné v aplikaci',
+                'required' => false,
+                'help'     => 'Vypnuté = interní (služby, týmové body) — účastník aktivitu v appce nevidí.',
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Uložit',

--- a/Form/WebAdmin/EventSectionEditType.php
+++ b/Form/WebAdmin/EventSectionEditType.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
+
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventSection;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Informační sekce programu (spec 2026-06-12: EventSection = event FK + NameableTrait + TextValueTrait
+ * + PriorityTrait + EntityPublicTrait + icon). Slouží pro instruktorskou patičku PDF i obsahové
+ * stránky v appce (NÁVŠTĚVY / TÝM / BALENÍ / info před akcí). Per turnus, bez dědičnosti.
+ */
+final class EventSectionEditType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label'    => 'Nadpis sekce',
+                'required' => false,
+                'help'     => 'Např. „BALENÍ", „NÁVŠTĚVY", „Info před akcí".',
+            ])
+            ->add('textValue', TextareaType::class, [
+                'label'    => 'Obsah',
+                'required' => false,
+                'attr'     => ['rows' => 6],
+            ])
+            ->add('icon', TextType::class, [
+                'label'    => 'Ikona (Iconify)',
+                'required' => false,
+                'help'     => 'Volitelně: název ikony (Iconify), např. „tabler:info-circle".',
+            ])
+            ->add('priority', IntegerType::class, [
+                'label'    => 'Pořadí',
+                'required' => false,
+                'help'     => 'Vyšší číslo = výš. Prázdné = 0.',
+            ])
+            ->add('publicInApp', CheckboxType::class, [
+                'label'    => 'Veřejné v aplikaci',
+                'required' => false,
+            ])
+            ->add('publicOnWeb', CheckboxType::class, [
+                'label'    => 'Veřejné na webu',
+                'required' => false,
+            ])
+            ->add('note', TextareaType::class, [
+                'label'    => 'Interní poznámka (jen pro tým)',
+                'required' => false,
+                'attr'     => ['rows' => 2],
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Uložit',
+                'attr'  => ['class' => 'btn btn-primary'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => EventSection::class,
+        ]);
+    }
+}

--- a/Form/WebAdmin/ProgramDayEditType.php
+++ b/Form/WebAdmin/ProgramDayEditType.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
+
+use OswisOrg\OswisCalendarBundle\Entity\Event\ProgramDay;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Den programu (spec 2026-06-12: „ProgramDay = event(turnus) FK + date + NameableTrait").
+ * Datum den seskupí aktivity v přehledu (aktivita padne pod den se shodným datem startu);
+ * name = label („PŘÍJEZDOVÝ DEN"), description = veřejná poznámka dne, note = interní.
+ */
+final class ProgramDayEditType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('date', DateType::class, [
+                'label'    => 'Datum',
+                'required' => true,
+                'widget'   => 'single_text',
+                'input'    => 'datetime',
+                'help'     => 'Podle data se pod tento den v přehledu seskupí aktivity se stejným datem startu.',
+            ])
+            ->add('name', TextType::class, [
+                'label'    => 'Název dne',
+                'required' => false,
+                'help'     => 'Např. „PŘÍJEZDOVÝ DEN", „TŘETÍ DEN". Prázdné = jen datum.',
+            ])
+            ->add('description', TextareaType::class, [
+                'label'    => 'Veřejná poznámka dne',
+                'required' => false,
+                'attr'     => ['rows' => 2],
+            ])
+            ->add('note', TextareaType::class, [
+                'label'    => 'Interní poznámka (jen pro tým)',
+                'required' => false,
+                'attr'     => ['rows' => 2],
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Uložit',
+                'attr'  => ['class' => 'btn btn-primary'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ProgramDay::class,
+        ]);
+    }
+}

--- a/Form/WebAdmin/StaffTeamEditType.php
+++ b/Form/WebAdmin/StaffTeamEditType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OswisOrg\OswisCalendarBundle\Form\WebAdmin;
+
+use OswisOrg\OswisCalendarBundle\Entity\Participant\StaffTeam;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Tým / podtým organizačního týmu (spec 2026-06-12: StaffTeam per turnus, členství M2M). Přiřazuje se
+ * k aktivitám místo vypisování všech členů; itinerář jednotlivce se pak expanduje. Členové se spravují
+ * zvlášť (add/remove) — tady jen název.
+ */
+final class StaffTeamEditType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label'    => 'Název týmu',
+                'required' => false,
+                'help'     => 'Např. „Kuchyň", „Technika", „Hlavní tým".',
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Uložit',
+                'attr'  => ['class' => 'btn btn-primary'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => StaffTeam::class,
+        ]);
+    }
+}

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -208,6 +208,12 @@ oswis_org_oswis_calendar_web_admin_checkin_list:
   path: "/web_admin/check-in/{eventSlug}"
   methods: [GET]
 
+## Program editor (spec krok 8) — přehledová stránka, ROLE_MANAGER
+oswis_org_oswis_calendar_web_admin_program_index:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::index
+  path: "/web_admin/program/{eventSlug}"
+  methods: [GET]
+
 ## Program-module outputs (STOPA 1.3 Fáze 7) — PDF/CSV downloads, ROLE_MANAGER
 oswis_org_oswis_calendar_web_admin_program_instructor:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramOutputController::turnusOutput

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -237,6 +237,23 @@ oswis_org_oswis_calendar_web_admin_program_staff_delete:
   requirements: { activityId: '\d+', assignmentId: '\d+' }
   methods: [POST]
 
+oswis_org_oswis_calendar_web_admin_program_section_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newSection
+  path: "/web_admin/program/{eventSlug}/sekce/nova"
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_section_edit:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::editSection
+  path: "/web_admin/program/{eventSlug}/sekce/{sectionId}/upravit"
+  requirements: { sectionId: '\d+' }
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_section_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteSection
+  path: "/web_admin/program/{eventSlug}/sekce/{sectionId}/smazat"
+  requirements: { sectionId: '\d+' }
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_day_new:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newDay
   path: "/web_admin/program/{eventSlug}/den/nova"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -225,6 +225,11 @@ oswis_org_oswis_calendar_web_admin_program_activity_edit:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_release:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::toggleProgramRelease
+  path: "/web_admin/program/{eventSlug}/zverejnit"
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_activity_duplicate:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::duplicateActivity
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/duplikovat"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -214,6 +214,11 @@ oswis_org_oswis_calendar_web_admin_program_index:
   path: "/web_admin/program/{eventSlug}"
   methods: [GET]
 
+oswis_org_oswis_calendar_web_admin_program_activity_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newActivity
+  path: "/web_admin/program/{eventSlug}/aktivita/nova"
+  methods: [GET, POST]
+
 oswis_org_oswis_calendar_web_admin_program_activity_edit:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::editActivity
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -225,6 +225,23 @@ oswis_org_oswis_calendar_web_admin_program_activity_edit:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_day_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newDay
+  path: "/web_admin/program/{eventSlug}/den/nova"
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_day_edit:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::editDay
+  path: "/web_admin/program/{eventSlug}/den/{dayId}/upravit"
+  requirements: { dayId: '\d+' }
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_day_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteDay
+  path: "/web_admin/program/{eventSlug}/den/{dayId}/smazat"
+  requirements: { dayId: '\d+' }
+  methods: [POST]
+
 ## Program-module outputs (STOPA 1.3 Fáze 7) — PDF/CSV downloads, ROLE_MANAGER
 oswis_org_oswis_calendar_web_admin_program_instructor:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramOutputController::turnusOutput

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -214,6 +214,12 @@ oswis_org_oswis_calendar_web_admin_program_index:
   path: "/web_admin/program/{eventSlug}"
   methods: [GET]
 
+oswis_org_oswis_calendar_web_admin_program_activity_edit:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::editActivity
+  path: "/web_admin/program/{eventSlug}/aktivita/{activityId}"
+  requirements: { activityId: '\d+' }
+  methods: [GET, POST]
+
 ## Program-module outputs (STOPA 1.3 Fáze 7) — PDF/CSV downloads, ROLE_MANAGER
 oswis_org_oswis_calendar_web_admin_program_instructor:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramOutputController::turnusOutput

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -242,6 +242,29 @@ oswis_org_oswis_calendar_web_admin_program_activity_staff:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_teams:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::teams
+  path: "/web_admin/program/{eventSlug}/tymy"
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_team_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteTeam
+  path: "/web_admin/program/{eventSlug}/tymy/{teamId}/smazat"
+  requirements: { teamId: '\d+' }
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_program_team_member_add:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::addTeamMember
+  path: "/web_admin/program/{eventSlug}/tymy/{teamId}/clen"
+  requirements: { teamId: '\d+' }
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_program_team_member_remove:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::removeTeamMember
+  path: "/web_admin/program/{eventSlug}/tymy/{teamId}/clen/{participantId}/odebrat"
+  requirements: { teamId: '\d+', participantId: '\d+' }
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_staff_delete:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteStaff
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/obsazeni/{assignmentId}/smazat"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -225,6 +225,12 @@ oswis_org_oswis_calendar_web_admin_program_activity_edit:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_activity_duplicate:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::duplicateActivity
+  path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/duplikovat"
+  requirements: { activityId: '\d+' }
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_activity_staff:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::activityStaff
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/obsazeni"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -219,6 +219,11 @@ oswis_org_oswis_calendar_web_admin_program_activity_new:
   path: "/web_admin/program/{eventSlug}/aktivita/nova"
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_block_new:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newBlock
+  path: "/web_admin/program/{eventSlug}/blok/novy"
+  methods: [GET, POST]
+
 oswis_org_oswis_calendar_web_admin_program_activity_edit:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::editActivity
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}"
@@ -233,6 +238,12 @@ oswis_org_oswis_calendar_web_admin_program_release:
 oswis_org_oswis_calendar_web_admin_program_activity_duplicate:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::duplicateActivity
   path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/duplikovat"
+  requirements: { activityId: '\d+' }
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_program_activity_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteActivity
+  path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/smazat"
   requirements: { activityId: '\d+' }
   methods: [POST]
 

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -242,6 +242,23 @@ oswis_org_oswis_calendar_web_admin_program_activity_staff:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_series:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::series
+  path: "/web_admin/program/{eventSlug}/serie"
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_series_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteSeries
+  path: "/web_admin/program/{eventSlug}/serie/{seriesId}/zrusit"
+  requirements: { seriesId: '\d+' }
+  methods: [POST]
+
+oswis_org_oswis_calendar_web_admin_program_series_remove_activity:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::removeSeriesActivity
+  path: "/web_admin/program/{eventSlug}/serie/aktivita/{activityId}/odebrat"
+  requirements: { activityId: '\d+' }
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_teams:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::teams
   path: "/web_admin/program/{eventSlug}/tymy"

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -225,6 +225,18 @@ oswis_org_oswis_calendar_web_admin_program_activity_edit:
   requirements: { activityId: '\d+' }
   methods: [GET, POST]
 
+oswis_org_oswis_calendar_web_admin_program_activity_staff:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::activityStaff
+  path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/obsazeni"
+  requirements: { activityId: '\d+' }
+  methods: [GET, POST]
+
+oswis_org_oswis_calendar_web_admin_program_staff_delete:
+  controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::deleteStaff
+  path: "/web_admin/program/{eventSlug}/aktivita/{activityId}/obsazeni/{assignmentId}/smazat"
+  requirements: { activityId: '\d+', assignmentId: '\d+' }
+  methods: [POST]
+
 oswis_org_oswis_calendar_web_admin_program_day_new:
   controller: OswisOrg\OswisCalendarBundle\Controller\WebAdmin\WebAdminProgramController::newDay
   path: "/web_admin/program/{eventSlug}/den/nova"

--- a/Resources/views/web_admin/event_edit.html.twig
+++ b/Resources/views/web_admin/event_edit.html.twig
@@ -61,6 +61,12 @@
             <div class="row">
                 <div class="col-12 mb-3">{{ form_row(form.placeText) }}</div>
             </div>
+            {% if form.parentBlock is defined %}
+                <div class="row">
+                    <div class="col-12 col-md-6 mb-3">{{ form_row(form.parentBlock) }}</div>
+                    <div class="col-12 col-md-6 mb-3">{{ form_row(form.targetGroup) }}</div>
+                </div>
+            {% endif %}
         </fieldset>
 
         <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-bottom: 1rem;">

--- a/Resources/views/web_admin/event_edit.html.twig
+++ b/Resources/views/web_admin/event_edit.html.twig
@@ -11,7 +11,7 @@
                     <span class="badge bg-danger" style="font-size: .55em; vertical-align: middle;">SMAZÁNO</span>
                 {% endif %}
             </h2>
-            <a href="{{ path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug }) }}"
+            <a href="{{ back_url|default(path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug })) }}"
                class="btn btn-sm btn-outline-secondary">← Zpět na přehled</a>
         </div>
 
@@ -63,8 +63,24 @@
             </div>
         </fieldset>
 
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-bottom: 1rem;">
+            <legend style="font-size: 1rem; font-weight: 600; padding: 0 .5rem; width: auto; margin-bottom: .5rem;">Přihlašování a cena</legend>
+            <div class="row">
+                <div class="col-12 col-md-6 mb-3">{{ form_row(form.signupMode) }}</div>
+                <div class="col-12 col-md-6 mb-3">{{ form_row(form.signupDeadline) }}</div>
+            </div>
+            <div class="row">
+                <div class="col-12 mb-3">{{ form_row(form.signupNote) }}</div>
+            </div>
+            <div class="row">
+                <div class="col-12 col-md-4 mb-3">{{ form_row(form.price) }}</div>
+                <div class="col-6 col-md-4 mb-3 d-flex align-items-end">{{ form_row(form.highlight) }}</div>
+                <div class="col-6 col-md-4 mb-3 d-flex align-items-end">{{ form_row(form.publicInApp) }}</div>
+            </div>
+        </fieldset>
+
         <div style="position: sticky; bottom: 0; background: rgba(255,255,255,.95); border-top: 1px solid #dee2e6; padding: .75rem 0; margin-top: 1rem; display: flex; gap: .5rem; justify-content: flex-end;">
-            <a href="{{ path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug }) }}"
+            <a href="{{ back_url|default(path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug })) }}"
                class="btn btn-outline-secondary">Zrušit</a>
             {{ form_row(form.submit, { attr: { class: 'btn btn-primary' } }) }}
         </div>

--- a/Resources/views/web_admin/event_edit.html.twig
+++ b/Resources/views/web_admin/event_edit.html.twig
@@ -11,7 +11,7 @@
                     <span class="badge bg-danger" style="font-size: .55em; vertical-align: middle;">SMAZÁNO</span>
                 {% endif %}
             </h2>
-            <a href="{{ back_url|default(path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug })) }}"
+            <a href="{{ back_url|default((event.slug|default(false)) ? path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug }) : '#') }}"
                class="btn btn-sm btn-outline-secondary">← Zpět na přehled</a>
         </div>
 
@@ -80,7 +80,7 @@
         </fieldset>
 
         <div style="position: sticky; bottom: 0; background: rgba(255,255,255,.95); border-top: 1px solid #dee2e6; padding: .75rem 0; margin-top: 1rem; display: flex; gap: .5rem; justify-content: flex-end;">
-            <a href="{{ back_url|default(path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug })) }}"
+            <a href="{{ back_url|default((event.slug|default(false)) ? path('oswis_org_oswis_calendar_web_admin_event', { eventSlug: event.slug }) : '#') }}"
                class="btn btn-outline-secondary">Zrušit</a>
             {{ form_row(form.submit, { attr: { class: 'btn btn-primary' } }) }}
         </div>

--- a/Resources/views/web_admin/program/activity_staff.html.twig
+++ b/Resources/views/web_admin/program/activity_staff.html.twig
@@ -19,7 +19,9 @@
             <tbody>
                 {% for a in assignments %}
                     <tr>
-                        <td>{{ a.name ?: '—' }}{% if a.external %} <span class="badge bg-light text-dark">externí</span>{% endif %}</td>
+                        <td>{{ a.name ?: '—' }}
+                            {% if a.kind == 'team' %} <span class="badge bg-info text-dark">tým</span>
+                            {% elseif a.kind == 'external' %} <span class="badge bg-light text-dark">externí</span>{% endif %}</td>
                         <td>{{ a.roleLabel ?? '—' }}</td>
                         <td>
                             <form method="post" style="margin: 0;"
@@ -56,6 +58,18 @@
                         <input type="text" name="externalName" class="form-control" placeholder="např. P. Svačina, ASC">
                     </div>
                 </div>
+                {% if teams|length > 0 %}
+                    <div class="row">
+                        <div class="col-12 col-md-6 mb-3">
+                            <label class="form-label">Nebo celý tým</label>
+                            <select name="team" class="form-select">
+                                <option value="">— žádný tým —</option>
+                                {% for t in teams %}<option value="{{ t.id }}">{{ t.name }}</option>{% endfor %}
+                            </select>
+                            <div class="form-text">Přiřadí celý tým; v itineráři se rozepíše na jednotlivce.</div>
+                        </div>
+                    </div>
+                {% endif %}
                 <div class="row">
                     <div class="col-12 col-md-6 mb-3">
                         <label class="form-label">Role</label>

--- a/Resources/views/web_admin/program/activity_staff.html.twig
+++ b/Resources/views/web_admin/program/activity_staff.html.twig
@@ -1,0 +1,71 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}Obsazení aktivity{% endblock %}
+
+{# Obsazení aktivity (spec krok 8): účastník z týmových přihlášek NEBO externí jméno + role.
+   Data: WebAdminProgramController::activityStaff. #}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem; flex-wrap: wrap;">
+            <h2 style="margin: 0;">Obsazení — {{ activity.name ?? ('#' ~ activity.id) }}</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        <table class="table table-sm" style="max-width: 46rem;">
+            <thead>
+                <tr><th>Kdo</th><th>Role</th><th style="width: 5rem;"></th></tr>
+            </thead>
+            <tbody>
+                {% for a in assignments %}
+                    <tr>
+                        <td>{{ a.name ?: '—' }}{% if a.external %} <span class="badge bg-light text-dark">externí</span>{% endif %}</td>
+                        <td>{{ a.roleLabel ?? '—' }}</td>
+                        <td>
+                            <form method="post" style="margin: 0;"
+                                  action="{{ path('oswis_org_oswis_calendar_web_admin_program_staff_delete', {eventSlug: eventSlug, activityId: activity.id, assignmentId: a.id}) }}"
+                                  onsubmit="return confirm('Odebrat „{{ a.name }}" z obsazení?');">
+                                <input type="hidden" name="_token" value="{{ csrf_token('program_staff_delete_' ~ a.id) }}">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" style="padding: .05rem .4rem;">odebrat</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="3" style="color: #adb5bd;">Zatím nikdo není obsazený.</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; max-width: 46rem;">
+            <legend style="font-size: 1rem; font-weight: 600; padding: 0 .5rem; width: auto;">Přidat obsazení</legend>
+            <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_staff', {eventSlug: eventSlug, activityId: activity.id}) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('program_staff_add_' ~ activity.id) }}">
+                <div class="row">
+                    <div class="col-12 col-md-6 mb-3">
+                        <label class="form-label">Člen týmu</label>
+                        <select name="participant" class="form-select">
+                            <option value="">— vyber ze seznamu —</option>
+                            {% for p in staffPool %}
+                                <option value="{{ p.id }}">{{ p.name }}</option>
+                            {% endfor %}
+                        </select>
+                        <div class="form-text">Nebo níže zadej externího člověka (mimo přihlášky).</div>
+                    </div>
+                    <div class="col-12 col-md-6 mb-3">
+                        <label class="form-label">Externí jméno</label>
+                        <input type="text" name="externalName" class="form-control" placeholder="např. P. Svačina, ASC">
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-12 col-md-6 mb-3">
+                        <label class="form-label">Role</label>
+                        <input type="text" name="roleLabel" class="form-control" placeholder="moderátor / technika / pomocník…">
+                    </div>
+                    <div class="col-12 col-md-6 mb-3 d-flex align-items-end">
+                        <button type="submit" class="btn btn-primary">Přidat</button>
+                    </div>
+                </div>
+            </form>
+        </fieldset>
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/program/block_new.html.twig
+++ b/Resources/views/web_admin/program/block_new.html.twig
@@ -1,0 +1,37 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}Nový blok programu{% endblock %}
+
+{# Vytvoření bloku programu (nadakce, kategorie program-block). Blok sdružuje podakce jedné rotace
+   nebo série; jeho čas se dopočítá z podakcí (vlastní čas zůstává prázdný). Po vytvoření se podakce
+   přidávají v přehledu tlačítkem „+ podakce". Data: WebAdminProgramController::newBlock. #}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem;">
+            <h2 style="margin: 0;">Nový blok programu</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        <div class="alert alert-info" style="max-width: 46rem;">
+            <strong>Blok</strong> je nadřazený bod programu, který sdružuje více podakcí — typicky
+            <em>rotaci</em> (např. „Dopolední rotace stanovišť": tři stanoviště, kterými se pásky
+            postupně protočí) nebo sérii. Čas bloku se <strong>dopočítá z podakcí</strong>, takže ho
+            teď nezadáváš. Podakce (rotační sloty) přidáš vzápětí v přehledu tlačítkem
+            <strong>„+ podakce"</strong> — u každé nastavíš čas a pásek (barevnou skupinu).
+        </div>
+
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; max-width: 46rem;">
+            <legend style="font-size: 1rem; font-weight: 600; padding: 0 .5rem; width: auto;">Název bloku</legend>
+            <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_program_block_new', {eventSlug: eventSlug}) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('program_block_new_' ~ turnusId) }}">
+                <div class="mb-3">
+                    <label class="form-label" for="block_name">Název</label>
+                    <input type="text" id="block_name" name="name" class="form-control" required autofocus
+                           placeholder="např. Dopolední rotace stanovišť">
+                </div>
+                <button type="submit" class="btn btn-primary">Vytvořit blok</button>
+            </form>
+        </fieldset>
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/program/day_edit.html.twig
+++ b/Resources/views/web_admin/program/day_edit.html.twig
@@ -1,0 +1,27 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ pageTitle }}{% endblock %}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem;">
+            <h2 style="margin: 0;">{{ pageTitle }}</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-bottom: 1rem; max-width: 46rem;">
+            <div class="row">
+                <div class="col-12 col-md-4 mb-3">{{ form_row(form.date) }}</div>
+                <div class="col-12 col-md-8 mb-3">{{ form_row(form.name) }}</div>
+            </div>
+            <div class="row"><div class="col-12 mb-3">{{ form_row(form.description) }}</div></div>
+            <div class="row"><div class="col-12 mb-3">{{ form_row(form.note) }}</div></div>
+        </fieldset>
+        <div style="display: flex; gap: .5rem; justify-content: flex-end; max-width: 46rem;">
+            <a href="{{ back_url }}" class="btn btn-outline-secondary">Zrušit</a>
+            {{ form_row(form.submit, { attr: { class: 'btn btn-primary' } }) }}
+        </div>
+        {{ form_end(form) }}
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -107,6 +107,8 @@
                                         {% if a.id %}
                                             <a class="btn btn-sm btn-outline-secondary"
                                                href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_edit', {eventSlug: eventSlug, activityId: a.id}) }}">upravit</a>
+                                            <a class="btn btn-sm btn-outline-secondary"
+                                               href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_staff', {eventSlug: eventSlug, activityId: a.id}) }}">obsazení</a>
                                         {% endif %}
                                     </td>
                                 </tr>

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -50,6 +50,8 @@
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_day_new', {eventSlug: eventSlug}) }}">+ Přidat den</a>
                 <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_section_new', {eventSlug: eventSlug}) }}">+ Přidat sekci</a>
+                <a class="btn btn-sm btn-outline-secondary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_teams', {eventSlug: eventSlug}) }}">Týmy</a>
                 <span style="width: .5rem;"></span>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -16,6 +16,32 @@
             </div>
         </div>
 
+        <div class="row" style="margin-top: .5rem;">
+            <div class="col">
+                {% if event.isProgramReleased %}
+                    <div class="alert alert-success" style="display: flex; align-items: center; gap: 1rem; padding: .45rem 1rem; margin: 0;">
+                        <span><span class="badge bg-success">ZVEŘEJNĚNO</span> Program vidí účastníci v aplikaci{% if event.programReleasedAt %} (od {{ event.programReleasedAt|date('j. n. Y H:i') }}){% endif %}.</span>
+                        <form method="post" style="margin: 0 0 0 auto;"
+                              action="{{ path('oswis_org_oswis_calendar_web_admin_program_release', {eventSlug: eventSlug}) }}"
+                              onsubmit="return confirm('Skrýt program účastníkům?');">
+                            <input type="hidden" name="_token" value="{{ csrf_token('program_release_' ~ event.id) }}">
+                            <button type="submit" class="btn btn-sm btn-outline-warning">Skrýt program</button>
+                        </form>
+                    </div>
+                {% else %}
+                    <div class="alert alert-warning" style="display: flex; align-items: center; gap: 1rem; padding: .45rem 1rem; margin: 0;">
+                        <span><span class="badge bg-warning text-dark">SKRYTO</span> Program se staví — účastníci ho v aplikaci nevidí. Zveřejni ho, až bude hotový a zkontrolovaný.</span>
+                        <form method="post" style="margin: 0 0 0 auto;"
+                              action="{{ path('oswis_org_oswis_calendar_web_admin_program_release', {eventSlug: eventSlug}) }}"
+                              onsubmit="return confirm('Zveřejnit program všem účastníkům turnusu?');">
+                            <input type="hidden" name="_token" value="{{ csrf_token('program_release_' ~ event.id) }}">
+                            <button type="submit" class="btn btn-sm btn-success">Zveřejnit program</button>
+                        </form>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+
         <div class="row" style="margin-top: .75rem;">
             <div class="col" style="display: flex; gap: .4rem; flex-wrap: wrap;">
                 <a class="btn btn-sm btn-primary"

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -20,6 +20,8 @@
             <div class="col" style="display: flex; gap: .4rem; flex-wrap: wrap;">
                 <a class="btn btn-sm btn-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_new', {eventSlug: eventSlug}) }}">+ Přidat aktivitu</a>
+                <a class="btn btn-sm btn-outline-primary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_day_new', {eventSlug: eventSlug}) }}">+ Přidat den</a>
                 <span style="width: .5rem;"></span>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>
@@ -46,12 +48,21 @@
         {% for row in tree %}
             <div class="row" style="margin-top: 1.25rem;">
                 <div class="col">
-                    <h3 style="margin: 0 0 .4rem; border-bottom: 2px solid #006fad; padding-bottom: .2rem;">
+                    <h3 style="margin: 0 0 .4rem; border-bottom: 2px solid #006fad; padding-bottom: .2rem; display: flex; align-items: baseline; gap: .5rem;">
                         {% if row.day %}
-                            {{ row.day.name ?? 'Den' }}
-                            <small style="color: #6c757d; font-weight: normal;">{{ row.day.date }}</small>
+                            <span>{{ row.day.name ?? 'Den' }}
+                                <small style="color: #6c757d; font-weight: normal;">{{ row.day.date }}</small></span>
+                            <span style="margin-left: auto; font-size: .8rem; font-weight: normal; display: inline-flex; gap: .4rem; align-items: baseline;">
+                                <a href="{{ path('oswis_org_oswis_calendar_web_admin_program_day_edit', {eventSlug: eventSlug, dayId: row.day.id}) }}">upravit</a>
+                                <form method="post" style="display: inline; margin: 0;"
+                                      action="{{ path('oswis_org_oswis_calendar_web_admin_program_day_delete', {eventSlug: eventSlug, dayId: row.day.id}) }}"
+                                      onsubmit="return confirm('Smazat den „{{ row.day.name ?? row.day.date }}"? Aktivity zůstanou.');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('program_day_delete_' ~ row.day.id) }}">
+                                    <button type="submit" style="border: 0; background: none; color: #b02a37; cursor: pointer; padding: 0; font-size: .8rem;">smazat</button>
+                                </form>
+                            </span>
                         {% else %}
-                            Nezařazené aktivity <small style="color: #6c757d; font-weight: normal;">(bez data)</small>
+                            <span>Nezařazené aktivity <small style="color: #6c757d; font-weight: normal;">(bez data)</small></span>
                         {% endif %}
                     </h3>
                     <table class="table table-sm" style="margin: 0;">

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -52,6 +52,8 @@
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_section_new', {eventSlug: eventSlug}) }}">+ Přidat sekci</a>
                 <a class="btn btn-sm btn-outline-secondary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_teams', {eventSlug: eventSlug}) }}">Týmy</a>
+                <a class="btn btn-sm btn-outline-secondary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_series', {eventSlug: eventSlug}) }}">Série</a>
                 <span style="width: .5rem;"></span>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -59,6 +59,7 @@
                                 <th>Místo</th>
                                 <th>Kategorie</th>
                                 <th>Obsazení</th>
+                                <th style="width: 4rem;"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -87,6 +88,12 @@
                                         {% for s in a.staff %}
                                             {{ s.name }}{% if s.roleLabel %} <span style="color: #6c757d;">({{ s.roleLabel }})</span>{% endif %}{% if not loop.last %}, {% endif %}
                                         {% else %}<span style="color: #adb5bd;">—</span>{% endfor %}
+                                    </td>
+                                    <td style="white-space: nowrap;">
+                                        {% if a.id %}
+                                            <a class="btn btn-sm btn-outline-secondary"
+                                               href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_edit', {eventSlug: eventSlug, activityId: a.id}) }}">upravit</a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -111,6 +111,11 @@
                                                href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_edit', {eventSlug: eventSlug, activityId: a.id}) }}">upravit</a>
                                             <a class="btn btn-sm btn-outline-secondary"
                                                href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_staff', {eventSlug: eventSlug, activityId: a.id}) }}">obsazení</a>
+                                            <form method="post" style="display: inline; margin: 0;"
+                                                  action="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_duplicate', {eventSlug: eventSlug, activityId: a.id}) }}">
+                                                <input type="hidden" name="_token" value="{{ csrf_token('program_activity_duplicate_' ~ a.id) }}">
+                                                <button type="submit" class="btn btn-sm btn-outline-secondary">duplikovat</button>
+                                            </form>
                                         {% endif %}
                                     </td>
                                 </tr>

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -18,6 +18,9 @@
 
         <div class="row" style="margin-top: .75rem;">
             <div class="col" style="display: flex; gap: .4rem; flex-wrap: wrap;">
+                <a class="btn btn-sm btn-primary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_new', {eventSlug: eventSlug}) }}">+ Přidat aktivitu</a>
+                <span style="width: .5rem;"></span>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -47,6 +47,9 @@
                 <a class="btn btn-sm btn-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_new', {eventSlug: eventSlug}) }}">+ Přidat aktivitu</a>
                 <a class="btn btn-sm btn-outline-primary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_block_new', {eventSlug: eventSlug}) }}"
+                   title="Nadřazený bod programu pro rotaci / sérii (např. dopolední rotace stanovišť)">+ Vytvořit blok</a>
+                <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_day_new', {eventSlug: eventSlug}) }}">+ Přidat den</a>
                 <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_section_new', {eventSlug: eventSlug}) }}">+ Přidat sekci</a>
@@ -70,8 +73,9 @@
             <div class="row" style="margin-top: 1.5rem;">
                 <div class="col">
                     <div class="alert alert-info" style="max-width: 46rem;">
-                        Program tohoto turnusu zatím nemá žádné aktivity. Zadávání aktivit z tohoto rozhraní
-                        přibude v dalším kroku editoru; do té doby program vzniká přes API (mobilní admin / import).
+                        Program tohoto turnusu zatím nemá žádné aktivity. Začni tlačítkem
+                        <strong>„+ Přidat aktivitu"</strong> (jednotlivý bod programu) nebo
+                        <strong>„+ Vytvořit blok"</strong> (rotace / série s podakcemi).
                     </div>
                 </div>
             </div>
@@ -137,6 +141,11 @@
                                     </td>
                                     <td style="white-space: nowrap;">
                                         {% if a.id %}
+                                            {% if a.isBlock %}
+                                                <a class="btn btn-sm btn-outline-primary"
+                                                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_new', {eventSlug: eventSlug, block: a.id}) }}"
+                                                   title="Přidat podakci (rotační slot) do tohoto bloku">+ podakce</a>
+                                            {% endif %}
                                             <a class="btn btn-sm btn-outline-secondary"
                                                href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_edit', {eventSlug: eventSlug, activityId: a.id}) }}">upravit</a>
                                             <a class="btn btn-sm btn-outline-secondary"
@@ -145,6 +154,12 @@
                                                   action="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_duplicate', {eventSlug: eventSlug, activityId: a.id}) }}">
                                                 <input type="hidden" name="_token" value="{{ csrf_token('program_activity_duplicate_' ~ a.id) }}">
                                                 <button type="submit" class="btn btn-sm btn-outline-secondary">duplikovat</button>
+                                            </form>
+                                            <form method="post" style="display: inline; margin: 0;"
+                                                  action="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_delete', {eventSlug: eventSlug, activityId: a.id}) }}"
+                                                  onsubmit="return confirm({% if a.subActivities|length > 0 %}'Smazat blok „{{ a.name|e('js') }}" i s {{ a.subActivities|length }} podakcemi? (skryje se z programu)'{% else %}'Smazat „{{ a.name|e('js') }}"? (skryje se z programu)'{% endif %});">
+                                                <input type="hidden" name="_token" value="{{ csrf_token('program_activity_delete_' ~ a.id) }}">
+                                                <button type="submit" class="btn btn-sm btn-outline-danger">smazat</button>
                                             </form>
                                         {% endif %}
                                     </td>

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -1,0 +1,116 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{# Program editor — přehledová stránka (spec krok 8, slice 1). Dny → aktivity + sekce + odkazy na PDF
+   výstupy. Read-only; blbuvzdorné formuláře (přidat/upravit/duplikovat) se navěsí v dalších slicech.
+   Data: WebAdminProgramController::index (ProgramDataService). #}
+
+{% block body_content %}
+    <div class="container" style="padding: 1rem;">
+        <div class="row">
+            <div class="col" style="display: flex; align-items: center; gap: .75rem; flex-wrap: wrap;">
+                <h2 style="margin: 0;">Program — {{ event.name ?? eventSlug }}</h2>
+                {% set dayCount = tree|filter(row => row.day is not null)|length %}
+                {% set activityCount = 0 %}
+                {% for row in tree %}{% set activityCount = activityCount + row.activities|length %}{% endfor %}
+                <span class="badge bg-primary" style="font-size: .95rem;">{{ dayCount }} dní · {{ activityCount }} aktivit</span>
+            </div>
+        </div>
+
+        <div class="row" style="margin-top: .75rem;">
+            <div class="col" style="display: flex; gap: .4rem; flex-wrap: wrap;">
+                <a class="btn btn-sm btn-outline-primary" target="_blank"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>
+                <a class="btn btn-sm btn-outline-primary" target="_blank"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_roster', {eventSlug: eventSlug}) }}">Rozpis služeb (PDF)</a>
+                <a class="btn btn-sm btn-outline-primary" target="_blank"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_team', {eventSlug: eventSlug}) }}">Přehled týmu (PDF)</a>
+                <a class="btn btn-sm btn-outline-primary" target="_blank"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_full', {eventSlug: eventSlug}) }}">Celý program (PDF)</a>
+            </div>
+        </div>
+
+        {% if activityCount == 0 %}
+            <div class="row" style="margin-top: 1.5rem;">
+                <div class="col">
+                    <div class="alert alert-info" style="max-width: 46rem;">
+                        Program tohoto turnusu zatím nemá žádné aktivity. Zadávání aktivit z tohoto rozhraní
+                        přibude v dalším kroku editoru; do té doby program vzniká přes API (mobilní admin / import).
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
+        {% for row in tree %}
+            <div class="row" style="margin-top: 1.25rem;">
+                <div class="col">
+                    <h3 style="margin: 0 0 .4rem; border-bottom: 2px solid #006fad; padding-bottom: .2rem;">
+                        {% if row.day %}
+                            {{ row.day.name ?? 'Den' }}
+                            <small style="color: #6c757d; font-weight: normal;">{{ row.day.date }}</small>
+                        {% else %}
+                            Nezařazené aktivity <small style="color: #6c757d; font-weight: normal;">(bez data)</small>
+                        {% endif %}
+                    </h3>
+                    <table class="table table-sm" style="margin: 0;">
+                        <thead>
+                            <tr>
+                                <th style="width: 6rem;">Čas</th>
+                                <th>Aktivita</th>
+                                <th>Místo</th>
+                                <th>Kategorie</th>
+                                <th>Obsazení</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for a in row.activities %}
+                                <tr>
+                                    <td style="white-space: nowrap;">{{ a.start ?? '—' }}{% if a.end %}–{{ a.end }}{% endif %}</td>
+                                    <td>
+                                        {% if a.highlight %}<strong>{{ a.name }}</strong>{% else %}{{ a.name }}{% endif %}
+                                        {% if a.seriesRoman %} {{ a.seriesRoman }}{% endif %}
+                                        {% if a.isBlock %}<span class="badge bg-secondary" style="margin-left: .3rem;">blok</span>{% endif %}
+                                        {% if a.price %}<span class="badge bg-warning text-dark" style="margin-left: .3rem;">{{ a.price }} Kč</span>{% endif %}
+                                        {% if a.targetGroup %}
+                                            <span class="badge" style="margin-left: .3rem; background: {{ a.targetGroup.color ?? '#6c757d' }};">{{ a.targetGroup.name }}</span>
+                                        {% endif %}
+                                        {% if not a.publicInApp %}<span class="badge bg-light text-dark" style="margin-left: .3rem;" title="Neveřejné (interní)">interní</span>{% endif %}
+                                        {% for sub in a.subActivities %}
+                                            <div style="margin-left: 1rem; color: #444; font-size: .9rem;">
+                                                ↳ {{ sub.start ?? '' }} {{ sub.name }}
+                                                {% if sub.targetGroup %}<span class="badge" style="background: {{ sub.targetGroup.color ?? '#6c757d' }};">{{ sub.targetGroup.name }}</span>{% endif %}
+                                            </div>
+                                        {% endfor %}
+                                    </td>
+                                    <td style="color: #444;">{{ a.placeText ?? '—' }}</td>
+                                    <td>{% if a.category %}<span class="badge bg-info text-dark">{{ a.category }}</span>{% else %}—{% endif %}</td>
+                                    <td style="font-size: .9rem;">
+                                        {% for s in a.staff %}
+                                            {{ s.name }}{% if s.roleLabel %} <span style="color: #6c757d;">({{ s.roleLabel }})</span>{% endif %}{% if not loop.last %}, {% endif %}
+                                        {% else %}<span style="color: #adb5bd;">—</span>{% endfor %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {% endfor %}
+
+        {% if sections|length > 0 %}
+            <div class="row" style="margin-top: 1.5rem;">
+                <div class="col">
+                    <h3 style="margin: 0 0 .4rem; border-bottom: 2px solid #006fad; padding-bottom: .2rem;">Sekce (info / patička)</h3>
+                    <ul class="list-group" style="max-width: 46rem;">
+                        {% for s in sections %}
+                            <li class="list-group-item" style="display: flex; align-items: center; gap: .5rem;">
+                                <strong>{{ s.name ?? '—' }}</strong>
+                                {% if s.publicInApp %}<span class="badge bg-success">veřejné</span>{% else %}<span class="badge bg-light text-dark">interní</span>{% endif %}
+                                <span style="color: #adb5bd; margin-left: auto;">priorita {{ s.priority ?? 0 }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/Resources/views/web_admin/program/index.html.twig
+++ b/Resources/views/web_admin/program/index.html.twig
@@ -22,6 +22,8 @@
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_activity_new', {eventSlug: eventSlug}) }}">+ Přidat aktivitu</a>
                 <a class="btn btn-sm btn-outline-primary"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_day_new', {eventSlug: eventSlug}) }}">+ Přidat den</a>
+                <a class="btn btn-sm btn-outline-primary"
+                   href="{{ path('oswis_org_oswis_calendar_web_admin_program_section_new', {eventSlug: eventSlug}) }}">+ Přidat sekci</a>
                 <span style="width: .5rem;"></span>
                 <a class="btn btn-sm btn-outline-primary" target="_blank"
                    href="{{ path('oswis_org_oswis_calendar_web_admin_program_instructor', {eventSlug: eventSlug}) }}">Instruktorský program (PDF)</a>
@@ -129,6 +131,15 @@
                                 <strong>{{ s.name ?? '—' }}</strong>
                                 {% if s.publicInApp %}<span class="badge bg-success">veřejné</span>{% else %}<span class="badge bg-light text-dark">interní</span>{% endif %}
                                 <span style="color: #adb5bd; margin-left: auto;">priorita {{ s.priority ?? 0 }}</span>
+                                {% if s.id %}
+                                    <a style="font-size: .8rem;" href="{{ path('oswis_org_oswis_calendar_web_admin_program_section_edit', {eventSlug: eventSlug, sectionId: s.id}) }}">upravit</a>
+                                    <form method="post" style="display: inline; margin: 0;"
+                                          action="{{ path('oswis_org_oswis_calendar_web_admin_program_section_delete', {eventSlug: eventSlug, sectionId: s.id}) }}"
+                                          onsubmit="return confirm('Smazat sekci „{{ s.name }}"?');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('program_section_delete_' ~ s.id) }}">
+                                        <button type="submit" style="border: 0; background: none; color: #b02a37; cursor: pointer; padding: 0; font-size: .8rem;">smazat</button>
+                                    </form>
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/Resources/views/web_admin/program/section_edit.html.twig
+++ b/Resources/views/web_admin/program/section_edit.html.twig
@@ -1,0 +1,32 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}{{ pageTitle }}{% endblock %}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem;">
+            <h2 style="margin: 0;">{{ pageTitle }}</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        {{ form_start(form, { attr: { novalidate: 'novalidate' } }) }}
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-bottom: 1rem; max-width: 52rem;">
+            <div class="row">
+                <div class="col-12 col-md-8 mb-3">{{ form_row(form.name) }}</div>
+                <div class="col-12 col-md-4 mb-3">{{ form_row(form.priority) }}</div>
+            </div>
+            <div class="row"><div class="col-12 mb-3">{{ form_row(form.textValue) }}</div></div>
+            <div class="row">
+                <div class="col-12 col-md-6 mb-3">{{ form_row(form.icon) }}</div>
+                <div class="col-6 col-md-3 mb-3 d-flex align-items-end">{{ form_row(form.publicInApp) }}</div>
+                <div class="col-6 col-md-3 mb-3 d-flex align-items-end">{{ form_row(form.publicOnWeb) }}</div>
+            </div>
+            <div class="row"><div class="col-12 mb-3">{{ form_row(form.note) }}</div></div>
+        </fieldset>
+        <div style="display: flex; gap: .5rem; justify-content: flex-end; max-width: 52rem;">
+            <a href="{{ back_url }}" class="btn btn-outline-secondary">Zrušit</a>
+            {{ form_row(form.submit, { attr: { class: 'btn btn-primary' } }) }}
+        </div>
+        {{ form_end(form) }}
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/program/series.html.twig
+++ b/Resources/views/web_admin/program/series.html.twig
@@ -1,0 +1,66 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}Série programu{% endblock %}
+
+{# Série aktivit (EventGroup program-series). „Stejná aktivita" = táž aktivita opakovaná kvůli
+   kapacitě/protočení (lukostřelby, degustace) → přehled čísluje římsky. Zakládá se z vybraných
+   aktivit turnusu. Data: WebAdminProgramController::series. #}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem;">
+            <h2 style="margin: 0;">Série</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        {% for s in series %}
+            <div style="border: 1px solid #dee2e6; border-radius: .375rem; padding: .8rem 1.1rem; margin-bottom: .8rem; max-width: 52rem;">
+                <div style="display: flex; align-items: center; gap: .75rem;">
+                    <strong style="font-size: 1.05rem;">{{ s.name }}</strong>
+                    {% if s.sameActivity %}<span class="badge bg-info text-dark">stejná aktivita (číslování I./II./…)</span>{% endif %}
+                    <span style="color: #adb5bd;">{{ s.activities|length }} aktivit</span>
+                    <form method="post" style="margin: 0 0 0 auto;"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_program_series_delete', {eventSlug: eventSlug, seriesId: s.id}) }}"
+                          onsubmit="return confirm('Zrušit sérii „{{ s.name }}"? Aktivity zůstanou, jen se rozpojí.');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('program_series_delete_' ~ s.id) }}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger" style="padding: .05rem .4rem;">zrušit sérii</button>
+                    </form>
+                </div>
+                <div style="color: #444; font-size: .9rem; margin-top: .3rem;">{{ s.activities|join(' · ') }}</div>
+            </div>
+        {% else %}
+            <p style="color: #adb5bd;">Zatím žádné série.</p>
+        {% endfor %}
+
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-top: 1rem; max-width: 52rem;">
+            <legend style="font-size: 1rem; font-weight: 600; padding: 0 .5rem; width: auto;">Nová série z aktivit</legend>
+            <form method="post" action="{{ path('oswis_org_oswis_calendar_web_admin_program_series', {eventSlug: eventSlug}) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('program_series_create_' ~ turnusId) }}">
+                <div class="row">
+                    <div class="col-12 col-md-8 mb-3">
+                        <label class="form-label">Název série</label>
+                        <input type="text" name="name" class="form-control" placeholder="např. Lukostřelba, Vinná degustace">
+                    </div>
+                    <div class="col-12 col-md-4 mb-3 d-flex align-items-end">
+                        <label style="display: inline-flex; gap: .4rem; align-items: center;">
+                            <input type="checkbox" name="sameActivity" value="1"> Stejná aktivita (číslovat)
+                        </label>
+                    </div>
+                </div>
+                <div style="margin-bottom: .5rem; color: #6c757d; font-size: .85rem;">Vyber aspoň dvě aktivity, které patří do série:</div>
+                <div style="max-height: 18rem; overflow-y: auto; border: 1px solid #eee; border-radius: .3rem; padding: .4rem .6rem;">
+                    {% for a in activities %}
+                        <label style="display: block; padding: .15rem 0;">
+                            <input type="checkbox" name="activities[]" value="{{ a.id }}">
+                            {{ a.start }} {{ a.name }}
+                            {% if a.seriesId %}<span class="badge bg-light text-dark">už v sérii</span>{% endif %}
+                        </label>
+                    {% else %}
+                        <span style="color: #adb5bd;">Turnus zatím nemá aktivity.</span>
+                    {% endfor %}
+                </div>
+                <button type="submit" class="btn btn-primary" style="margin-top: .7rem;">Vytvořit sérii</button>
+            </form>
+        </fieldset>
+    </main>
+{% endblock %}

--- a/Resources/views/web_admin/program/teams.html.twig
+++ b/Resources/views/web_admin/program/teams.html.twig
@@ -1,0 +1,74 @@
+{% extends '@OswisOrgOswisCore/web_admin/page-skeleton-web-admin.html.twig' %}
+
+{% block html_title %}Týmy programu{% endblock %}
+
+{# Týmy/podtýmy turnusu (StaffTeam, M2M členství). Přiřazují se k aktivitám v obsazení.
+   Data: WebAdminProgramController::teams. #}
+
+{% block body_content %}
+    <main class="container" style="padding-bottom: 4rem;">
+        <div style="display: flex; align-items: center; gap: .75rem; margin-bottom: .75rem;">
+            <h2 style="margin: 0;">Týmy</h2>
+            <a href="{{ back_url }}" class="btn btn-sm btn-outline-secondary">← Zpět na program</a>
+        </div>
+
+        {% if staffPool|length == 0 %}
+            <div class="alert alert-info" style="max-width: 52rem;">
+                Zatím nejsou žádné týmové přihlášky (instruktoři/pořadatelé) na tomto turnusu, takže není z koho
+                skládat členy. Týmy jde založit, členy přidáš, až budou instruktoři zaregistrovaní jako účastníci.
+            </div>
+        {% endif %}
+
+        <fieldset style="border: 1px solid #dee2e6; border-radius: .375rem; padding: 1rem 1.25rem; margin-bottom: 1.25rem; max-width: 40rem;">
+            <legend style="font-size: 1rem; font-weight: 600; padding: 0 .5rem; width: auto;">Nový tým</legend>
+            {{ form_start(form) }}
+            <div style="display: flex; gap: .5rem; align-items: flex-end;">
+                <div style="flex: 1;">{{ form_row(form.name) }}</div>
+                {{ form_row(form.submit, { attr: { class: 'btn btn-primary' } }) }}
+            </div>
+            {{ form_end(form) }}
+        </fieldset>
+
+        {% for team in teams %}
+            <div style="border: 1px solid #dee2e6; border-radius: .375rem; padding: .8rem 1.1rem; margin-bottom: .8rem; max-width: 52rem;">
+                <div style="display: flex; align-items: center; gap: .75rem;">
+                    <strong style="font-size: 1.05rem;">{{ team.name }}</strong>
+                    <span style="color: #adb5bd;">{{ team.members|length }} členů</span>
+                    <form method="post" style="margin: 0 0 0 auto;"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_program_team_delete', {eventSlug: eventSlug, teamId: team.id}) }}"
+                          onsubmit="return confirm('Smazat tým „{{ team.name }}"?');">
+                        <input type="hidden" name="_token" value="{{ csrf_token('program_team_delete_' ~ team.id) }}">
+                        <button type="submit" class="btn btn-sm btn-outline-danger" style="padding: .05rem .4rem;">smazat tým</button>
+                    </form>
+                </div>
+                <ul style="margin: .5rem 0 .3rem; padding-left: 1.2rem;">
+                    {% for m in team.members %}
+                        <li style="display: flex; align-items: center; gap: .5rem;">
+                            {{ m.name }}
+                            <form method="post" style="margin: 0;"
+                                  action="{{ path('oswis_org_oswis_calendar_web_admin_program_team_member_remove', {eventSlug: eventSlug, teamId: team.id, participantId: m.id}) }}">
+                                <input type="hidden" name="_token" value="{{ csrf_token('program_team_member_remove_' ~ team.id ~ '_' ~ m.id) }}">
+                                <button type="submit" style="border: 0; background: none; color: #b02a37; cursor: pointer; padding: 0; font-size: .8rem;">odebrat</button>
+                            </form>
+                        </li>
+                    {% else %}
+                        <li style="color: #adb5bd; list-style: none; margin-left: -1.2rem;">Zatím bez členů.</li>
+                    {% endfor %}
+                </ul>
+                {% if staffPool|length > 0 %}
+                    <form method="post" style="display: flex; gap: .4rem; align-items: center;"
+                          action="{{ path('oswis_org_oswis_calendar_web_admin_program_team_member_add', {eventSlug: eventSlug, teamId: team.id}) }}">
+                        <input type="hidden" name="_token" value="{{ csrf_token('program_team_member_' ~ team.id) }}">
+                        <select name="participant" class="form-select" style="max-width: 20rem;">
+                            <option value="">— přidat člena —</option>
+                            {% for p in staffPool %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-outline-primary">Přidat</button>
+                    </form>
+                {% endif %}
+            </div>
+        {% else %}
+            <p style="color: #adb5bd;">Zatím žádné týmy.</p>
+        {% endfor %}
+    </main>
+{% endblock %}

--- a/Service/Program/ProgramDataService.php
+++ b/Service/Program/ProgramDataService.php
@@ -265,6 +265,7 @@ final class ProgramDataService
                 continue;
             }
             $rows[] = [
+                'id' => $section->getId(),
                 'name' => $section->getName(),
                 'textValue' => $section->getTextValue(),
                 'icon' => $section->getIcon(),

--- a/Service/Program/ProgramDataService.php
+++ b/Service/Program/ProgramDataService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OswisOrg\OswisCalendarBundle\Service\Program;
 
 use OswisOrg\OswisCalendarBundle\Entity\Event\Event;
+use OswisOrg\OswisCalendarBundle\Entity\Event\EventCategory;
 use OswisOrg\OswisCalendarBundle\Entity\Event\EventStaffAssignment;
 use OswisOrg\OswisCalendarBundle\Entity\Participant\Participant;
 use OswisOrg\OswisCalendarBundle\Repository\Event\EventSectionRepository;
@@ -47,6 +48,9 @@ final class ProgramDataService
     {
         $activities = [];
         foreach ($turnus->getSubEvents() as $sub) {
+            if (null !== $sub->getDeletedAt()) {
+                continue; // smazané (soft-delete) aktivity/bloky se v programu ani výstupech nezobrazují
+            }
             $activities[] = $this->activityArray($sub);
         }
         $sortKey = static fn (array $a): string => (is_string($a['date'] ?? null) ? $a['date'] : '')
@@ -309,6 +313,9 @@ final class ProgramDataService
             return;
         }
         foreach ($event->getSubEvents() as $sub) {
+            if (null !== $sub->getDeletedAt()) {
+                continue; // smazané (soft-delete) podakce se do sběru (obsazení/matice služeb) nepočítají
+            }
             $out[] = $sub;
             $this->collectEvents($sub, $out, $depth + 1);
         }
@@ -321,11 +328,23 @@ final class ProgramDataService
     {
         $subActivities = [];
         foreach ($event->getSubEvents() as $sub) {
+            if (null !== $sub->getDeletedAt()) {
+                continue; // smazaný (soft-delete) slot rotace se nezobrazuje
+            }
+            // Sloty nesou i pole, která potřebuje účastnický výstup, až se blok „zploští" po časech
+            // (viz ProgramOutputService::flattenBlocks). Přehled web adminu čte jen podmnožinu (↳ řádek).
             $subActivities[] = [
                 'id' => $sub->getId(),
                 'name' => $sub->getName(),
                 'start' => $sub->getStartDateTimeRecursive()?->format('H:i'),
+                'end' => $sub->getEndDateTimeRecursive()?->format('H:i'),
+                'placeText' => $sub->getPlaceText(),
+                'highlight' => $sub->isHighlight(),
+                'publicInApp' => $sub->isPublicInApp(),
+                'price' => $sub->getPrice(),
+                'seriesRoman' => null,
                 'targetGroup' => $this->groupArray($sub),
+                'subActivities' => [],
             ];
         }
         $staff = [];
@@ -359,7 +378,9 @@ final class ProgramDataService
                 'name' => $targetGroup->getName(),
                 'color' => $targetGroup->getColor(),
             ] : null,
-            'isBlock' => [] !== $subActivities,
+            // Blok = má podakce (strukturálně nadakce) NEBO je kategorie „program-block" — aby i PRÁZDNÝ
+            // blok nabídl „+ podakce" (jinak by do něj nešlo přidat první podakci).
+            'isBlock' => [] !== $subActivities || EventCategory::PROGRAM_BLOCK === $event->getCategory()?->getType(),
             'subActivities' => $subActivities,
         ];
     }

--- a/Service/Program/ProgramOutputService.php
+++ b/Service/Program/ProgramOutputService.php
@@ -181,7 +181,7 @@ final class ProgramOutputService
     private function groupIntoBlocks(array $activities): array
     {
         $blocks = $this->emptyBlocks();
-        foreach ($activities as $activity) {
+        foreach ($this->flattenBlocks($activities) as $activity) {
             if (true !== ($activity['publicInApp'] ?? null)) {
                 continue;
             }
@@ -195,8 +195,47 @@ final class ProgramOutputService
                 $blocks['VEČERNÍ'][] = $activity;
             }
         }
+        // Po zploštění rotací se sloty (různé časy) prokládají s ostatními aktivitami → seřadit po čase.
+        // usort je v PHP 8 stabilní, takže stejný čas zachová vstupní pořadí (např. pořadí stanovišť).
+        foreach ($blocks as &$list) {
+            usort($list, static function (mixed $x, mixed $y): int {
+                $xs = is_array($x) && is_string($x['start'] ?? null) ? $x['start'] : '99';
+                $ys = is_array($y) && is_string($y['start'] ?? null) ? $y['start'] : '99';
+
+                return $xs <=> $ys;
+            });
+        }
+        unset($list);
 
         return $blocks;
+    }
+
+    /**
+     * Rozbalí bloky (nadakce) na jejich sloty — účastnický program ukazuje rotaci PLOŠE po časech
+     * (jeden slot = jeden řádek s vlastním časem a páskem, à la 3.den.pdf), NE blok jako jeden bod;
+     * blok samotný je interní kontejner (publicInApp=false), takže se nevykresluje. Ostatní aktivity
+     * projdou beze změny. Sloty nesou vlastní publicInApp/start/place… ({@see ProgramDataService}).
+     *
+     * @param  list<array<string, mixed>>  $activities
+     * @return list<array<mixed>>
+     */
+    private function flattenBlocks(array $activities): array
+    {
+        $out = [];
+        foreach ($activities as $activity) {
+            $subs = is_array($activity['subActivities'] ?? null) ? $activity['subActivities'] : [];
+            if (true === ($activity['isBlock'] ?? false) && [] !== $subs) {
+                foreach ($subs as $slot) {
+                    if (is_array($slot)) {
+                        $out[] = $slot;
+                    }
+                }
+                continue;
+            }
+            $out[] = $activity;
+        }
+
+        return $out;
     }
 
     /** Personal itinerary for one instructor ("kde mám být") — their slots, chronological. */

--- a/State/EventDuplicateProcessor.php
+++ b/State/EventDuplicateProcessor.php
@@ -47,12 +47,38 @@ final class EventDuplicateProcessor implements ProcessorInterface
         }
         $payload = $this->payload();
 
+        return $this->duplicate(
+            $source,
+            $this->resolve($payload, 'superEvent', Event::class),
+            $this->resolve($payload, 'category', EventCategory::class),
+            $this->resolve($payload, 'targetGroup', ParticipantGroup::class),
+            $this->dateTime($payload['startDateTime'] ?? null),
+            $this->dateTime($payload['endDateTime'] ?? null),
+            $this->str($payload['name'] ?? null),
+        );
+    }
+
+    /**
+     * Naklonuje jeden programový slot (aktivita/blok) BEZ dětí (subEvents/attendances/staff) —
+     * JEDINÝ zdroj toho, co se při duplikaci kopíruje. Sdílí API POST /duplicate i web-admin editor.
+     * Přepisy (nový nadčas / kategorie / cílová skupina / nadakce / jméno) jsou volitelné; jinak se
+     * převezmou ze zdroje.
+     */
+    public function duplicate(
+        Event $source,
+        ?Event $superEvent = null,
+        ?EventCategory $category = null,
+        ?ParticipantGroup $targetGroup = null,
+        ?DateTime $start = null,
+        ?DateTime $end = null,
+        ?string $name = null,
+    ): Event {
         $clone = new Event();
-        $clone->setName($this->str($payload['name'] ?? null) ?? $source->getName());
+        $clone->setName($name ?? $source->getName());
         $clone->setShortName($source->getShortName());
         $clone->setDescription($source->getDescription());
         $clone->setColor($source->getColor());
-        $clone->setCategory($this->resolve($payload, 'category', EventCategory::class) ?? $source->getCategory());
+        $clone->setCategory($category ?? $source->getCategory());
         $clone->setPlace($source->getPlace(false));
         $clone->setPlaceText($source->getPlaceText());
         $clone->setSignupMode($source->getSignupMode());
@@ -62,19 +88,24 @@ final class EventDuplicateProcessor implements ProcessorInterface
         $clone->setCapacity(new Capacity($source->getBaseCapacity(), $source->getFullCapacity()));
         $clone->setHighlight($source->isHighlight());
         $clone->setGroup($source->getGroup());
-        $clone->setSuperEvent($this->resolve($payload, 'superEvent', Event::class) ?? $source->getSuperEvent());
-        $clone->setTargetGroup($this->resolve($payload, 'targetGroup', ParticipantGroup::class) ?? $source->getTargetGroup());
+        $clone->setSuperEvent($superEvent ?? $source->getSuperEvent());
+        $clone->setTargetGroup($targetGroup ?? $source->getTargetGroup());
         $clone->setPublicOnWeb($source->isPublicOnWeb());
         $clone->setPublicInApp($source->isPublicInApp());
 
-        // New time from request; fall back to the source slot's time (admin shifts later).
-        $start = $this->dateTime($payload['startDateTime'] ?? null) ?? $source->getStartDateTime();
-        $end = $this->dateTime($payload['endDateTime'] ?? null) ?? $source->getEndDateTime();
+        // New time from override; fall back to the source slot's time (admin shifts later).
+        $start ??= $source->getStartDateTime();
+        $end ??= $source->getEndDateTime();
         if (null !== $start) {
             $clone->setStartDateTime($start);
         }
         if (null !== $end) {
             $clone->setEndDateTime($end);
+        }
+        // Odvodit slug z názvu — bez toho měl duplikát slug NULL (žádný listener ho negeneruje;
+        // dosud latentní i u API /duplicate).
+        if (empty($clone->getSlug())) {
+            $clone->updateSlug();
         }
 
         $this->em->persist($clone);


### PR DESCRIPTION
## Co
První slice **editoru programu** (spec `2026-06-12-program-module-design.md` krok 8) — stránka `/web_admin/program/{eventSlug}`, kde je program vidět a na kterou se v dalších slicech navěsí blbuvzdorné formuláře (přidat/upravit/duplikovat den, aktivitu, sekci).

## Proč
Program modul má model + API (STOPA 1.2, deployed v0.2.49) + 7 PDF/CSV výstupů, ale **ve web adminu chyběla stránka, kde program vidět/skládat** — šlo jen generovat PDF naslepo. Uživatel to opakovaně hlásil jako nedodělek. Rozhodnutí o editoru (kdo/kde/jak) jsou z řízené procházky 12.–13. 6. — beru je odtud, nevymýšlím znovu.

## Obsah
- `WebAdminProgramController::index` — `#[IsGranted('ROLE_MANAGER')]` (edit = manažerská role dle specu), data přes `ProgramDataService::getProgramTree`/`getSections` (read-only pole, ne entity do šablony).
- Šablona: dny jako sekce (label + datum) → tabulka aktivit (čas · název · místo · kategorie chip · obsazení); nezařazené aktivity v bucketu „bez data"; bloky/série(řím. číslo)/highlight/cena/cílová skupina jako badge; sekce (info/patička); odkazy na existující PDF výstupy; empty-state.

## Ověřeno
Renderuje naostro na klonu (turnus 2022, 4 aktivity, kategorie Evidence/Večeře, 200). PHPStan max 0. ⚠️ nová třída v bundle → deploy vyžaduje `composer dump-autoload` v appce (classmap-authoritative).

## Další slicy (dle specu krok 8–9)
Formuláře přidat/upravit/duplikovat (den/aktivita/sekce/blok/série/obsazení) — klienti už hotového API; pak Ionic admin editor (krok 9). Tato stránka je jejich základ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)